### PR TITLE
Prevent pipes from being closed prematurely on OS X and Linux

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -3,15 +3,13 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
     public class Connection : ConnectionContext, IConnectionControl
     {
-        private const int EOF = -4095;
-        private const int ECONNRESET = -4077;
-
         private static readonly Action<UvStreamHandle, int, Exception, object> _readCallback = ReadCallback;
         private static readonly Func<UvStreamHandle, int, object, Libuv.uv_buf_t> _allocCallback = AllocCallback;
 
@@ -60,7 +58,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             SocketInput.Unpin(status);
 
             var normalRead = error == null && status > 0;
-            var normalDone = status == 0 || status == ECONNRESET || status == EOF;
+            var normalDone = status == 0 || status == Constants.ECONNRESET || status == Constants.EOF;
             var errorDone = !(normalDone || normalRead);
 
             if (normalRead)

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/Constants.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/Constants.cs
@@ -7,6 +7,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
     {
         public const int ListenBacklog = 128;
 
+        public const int EOF = -4095;
+        public const int ECONNRESET = -4077;
+
         /// <summary>
         /// Prefix of host name used to specify Unix sockets in the configuration.
         /// </summary>

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
@@ -253,6 +253,15 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        unsafe protected delegate int uv_pipe_pending_count(UvPipeHandle handle);
+        protected uv_pipe_pending_count _uv_pipe_pending_count = default(uv_pipe_pending_count);
+        unsafe public int pipe_pending_count(UvPipeHandle handle)
+        {
+            handle.Validate();
+            return _uv_pipe_pending_count(handle);
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void uv_alloc_cb(IntPtr server, int suggested_size, out uv_buf_t buf);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void uv_read_cb(IntPtr server, int nread, ref uv_buf_t buf);

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvPipeHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvPipeHandle.cs
@@ -32,5 +32,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
         {
             _uv.pipe_bind(this, name);
         }
+
+        public int PendingCount()
+        {
+            return _uv.pipe_pending_count(this);
+        }
     }
 }


### PR DESCRIPTION
This change fixes the in-process marshalling of TCP handles on Mac and Linux
that is used to support having multiple threads accepting connections from
multiple loops.

On these two platforms, the ReadStart callback somtimes gets called with a
status and pipe_pending_count equal to zero. Now when the status is zero
just exit the callback without closing the pipe.

This change more closely follows the example at
https://nikhilm.github.io/uvbook/processes.html#sending-file-descriptors-over-pipes