### PR TITLE
Socket constructor should have 3 parameters

### DIFF
--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -322,7 +322,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             using (var server = new TestServer(App))
             {
-                var socket = new Socket(SocketType.Stream, ProtocolType.IP);
+                var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
                 socket.Connect(IPAddress.Loopback, 54321);
                 await Task.Delay(200);
                 socket.Disconnect(false);


### PR DESCRIPTION
According to the doc[1] the constructor for the Socket class has parameters that specify the address family, socket type, and protocol type that the socket uses to make connections.

Previously the xunit-test Target failed to compile, with following error message:
```
info: Target xunit-test
info: Exec
info:   program: k
info:   commandline: test
info:   workingdir: test/Microsoft.AspNet.Server.KestrelTests
xUnit.net Project K test runner (64-bit Asp.Net,Version=v5.0)
Copyright (C) 2014 Outercurve Foundation, Microsoft Open Technologies, Inc.

Microsoft.Framework.Runtime.Roslyn.RoslynCompilationException: /Users/diorahman/Experiments/aspnet/kestrel/src/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs(325,34): error CS1729: 'Socket' does not contain a constructor that takes 2 arguments
Microsoft.Framework.Runtime.Roslyn.RoslynCompilationException: /Users/diorahman/Experiments/aspnet/kestrel/src/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs(325,34): error CS1729: 'Socket' does not contain a constructor that takes 2 arguments
... ommitted
```

[1] http://msdn.microsoft.com/en-us/library/1w48w47c(v=vs.110).aspx