### PR TITLE
Pre-create Continue bytes in Frame

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -289,7 +289,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             //_upgradeTask = callback(_callContext);
         }
 
-        byte[] _continueBytes = Encoding.ASCII.GetBytes("HTTP/1.1 100 Continue\r\n\r\n");
+        static readonly ArraySegment<byte> _continueBytes = CreateAsciiByteArraySegment("HTTP/1.1 100 Continue\r\n\r\n");
+
+        static ArraySegment<byte> CreateAsciiByteArraySegment(string text)
+        {
+            var bytes = Encoding.ASCII.GetBytes(text);
+            return new ArraySegment<byte>(bytes, 0, bytes.Length);
+        }
 
         public void ProduceContinue()
         {
@@ -301,7 +307,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 (expect.FirstOrDefault() ?? "").Equals("100-continue", StringComparison.OrdinalIgnoreCase))
             {
                 SocketOutput.Write(
-                    new ArraySegment<byte>(_continueBytes, 0, _continueBytes.Length),
+                    _continueBytes,
                     (error, _) =>
                     {
                         if (error != null)


### PR DESCRIPTION
The `HTTP/1.1 100 Continue` header bytes can be `static readonly`, and can be pre-created as an `ArraySegment` instead of creating it for each response.