### PR TITLE
Implement support for UNIX sockets

### DIFF
--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -13,6 +13,7 @@
     },
     "commands": {
         "run": "Microsoft.AspNet.Server.Kestrel",
+        "run-socket": "Microsoft.AspNet.Server.Kestrel --server.urls unix:///tmp/kestrel-test.sock",
         "kestrel": "Microsoft.AspNet.Server.Kestrel",
         "web": "Microsoft.AspNet.Hosting"
     }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/IListener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/IListener.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    /// <summary>
+    /// A listener waits for incoming connections on a specified socket.
+    /// </summary>
+    public interface IListener : IDisposable
+    {
+        Task StartAsync(
+            string scheme,
+            string host,
+            int port,
+            KestrelThread thread,
+            Func<Frame, Task> application);
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/IListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/IListenerPrimary.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    /// <summary>
+    /// A primary listener waits for incoming connections on a specified socket. Incoming 
+    /// connections may be passed to a secondary listener to handle.
+    /// </summary>
+    public interface IListenerPrimary : IListener
+    {
+        Task StartAsync(
+            string pipeName,
+            string scheme,
+            string host,
+            int port,
+            KestrelThread thread,
+            Func<Frame, Task> application);
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/IListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/IListenerSecondary.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    /// <summary>
+    /// A secondary listener is delegated requests from a primary listener via a named pipe or 
+    /// UNIX domain socket.
+    /// </summary>
+    public interface IListenerSecondary : IDisposable
+    {
+        Task StartAsync(
+            string pipeName,
+            KestrelThread thread,
+            Func<Frame, Task> application);
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
@@ -9,11 +9,15 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
-    public class ListenerSecondary : ListenerContext, IDisposable
+    /// <summary>
+    /// A secondary listener is delegated requests from a primary listener via a named pipe or 
+    /// UNIX domain socket.
+    /// </summary>
+    public abstract class ListenerSecondary<T> : ListenerContext, IListenerSecondary where T : UvStreamHandle
     {
         UvPipeHandle DispatchPipe { get; set; }
 
-        public ListenerSecondary(IMemoryPool memory)
+        protected ListenerSecondary(IMemoryPool memory)
         {
             Memory = memory;
         }
@@ -64,8 +68,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                                             return;
                                         }
 
-                                        var acceptSocket = new UvTcpHandle();
-                                        acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
+                                        var acceptSocket = CreateAcceptSocket();
 
                                         try
                                         {
@@ -101,6 +104,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             }, null);
             return tcs.Task;
         }
+
+        /// <summary>
+        /// Creates a socket which can be used to accept an incoming connection
+        /// </summary>
+        protected abstract T CreateAcceptSocket();
 
         public void Dispose()
         {

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerPrimary.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+using Microsoft.AspNet.Server.Kestrel.Networking;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    /// <summary>
+    /// An implementation of <see cref="ListenerPrimary{T}"/> using UNIX sockets.
+    /// </summary>
+    public class PipeListenerPrimary : ListenerPrimary<UvPipeHandle>
+    {
+        public PipeListenerPrimary(IMemoryPool memory) : base(memory)
+        {
+        }
+
+        /// <summary>
+        /// Creates the socket used to listen for incoming connections
+        /// </summary>
+        protected override UvPipeHandle CreateListenSocket(string host, int port)
+        {
+            var socket = new UvPipeHandle();
+            socket.Init(Thread.Loop, false);
+            socket.Bind(host);
+            socket.Listen(Constants.ListenBacklog, ConnectionCallback, this);
+            return socket;
+        }
+
+        /// <summary>
+        /// Handles an incoming connection
+        /// </summary>
+        /// <param name="listenSocket">Socket being used to listen on</param>
+        /// <param name="status">Connection status</param>
+        protected override void OnConnection(UvPipeHandle listenSocket, int status)
+        {
+            var acceptSocket = new UvPipeHandle();
+            acceptSocket.Init(Thread.Loop, false);
+            listenSocket.Accept(acceptSocket);
+
+            DispatchConnection(acceptSocket);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerSecondary.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Server.Kestrel.Networking;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    /// <summary>
+    /// An implementation of <see cref="ListenerSecondary{T}"/> using UNIX sockets.
+    /// </summary>
+    public class PipeListenerSecondary : ListenerSecondary<UvPipeHandle>
+    {
+        public PipeListenerSecondary(IMemoryPool memory) : base(memory)
+        {
+        }
+
+        /// <summary>
+        /// Creates a socket which can be used to accept an incoming connection
+        /// </summary>
+        protected override UvPipeHandle CreateAcceptSocket()
+        {
+            var acceptSocket = new UvPipeHandle();
+            acceptSocket.Init(Thread.Loop, false);
+            return acceptSocket;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListener.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+using Microsoft.AspNet.Server.Kestrel.Networking;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    /// <summary>
+    /// Implementation of <see cref="Listener{T}"/> that uses TCP sockets as its transport.
+    /// </summary>
+    public class TcpListener : Listener<UvTcpHandle>
+    {
+        public TcpListener(IMemoryPool memory) : base(memory)
+        {
+        }
+
+        /// <summary>
+        /// Creates the socket used to listen for incoming connections
+        /// </summary>
+        protected override UvTcpHandle CreateListenSocket(string host, int port)
+        {
+            var socket = new UvTcpHandle();
+            socket.Init(Thread.Loop, Thread.QueueCloseHandle);
+            socket.Bind(new IPEndPoint(IPAddress.Any, port));
+            socket.Listen(Constants.ListenBacklog, ConnectionCallback, this);
+            return socket;
+        }
+
+        /// <summary>
+        /// Handle an incoming connection
+        /// </summary>
+        /// <param name="listenSocket">Socket being used to listen on</param>
+        /// <param name="status">Connection status</param>
+        protected override void OnConnection(UvTcpHandle listenSocket, int status)
+        {
+            var acceptSocket = new UvTcpHandle();
+            acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
+            listenSocket.Accept(acceptSocket);
+
+            DispatchConnection(acceptSocket);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerPrimary.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+using Microsoft.AspNet.Server.Kestrel.Networking;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    /// <summary>
+    /// An implementation of <see cref="ListenerPrimary{T}"/> using TCP sockets.
+    /// </summary>
+    public class TcpListenerPrimary : ListenerPrimary<UvTcpHandle>
+    {
+        public TcpListenerPrimary(IMemoryPool memory) : base(memory)
+        {
+        }
+
+        /// <summary>
+        /// Creates the socket used to listen for incoming connections
+        /// </summary>
+        protected override UvTcpHandle CreateListenSocket(string host, int port)
+        {
+            var socket = new UvTcpHandle();
+            socket.Init(Thread.Loop, Thread.QueueCloseHandle);
+            socket.Bind(new IPEndPoint(IPAddress.Any, port));
+            socket.Listen(Constants.ListenBacklog, ConnectionCallback, this);
+            return socket;
+        }
+
+        /// <summary>
+        /// Handles an incoming connection
+        /// </summary>
+        /// <param name="listenSocket">Socket being used to listen on</param>
+        /// <param name="status">Connection status</param>
+        protected override void OnConnection(UvTcpHandle listenSocket, int status)
+        {
+            var acceptSocket = new UvTcpHandle();
+            acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
+            listenSocket.Accept(acceptSocket);
+
+            DispatchConnection(acceptSocket);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerSecondary.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Server.Kestrel.Networking;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    /// <summary>
+    /// An implementation of <see cref="ListenerSecondary{T}"/> using TCP sockets.
+    /// </summary>
+    public class TcpListenerSecondary : ListenerSecondary<UvTcpHandle>
+    {
+        public TcpListenerSecondary(IMemoryPool memory) : base(memory)
+        {
+        }
+
+        /// <summary>
+        /// Creates a socket which can be used to accept an incoming connection
+        /// </summary>
+        protected override UvTcpHandle CreateAcceptSocket()
+        {
+            var acceptSocket = new UvTcpHandle();
+            acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
+            return acceptSocket;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/Constants.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/Constants.cs
@@ -1,12 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 {
     internal class Constants
     {
         public const int ListenBacklog = 128;
+
+        /// <summary>
+        /// URL scheme for specifying Unix sockets in the configuration.
+        /// </summary>
+        public const string UnixScheme = "unix";
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Hosting.Server;
 using Microsoft.AspNet.Http.Features;
-using Microsoft.AspNet.Server.Kestrel;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Framework.Configuration;
+using Constants = Microsoft.AspNet.Server.Kestrel.Infrastructure.Constants;
 
 namespace Microsoft.AspNet.Server.Kestrel
 {
@@ -43,7 +43,8 @@ namespace Microsoft.AspNet.Server.Kestrel
             {
                 disposables.Add(engine.CreateServer(
                     address.Scheme,
-                    address.Host,
+                    // Unix sockets use a file path, not a hostname.
+                    address.Scheme == Constants.UnixScheme ? address.Path : address.Host,
                     address.Port,
                     async frame =>
                     {


### PR DESCRIPTION
The common use-case for Kestrel in production will be behind a reverse proxy such as Nginx. In cases where the reverse proxy is located on the same machine as the application, connecting via a UNIX socket is more efficient than a TCP socket, as it avoids going through the network layer. Accessing 127.0.0.1 through TCP still needs to initiate a TCP connection and perform handshaking, checksumming, etc, all of which is avoided by using UNIX sockets.

 - Moved TCP-specific stuff from Listener into new TcpListener class (same with ListenerPrimary and ListenerSecondary)
 - Made Listener abstract
 - Created new PipeListener. Note that while the use case is for UNIX sockets, this is called "Pipe" in uv, so I've called this "PipeListener" so the terminology is consistant
 - Uses "unix" URL scheme to determine whether to use socket. "http://127.0.0.1:5000" is for listening via TCP while "unix:///var/run/kestrel-test.sock" is for listening via UNIX socket

Example Nginx configuration for proxying to a UNIX socket:
```nginx
server {
  server_name kestreltest.localhost;
  root /var/www/dan.cx/net5test/wwwroot;

  location / {
    # Serve static files directly; proxy everything else to Kestrel
    try_files $uri @aspnet;
  }

  location @aspnet {
    proxy_pass http://unix:/tmp/kestrel-test.sock;
    proxy_set_header Host $host;
  }
}
```

#156