### PR TITLE
Use an IPv4/IPv6 dual stack socket

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     ListenSocket = new UvTcpHandle();
                     ListenSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
-                    ListenSocket.Bind(new IPEndPoint(IPAddress.Any, port));
+                    ListenSocket.Bind(new IPEndPoint(IPAddress.IPv6Any, port));
                     ListenSocket.Listen(10, _connectionCallback, this);
                     tcs.SetResult(0);
                 }


### PR DESCRIPTION
As [discussed](https://github.com/aspnet/KestrelHttpServer/pull/77/files#r27994693) in #77, here is Kestrel using a dual-stack socket accepting both IPv4 and IPv6 connections.

I've been running this actively for—uh—months now, without any issues. I know browsers connect to 'localhost' or a LLMNR-discoverable host using either (or even both) methods without me knowing which it is.