### PR TITLE
Allow Kestrel to boot when on CoreCLR and *NIX

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/PlatformApis.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/PlatformApis.cs
@@ -13,7 +13,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
         public static bool IsWindows()
         {
 #if DNXCORE50
-            return true;
+            // Until Environment.OSVersion.Platform is exposed on .NET Core, we
+            // try to call uname and if that fails we assume we are on Windows.
+            return GetUname() == string.Empty;
 #else
             var p = (int)Environment.OSVersion.Platform;
             return (p != 4) && (p != 6) && (p != 128);


### PR DESCRIPTION
With cross platform .NET Core support coming online, we need to update
our IsWindows check to not assume running on .NET Core means running on
Windows.  Since CoreFX doesn't yet expose a method for doing this (they
are working on adding it back), we'll just call Uname and if that
returns an empty string assume that we are on Windows.