### PR TITLE
Fixed shutdown hanging

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -61,6 +61,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             _socket = socket;
             ConnectionControl = this;
+
+            Thread.OnStopping += OnLoopStopping;
         }
 
         public void Start()
@@ -71,6 +73,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             SocketOutput = new SocketOutput(Thread, _socket);
             _frame = new Frame(this);
             _socket.ReadStart(_allocCallback, _readCallback, this);
+        }
+
+        private void OnLoopStopping()
+        {
+            _socket.Dispose();
         }
 
         private Libuv.uv_buf_t OnAlloc(UvStreamHandle handle, int suggestedSize)


### PR DESCRIPTION
- Added Stopping event to KestrelThread so that
incoming connections get a chance to gracefully close
before disposing the event loop
- Call _post.Dispose instead of UnReference. Sometimes
Dispose would happen on the finalizer thread and _queueCloseHandle
would be null.

#9