### PR TITLE
Organize platform detection code to avoid "Duplication of Roles".

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
@@ -31,31 +31,31 @@ namespace Microsoft.AspNet.Server.Kestrel
                 {
                     libraryPath = Path.GetDirectoryName(libraryPath);
                 }
-                if (Libuv.IsWindows)
+                switch (PlatformApis.GetPlatform())
                 {
-                    var architecture = IntPtr.Size == 4
-                        ? "x86"
-                        : "amd64";
+                    case PlatformApis.Platform.Windows:
+                        var architecture = IntPtr.Size == 4
+                            ? "x86"
+                            : "amd64";
 
-                    libraryPath = Path.Combine(
-                        libraryPath, 
-                        "native",
-                        "windows",
-                        architecture, 
-                        "libuv.dll");
-                }
-                else if (Libuv.IsDarwin)
-                {
-                    libraryPath = Path.Combine(
-                        libraryPath,
-                        "native",
-                        "darwin",
-                        "universal",
-                        "libuv.dylib");
-                }
-                else
-                {
-                    libraryPath = "libuv.so.1";
+                        libraryPath = Path.Combine(
+                            libraryPath,
+                            "native",
+                            "windows",
+                            architecture,
+                            "libuv.dll");
+                        break;
+                    case PlatformApis.Platform.MacOSX:
+                        libraryPath = Path.Combine(
+                            libraryPath,
+                            "native",
+                            "darwin",
+                            "universal",
+                            "libuv.dylib");
+                        break;
+                    case PlatformApis.Platform.OtherUnixSystems:
+                        libraryPath = "libuv.so.1";
+                        break;
                 }
             }
             Libuv.Load(libraryPath);

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
@@ -12,15 +12,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     {
         public Libuv()
         {
-            IsWindows = PlatformApis.IsWindows();
-            if (!IsWindows)
-            {
-                IsDarwin = PlatformApis.IsDarwin();
-            }
         }
-
-        public bool IsWindows;
-        public bool IsDarwin;
 
         public Func<string, IntPtr> LoadLibrary;
         public Func<IntPtr, bool> FreeLibrary;
@@ -327,7 +319,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
 
         public uv_buf_t buf_init(IntPtr memory, int len)
         {
-            return new uv_buf_t(memory, len, IsWindows);
+            return new uv_buf_t(memory, len, PlatformApis.GetPlatform() == PlatformApis.Platform.Windows);
         }
 
         public struct sockaddr


### PR DESCRIPTION
 - Unified similar code in PlatformApis and Libuv.
 - Switched to better platform constants than IsWindows/IsDarwin/...
 - Adopt KestrelEngine to new style.