### PR TITLE
Spin off PlatformApis thing into separate library

### DIFF
--- a/src/Kestrel.LibraryLoader/Library.cs
+++ b/src/Kestrel.LibraryLoader/Library.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Kestrel.LibraryLoader
+{
+    public abstract class Library
+    {
+        public Library()
+        {
+            IsWindows = PlatformApis.IsWindows();
+            if (!IsWindows)
+            {
+                IsDarwin = PlatformApis.IsDarwin();
+            }
+        }
+
+        public bool IsWindows;
+        public bool IsDarwin;
+
+        public Func<string, IntPtr> LoadLibrary;
+        public Func<IntPtr, bool> FreeLibrary;
+        public Func<IntPtr, string, IntPtr> GetProcAddress;
+
+        public virtual void Load(string dllToLoad)
+        {
+            PlatformApis.Apply(this);
+
+            var module = LoadLibrary(dllToLoad);
+            if (module == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Unable to load library.");
+            }
+
+            foreach (var field in GetType().GetTypeInfo().DeclaredFields)
+            {
+                var procAddress = GetProcAddress(module, field.Name.TrimStart('_'));
+                if (procAddress == IntPtr.Zero)
+                {
+                    continue;
+                }
+                var value = Marshal.GetDelegateForFunctionPointer(procAddress, field.FieldType);
+                field.SetValue(this, value);
+            }
+        }
+    }
+}

--- a/src/Kestrel.LibraryLoader/PlatformApis.cs
+++ b/src/Kestrel.LibraryLoader/PlatformApis.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 
-namespace Microsoft.AspNet.Server.Kestrel.Networking
+namespace Kestrel.LibraryLoader
 {
     public static class PlatformApis
     {
@@ -48,15 +46,15 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             return string.Equals(GetUname(), "Darwin", StringComparison.Ordinal);
         }
 
-        public static void Apply(Libuv libuv)
+        public static void Apply(Library library)
         {
-            if (libuv.IsWindows)
+            if (library.IsWindows)
             {
-                WindowsApis.Apply(libuv);
+                WindowsApis.Apply(library);
             }
             else
             {
-                LinuxApis.Apply(libuv);
+                LinuxApis.Apply(library);
             }
         }
 
@@ -71,11 +69,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             [DllImport("kernel32", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
             public static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
 
-            public static void Apply(Libuv libuv)
+            public static void Apply(Library library)
             {
-                libuv.LoadLibrary = LoadLibrary;
-                libuv.FreeLibrary = FreeLibrary;
-                libuv.GetProcAddress = GetProcAddress;
+                library.LoadLibrary = LoadLibrary;
+                library.FreeLibrary = FreeLibrary;
+                library.GetProcAddress = GetProcAddress;
             }
         }
 
@@ -111,11 +109,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
                 return errPtr == IntPtr.Zero ? res : IntPtr.Zero;
             }
 
-            public static void Apply(Libuv libuv)
+            public static void Apply(Library library)
             {
-                libuv.LoadLibrary = LoadLibrary;
-                libuv.FreeLibrary = FreeLibrary;
-                libuv.GetProcAddress = GetProcAddress;
+                library.LoadLibrary = LoadLibrary;
+                library.FreeLibrary = FreeLibrary;
+                library.GetProcAddress = GetProcAddress;
             }
         }
     }

--- a/src/Kestrel.LibraryLoader/project.json
+++ b/src/Kestrel.LibraryLoader/project.json
@@ -1,0 +1,7 @@
+﻿{
+    "version": "1.0.0-*",
+    "description": "Load libraries between Windows and Unix with delight.",
+    "compilationOptions": {
+        "allowUnsafe": true
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
@@ -5,28 +5,13 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using Kestrel.LibraryLoader;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
-    public class Libuv
+    public class Libuv : Library
     {
-        public Libuv()
-        {
-            IsWindows = PlatformApis.IsWindows();
-            if (!IsWindows)
-            {
-                IsDarwin = PlatformApis.IsDarwin();
-            }
-        }
-
-        public bool IsWindows;
-        public bool IsDarwin;
-
-        public Func<string, IntPtr> LoadLibrary;
-        public Func<IntPtr, bool> FreeLibrary;
-        public Func<IntPtr, string, IntPtr> GetProcAddress;
-
-        public void Load(string dllToLoad)
+        public override void Load(string dllToLoad)
         {
             PlatformApis.Apply(this);
 

--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -2,7 +2,8 @@
     "version": "1.0.0-*",
     "description": "ASP.NET 5 cross platform development web server.",
     "dependencies": {
-        "Microsoft.Framework.Runtime.Interfaces": "1.0.0-*"
+        "Microsoft.Framework.Runtime.Interfaces": "1.0.0-*",
+        "Kestrel.LibraryLoader": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": { },


### PR DESCRIPTION
The whole cross-platform library loader helper stuff you guys have is pretty neat and I would like to use it for my own project. However, I'd rather not have a dependency on Kestrel so I just spun out the stuff I needed.