### PR TITLE
Gracefully handle exceptions thrown from OnStarting callbacks

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -317,6 +317,31 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public void ProduceEnd(Exception ex)
         {
+            if (ex != null)
+            {
+                if (_resultStarted)
+                {
+                    // We can no longer respond with a 500, so we simply close the connection.
+                    ConnectionControl.End(ProduceEndType.SocketDisconnect);
+                    return;
+                }
+                else
+                {
+                    StatusCode = 500;
+                    ReasonPhrase = null;
+
+                    // If OnStarting hasn't been triggered yet, we don't want to trigger it now that
+                    // the app func has failed. https://github.com/aspnet/KestrelHttpServer/issues/43
+                    _onStarting = null;
+
+                    ResponseHeaders.Clear();
+                    if (_keepAlive)
+                    {
+                        ResponseHeaders["Content-Length"] = new[] { "0" };
+                    }
+                }
+            }
+
             ProduceStart();
 
             if (!_keepAlive)

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -24,7 +24,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         }
 
         Mode _mode;
-        private bool _resultStarted;
         private bool _responseStarted;
         private bool _keepAlive;
 
@@ -232,6 +231,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             try
             {
                 await Application.Invoke(this);
+
+                // Trigger FireOnStarting if ProduceStart hasn't been called yet.
+                // We call it here, so it can go through our normal error handling
+                // and respond with a 500 if an OnStarting callback throws.
+                if (!_responseStarted)
+                {
+                    FireOnStarting();
+                }
             }
             catch (Exception ex)
             {
@@ -270,7 +277,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public void ProduceContinue()
         {
-            if (_resultStarted) return;
+            if (_responseStarted) return;
 
             string[] expect;
             if (HttpVersion.Equals("HTTP/1.1") &&
@@ -292,11 +299,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public void ProduceStart()
         {
-            if (_resultStarted) return;
-            _resultStarted = true;
-
+            // ProduceStart shouldn't no-op in the future just b/c FireOnStarting throws.
+            if (_responseStarted) return;
             FireOnStarting();
-
             _responseStarted = true;
 
             var status = ReasonPhrases.ToStatus(StatusCode, ReasonPhrase);
@@ -319,7 +324,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             if (ex != null)
             {
-                if (_resultStarted)
+                if (_responseStarted)
                 {
                     // We can no longer respond with a 500, so we simply close the connection.
                     ConnectionControl.End(ProduceEndType.SocketDisconnect);

--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Server.Kestrel;
-using Microsoft.AspNet.Server.Kestrel.Http;
-using Microsoft.Framework.Runtime;
-using Microsoft.Framework.Runtime.Infrastructure;
 using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel;
+using Microsoft.AspNet.Server.Kestrel.Http;
+using Microsoft.Framework.Runtime;
+using Microsoft.Framework.Runtime.Infrastructure;
 using Xunit;
 
 namespace Microsoft.AspNet.Server.KestrelTests
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
     /// <summary>
     /// Summary description for EngineTests
     /// </summary>
-    internal class EngineTests
+    public class EngineTests
     {
         private async Task App(Frame frame)
         {
@@ -55,6 +55,20 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 catch (NullReferenceException)
                 { return null; }
             }
+        }
+
+        private async Task AppThatThrows(Frame frame)
+        {
+            // Anything added to the ResponseHeaders dictionary is ignored
+            frame.ResponseHeaders["Content-Length"] = new[] { "11" };
+            throw new Exception();
+        }
+
+        private async Task AppThatThrowsAfterWrite(Frame frame)
+        {
+            frame.ResponseHeaders["Content-Length"] = new[] { "11" };
+            await frame.ResponseBody.WriteAsync(Encoding.UTF8.GetBytes("Hello World"), 0, 11);
+            throw new Exception();
         }
 
         private async Task AppChunked(Frame frame)
@@ -340,6 +354,52 @@ namespace Microsoft.AspNet.Server.KestrelTests
                     await connection.ReceiveEnd(
                         "HTTP/1.0 200 OK",
                         "\r\n");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ThrowingResultsIn500Response()
+        {
+            using (var server = new TestServer(AppThatThrows))
+            {
+                using (var connection = new TestConnection())
+                {
+                    await connection.SendEnd(
+                        "GET / HTTP/1.1",
+                        "",
+                        "GET / HTTP/1.1",
+                        "Connection: close",
+                        "",
+                        "");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 500 Internal Server Error",
+                        "Content-Length: 0",
+                        "",
+                        "HTTP/1.1 500 Internal Server Error",
+                        "Connection: close",
+                        "",
+                        "");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ThrowingAfterWritingKillsConnection()
+        {
+            using (var server = new TestServer(AppThatThrowsAfterWrite))
+            {
+                using (var connection = new TestConnection())
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "",
+                        "");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 200 OK",
+                        "Content-Length: 11",
+                        "",
+                        "Hello World");
                 }
             }
         }

--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -57,20 +57,6 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        private async Task AppThatThrows(Frame frame)
-        {
-            // Anything added to the ResponseHeaders dictionary is ignored
-            frame.ResponseHeaders["Content-Length"] = new[] { "11" };
-            throw new Exception();
-        }
-
-        private async Task AppThatThrowsAfterWrite(Frame frame)
-        {
-            frame.ResponseHeaders["Content-Length"] = new[] { "11" };
-            await frame.ResponseBody.WriteAsync(Encoding.UTF8.GetBytes("Hello World"), 0, 11);
-            throw new Exception();
-        }
-
         private async Task AppChunked(Frame frame)
         {
             var data = new MemoryStream();
@@ -361,7 +347,20 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public async Task ThrowingResultsIn500Response()
         {
-            using (var server = new TestServer(AppThatThrows))
+            bool onStartingCalled = false;
+
+            using (var server = new TestServer(frame =>
+            {
+                frame.OnStarting(_ =>
+                {
+                    onStartingCalled = true;
+                    return Task.FromResult<object>(null);
+                }, null);
+
+                // Anything added to the ResponseHeaders dictionary is ignored
+                frame.ResponseHeaders["Content-Length"] = new[] { "11" };
+                throw new Exception();
+            }))
             {
                 using (var connection = new TestConnection())
                 {
@@ -380,6 +379,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
                         "Connection: close",
                         "",
                         "");
+
+                    Assert.False(onStartingCalled);
                 }
             }
         }
@@ -387,7 +388,20 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public async Task ThrowingAfterWritingKillsConnection()
         {
-            using (var server = new TestServer(AppThatThrowsAfterWrite))
+            bool onStartingCalled = false;
+
+            using (var server = new TestServer(async frame =>
+            {
+                frame.OnStarting(_ =>
+                {
+                    onStartingCalled = true;
+                    return Task.FromResult<object>(null);
+                }, null);
+
+                frame.ResponseHeaders["Content-Length"] = new[] { "11" };
+                await frame.ResponseBody.WriteAsync(Encoding.ASCII.GetBytes("Hello World"), 0, 11);
+                throw new Exception();
+            }))
             {
                 using (var connection = new TestConnection())
                 {
@@ -400,6 +414,43 @@ namespace Microsoft.AspNet.Server.KestrelTests
                         "Content-Length: 11",
                         "",
                         "Hello World");
+
+                    Assert.True(onStartingCalled);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ThrowingAfterPartialWriteKillsConnection()
+        {
+            bool onStartingCalled = false;
+
+            using (var server = new TestServer(async frame =>
+            {
+                frame.OnStarting(_ =>
+                {
+                    onStartingCalled = true;
+                    return Task.FromResult<object>(null);
+                }, null);
+
+                frame.ResponseHeaders["Content-Length"] = new[] { "11" };
+                await frame.ResponseBody.WriteAsync(Encoding.ASCII.GetBytes("Hello"), 0, 5);
+                throw new Exception();
+            }))
+            {
+                using (var connection = new TestConnection())
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "",
+                        "");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 200 OK",
+                        "Content-Length: 11",
+                        "",
+                        "Hello");
+
+                    Assert.True(onStartingCalled);
                 }
             }
         }

--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -454,5 +454,81 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 }
             }
         }
+        
+        [Fact]
+        public async Task ThrowingInOnStartingResultsIn500Response()
+        {
+            using (var server = new TestServer(frame =>
+            {
+                frame.OnStarting(_ =>
+                {
+                    throw new Exception();
+                }, null);
+
+                frame.ResponseHeaders["Content-Length"] = new[] { "11" };
+
+                // If we write to the response stream, we will not get a 500.
+
+                return Task.FromResult<object>(null);
+            }))
+            {
+                using (var connection = new TestConnection())
+                {
+                    await connection.SendEnd(
+                        "GET / HTTP/1.1",
+                        "",
+                        "GET / HTTP/1.1",
+                        "Connection: close",
+                        "",
+                        "");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 500 Internal Server Error",
+                        "Content-Length: 0",
+                        "",
+                        "HTTP/1.1 500 Internal Server Error",
+                        "Connection: close",
+                        "",
+                        "");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ThrowingInOnStartingResultsInFailedWrites()
+        {
+            using (var server = new TestServer(async frame =>
+            {
+                var onStartingException = new Exception();
+
+                frame.OnStarting(_ =>
+                {
+                    throw onStartingException;
+                }, null);
+
+                frame.ResponseHeaders["Content-Length"] = new[] { "11" };
+
+                var writeException = await Assert.ThrowsAsync<Exception>(async () =>
+                    await frame.ResponseBody.WriteAsync(Encoding.ASCII.GetBytes("Hello World"), 0, 11));
+
+                Assert.Same(onStartingException, writeException);
+
+                // The second write should succeed since the OnStarting callback will not be called again
+                await frame.ResponseBody.WriteAsync(Encoding.ASCII.GetBytes("Exception!!"), 0, 11);
+            }))
+            {
+                using (var connection = new TestConnection())
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "",
+                        "");
+                    await connection.Receive(
+                        "HTTP/1.1 200 OK",
+                        "Content-Length: 11",
+                        "",
+                        "Exception!!"); ;
+                }
+            }
+        }
     }
 }

--- a/test/Microsoft.AspNet.Server.KestrelTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
- If OnStarting is being called after the app func has completed, return a 500.
- If Onstarting is being called due to a call to write, throw from write.