### PR TITLE
Move non-nested classes and interfaces to their own files

### DIFF
--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace SampleApp
 {

--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
 

--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -13,11 +13,11 @@ namespace SampleApp
         {
             app.Run(async context =>
             {
-                Console.WriteLine("{0} {1}{2}{3}",
-                    context.Request.Method,
-                    context.Request.PathBase,
-                    context.Request.Path,
-                    context.Request.QueryString);
+                //Console.WriteLine("{0} {1}{2}{3}",
+                //    context.Request.Method,
+                //    context.Request.PathBase,
+                //    context.Request.Path,
+                //    context.Request.QueryString);
 
                 context.Response.ContentLength = 11;
                 context.Response.ContentType = "text/plain";

--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -4,12 +4,8 @@
         "Kestrel": "1.0.0-*"
     },
     "frameworks": {
-        "dnx451": { },
-        "dnxcore50": {
-            "dependencies": {
-                "System.Console": "4.0.0-beta-*"
-            }
-        }
+        "dnx451": { }
+
     },
     "commands": {
         "run": "Kestrel",

--- a/src/Kestrel/Program.cs
+++ b/src/Kestrel/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Linq;
 
 namespace Kestrel

--- a/src/Kestrel/ServerAddress.cs
+++ b/src/Kestrel/ServerAddress.cs
@@ -1,4 +1,7 @@
-﻿namespace Kestrel
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Kestrel
 {
     public class ServerAddress
     {

--- a/src/Kestrel/project.json
+++ b/src/Kestrel/project.json
@@ -12,11 +12,6 @@
     "frameworks": {
         "dnx451": {
             "dependencies": { }
-        },
-        "dnxcore50": {
-            "dependencies": {
-                "System.Runtime": "4.0.20-beta-*"
-            }
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -2,42 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using System.Diagnostics;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
-    public class ConnectionContext : ListenerContext
-    {
-        public ConnectionContext()
-        {
-        }
-
-        public ConnectionContext(ListenerContext context) : base(context)
-        {
-        }
-
-        public ConnectionContext(ConnectionContext context) : base(context)
-        {
-            SocketInput = context.SocketInput;
-            SocketOutput = context.SocketOutput;
-            ConnectionControl = context.ConnectionControl;
-        }
-
-        public SocketInput SocketInput { get; set; }
-        public ISocketOutput SocketOutput { get; set; }
-
-        public IConnectionControl ConnectionControl { get; set; }
-    }
-
-    public interface IConnectionControl
-    {
-        void Pause();
-        void Resume();
-        void End(ProduceEndType endType);
-    }
-
     public class Connection : ConnectionContext, IConnectionControl
     {
         private static readonly Action<UvStreamHandle, int, Exception, object> _readCallback = ReadCallback;

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ConnectionContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ConnectionContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
     public class ConnectionContext : ListenerContext

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ConnectionContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ConnectionContext.cs
@@ -1,0 +1,25 @@
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    public class ConnectionContext : ListenerContext
+    {
+        public ConnectionContext()
+        {
+        }
+
+        public ConnectionContext(ListenerContext context) : base(context)
+        {
+        }
+
+        public ConnectionContext(ConnectionContext context) : base(context)
+        {
+            SocketInput = context.SocketInput;
+            SocketOutput = context.SocketOutput;
+            ConnectionControl = context.ConnectionControl;
+        }
+
+        public SocketInput SocketInput { get; set; }
+        public ISocketOutput SocketOutput { get; set; }
+
+        public IConnectionControl ConnectionControl { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -13,35 +13,6 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
-
-    public enum ProduceEndType
-    {
-        SocketShutdownSend,
-        SocketDisconnect,
-        ConnectionKeepAlive,
-    }
-
-    public class FrameContext : ConnectionContext
-    {
-        public FrameContext()
-        {
-
-        }
-
-        public FrameContext(ConnectionContext context) : base(context)
-        {
-
-        }
-
-        public IFrameControl FrameControl { get; set; }
-    }
-
-    public interface IFrameControl
-    {
-        void ProduceContinue();
-        void Write(ArraySegment<byte> data, Action<Exception, object> callback, object state);
-    }
-
     public class Frame : FrameContext, IFrameControl
     {
         enum Mode

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 // ReSharper disable AccessToModifiedClosure
@@ -158,7 +159,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             ResponseBody = new FrameResponseStream(this);
             DuplexStream = new FrameDuplexStream(RequestBody, ResponseBody);
             SocketInput.Free();
-            Task.Run(ExecuteAsync);
+            //Task.Run(ExecuteAsync);
+            //var ignore = ExecuteAsync();
+            ThreadPool.UnsafeQueueUserWorkItem(_ => ExecuteAsync(), null);
         }
 
         public void OnStarting(Func<object, Task> callback, object state)

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
     public class FrameContext : ConnectionContext

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameContext.cs
@@ -1,0 +1,17 @@
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    public class FrameContext : ConnectionContext
+    {
+        public FrameContext()
+        {
+
+        }
+
+        public FrameContext(ConnectionContext context) : base(context)
+        {
+
+        }
+
+        public IFrameControl FrameControl { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/IConnectionControl.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/IConnectionControl.cs
@@ -1,0 +1,9 @@
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    public interface IConnectionControl
+    {
+        void Pause();
+        void Resume();
+        void End(ProduceEndType endType);
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/IConnectionControl.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/IConnectionControl.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
     public interface IConnectionControl

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/IFrameControl.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/IFrameControl.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/IFrameControl.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/IFrameControl.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    public interface IFrameControl
+    {
+        void ProduceContinue();
+        void Write(ArraySegment<byte> data, Action<Exception, object> callback, object state);
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/IMemoryPool.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/IMemoryPool.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    public interface IMemoryPool
+    {
+        byte[] Empty { get; }
+
+        byte[] AllocByte(int minimumSize);
+        void FreeByte(byte[] memory);
+
+        char[] AllocChar(int minimumSize);
+        void FreeChar(char[] memory);
+
+        /// <summary>
+        ///   Acquires a sub-segment of a larger memory allocation. Used for async sends of write-behind
+        ///   buffers to reduce number of array segments pinned
+        /// </summary>
+        /// <param name = "minimumSize">The smallest length of the ArraySegment.Count that may be returned</param>
+        /// <returns>An array segment which is a sub-block of a larger allocation</returns>
+        ArraySegment<byte> AllocSegment(int minimumSize);
+
+        /// <summary>
+        ///   Frees a sub-segment of a larger memory allocation produced by AllocSegment. The original ArraySegment
+        ///   must be frees exactly once and must have the same offset and count that was returned by the Alloc.
+        ///   If a segment is not freed it won't be re-used and has the same effect as a memory leak, so callers must be
+        ///   implemented exactly correctly.
+        /// </summary>
+        /// <param name = "segment">The sub-block that was originally returned by a call to AllocSegment.</param>
+        void FreeSegment(ArraySegment<byte> segment);
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/IMemoryPool.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/IMemoryPool.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ISocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ISocketOutput.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    /// <summary>
+    ///   Operations performed for buffered socket output
+    /// </summary>
+    public interface ISocketOutput
+    {
+        void Write(ArraySegment<byte> buffer, Action<Exception, object> callback, object state);
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ISocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ISocketOutput.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
@@ -9,24 +9,6 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
-    public class ListenerContext
-    {
-        public ListenerContext() { }
-
-        public ListenerContext(ListenerContext context)
-        {
-            Thread = context.Thread;
-            Application = context.Application;
-            Memory = context.Memory;
-        }
-
-        public KestrelThread Thread { get; set; }
-
-        public Func<Frame, Task> Application { get; set; }
-
-        public IMemoryPool Memory { get; set; }
-    }
-
     /// <summary>
     /// Summary description for Accept
     /// </summary>

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    public class ListenerContext
+    {
+        public ListenerContext() { }
+
+        public ListenerContext(ListenerContext context)
+        {
+            Thread = context.Thread;
+            Application = context.Application;
+            Memory = context.Memory;
+        }
+
+        public KestrelThread Thread { get; set; }
+
+        public Func<Frame, Task> Application { get; set; }
+
+        public IMemoryPool Memory { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/MemoryPool.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/MemoryPool.cs
@@ -6,34 +6,6 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
-    public interface IMemoryPool
-    {
-        byte[] Empty { get; }
-
-        byte[] AllocByte(int minimumSize);
-        void FreeByte(byte[] memory);
-
-        char[] AllocChar(int minimumSize);
-        void FreeChar(char[] memory);
-
-        /// <summary>
-        ///   Acquires a sub-segment of a larger memory allocation. Used for async sends of write-behind
-        ///   buffers to reduce number of array segments pinned
-        /// </summary>
-        /// <param name = "minimumSize">The smallest length of the ArraySegment.Count that may be returned</param>
-        /// <returns>An array segment which is a sub-block of a larger allocation</returns>
-        ArraySegment<byte> AllocSegment(int minimumSize);
-
-        /// <summary>
-        ///   Frees a sub-segment of a larger memory allocation produced by AllocSegment. The original ArraySegment
-        ///   must be frees exactly once and must have the same offset and count that was returned by the Alloc.
-        ///   If a segment is not freed it won't be re-used and has the same effect as a memory leak, so callers must be
-        ///   implemented exactly correctly.
-        /// </summary>
-        /// <param name = "segment">The sub-block that was originally returned by a call to AllocSegment.</param>
-        void FreeSegment(ArraySegment<byte> segment);
-    }
-
     public class MemoryPool : IMemoryPool
     {
         static readonly byte[] EmptyArray = new byte[0];

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/MessageBody.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/MessageBody.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/MessageBodyExchanger.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/MessageBodyExchanger.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 }
                 if (_reads.Any())
                 {
-                    ThreadPool.QueueUserWorkItem(_completePending, this);
+                    ThreadPool.UnsafeQueueUserWorkItem(_completePending, this);
                 }
             }
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ProduceEndType.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ProduceEndType.cs
@@ -1,0 +1,9 @@
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    public enum ProduceEndType
+    {
+        SocketShutdownSend,
+        SocketDisconnect,
+        ConnectionKeepAlive,
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ProduceEndType.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ProduceEndType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
     public enum ProduceEndType

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
@@ -3,19 +3,10 @@
 
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using System;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
-    /// <summary>
-    ///   Operations performed for buffered socket output
-    /// </summary>
-    public interface ISocketOutput
-    {
-        void Write(ArraySegment<byte> buffer, Action<Exception, object> callback, object state);
-    }
-
     public class SocketOutput : ISocketOutput
     {
         private readonly KestrelThread _thread;

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                 // Get off the event loop before calling user code!
                 _callbackError = error;
-                ThreadPool.QueueUserWorkItem(obj =>
+                ThreadPool.UnsafeQueueUserWorkItem(obj =>
                 {
                     var req = (ThisWriteReq)obj;
                     req._callback(req._callbackError, req._state);

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -199,7 +199,7 @@ namespace Microsoft.AspNet.Server.Kestrel
                     work.Callback(work.State);
                     if (work.Completion != null)
                     {
-                        ThreadPool.QueueUserWorkItem(
+                        ThreadPool.UnsafeQueueUserWorkItem(
                             tcs =>
                             {
                                 ((TaskCompletionSource<int>)tcs).SetResult(0);
@@ -211,7 +211,7 @@ namespace Microsoft.AspNet.Server.Kestrel
                 {
                     if (work.Completion != null)
                     {
-                        ThreadPool.QueueUserWorkItem(_ => work.Completion.SetException(ex), null);
+                        ThreadPool.UnsafeQueueUserWorkItem(_ => work.Completion.SetException(ex), null);
                     }
                     else
                     {

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 //using System.Diagnostics.Tracing;
 
 namespace Microsoft.AspNet.Server.Kestrel

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/PlatformApis.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/PlatformApis.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvAsyncHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvAsyncHandle.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             _uv.async_send(this);
         }
 
-        unsafe static void AsyncCb(IntPtr handle)
+        unsafe private static void AsyncCb(IntPtr handle)
         {
             FromIntPtr<UvAsyncHandle>(handle)._callback.Invoke();
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvReq.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Server.Kestrel.Networking
+{
+    public abstract class UvReq : UvMemory
+    {
+        protected override bool ReleaseHandle()
+        {
+            DestroyMemory(handle);
+            handle = IntPtr.Zero;
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
@@ -1,6 +1,3 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -115,16 +112,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             {
                 Trace.WriteLine("UvWriteCb " + ex.ToString());
             }
-        }
-    }
-
-    public abstract class UvReq : UvMemory
-    {
-        protected override bool ReleaseHandle()
-        {
-            DestroyMemory(handle);
-            handle = IntPtr.Zero;
-            return true;
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -9,26 +9,7 @@
         "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*"
     },
     "frameworks": {
-        "dnx451": { },
-        "dnxcore50": {
-            "dependencies": {
-                "System.Collections": "4.0.10-beta-*",
-                "System.Diagnostics.Debug": "4.0.10-beta-*",
-                "System.Diagnostics.TraceSource": "4.0.0-beta-*",
-                "System.Diagnostics.Tracing": "4.0.20-beta-*",
-                "System.Globalization": "4.0.10-beta-*",
-                "System.IO": "4.0.10-beta-*",
-                "System.Linq": "4.0.0-beta-*",
-                "System.Net.Primitives": "4.0.10-beta-*",
-                "System.Runtime.Extensions": "4.0.10-beta-*",
-                "System.Runtime.InteropServices": "4.0.20-beta-*",
-                "System.Text.Encoding": "4.0.10-beta-*",
-                "System.Threading": "4.0.10-beta-*",
-                "System.Threading.Tasks": "4.0.10-beta-*",
-                "System.Threading.Thread": "4.0.0-beta-*",
-                "System.Threading.ThreadPool": "4.0.10-beta-*"
-            }
-        }
+        "dnx451": { }
     },
     "compilationOptions": {
         "allowUnsafe": true

--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Server.Kestrel;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Server.Kestrel;
 using Microsoft.AspNet.Server.Kestrel.Http;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Infrastructure;

--- a/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyExchangerTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyExchangerTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNet.Server.Kestrel;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNet.Server.Kestrel.Http;
 using System;
 using System.Threading.Tasks;

--- a/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.AspNet.Server.Kestrel.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Server.Kestrel.Http;
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/test/Microsoft.AspNet.Server.KestrelTests/Program.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNet.Server.KestrelTests
 {

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestConnection.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestConnection.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestInput.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestInput.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNet.Server.Kestrel.Http;
 
 namespace Microsoft.AspNet.Server.KestrelTests

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestServer.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestServer.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Server.Kestrel;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Server.Kestrel;
 using Microsoft.AspNet.Server.Kestrel.Http;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Infrastructure;


### PR DESCRIPTION
- Ensure all the C# files have copyright notices