### PR TITLE
Fix ListenerSecondary so it can reliably accept new connections on Windows

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
@@ -50,8 +50,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                             try
                             {
-                                var ptr = Marshal.AllocHGlobal(16);
-                                var buf = Thread.Loop.Libuv.buf_init(ptr, 16);
+                                var ptr = Marshal.AllocHGlobal(4);
+                                var buf = Thread.Loop.Libuv.buf_init(ptr, 4);
 
                                 DispatchPipe.ReadStart(
                                     (_1, _2, _3) => buf,


### PR DESCRIPTION
Calling uv_read_start on a named pipe with a larger than necessary buffer
would cause pieces of the next uv_ipc_frame_uv_stream struct to be read into
the uv_read_start buffer when a lot of tcp handles were passed quickly over
the pipe.

This prevented the struct from properly being queued for the next call to
uv_accept to consume. The empty queue caused the call to uv_accept in
ListenerSecondary to fail and return WSAEWOULDBLOCK leaving the connection
in a zombie state.