### PR TITLE
Set Content-Length: 0 when an AppFunc completes without a write

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -254,11 +254,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     FireOnStarting();
                 }
-
-                if (_autoChunk)
-                {
-                    WriteChunkedResponseSuffix();
-                }
             }
             catch (Exception ex)
             {
@@ -380,7 +375,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             }
         }
 
-        public void ProduceStart(bool immediate = true)
+        public void ProduceStart(bool immediate = true, bool appCompleted = false)
         {
             // ProduceStart shouldn't no-op in the future just b/c FireOnStarting throws.
             if (_responseStarted) return;
@@ -389,7 +384,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
             var status = ReasonPhrases.ToStatus(StatusCode, ReasonPhrase);
 
-            var responseHeader = CreateResponseHeader(status, ResponseHeaders);
+            var responseHeader = CreateResponseHeader(status, appCompleted, ResponseHeaders);
             SocketOutput.Write(
                 responseHeader.Item1,
                 (error, x) =>
@@ -428,7 +423,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 }
             }
 
-            ProduceStart();
+            ProduceStart(immediate: true, appCompleted: true);
+
+            // _autoChunk should be checked after we are sure ProduceStart() has been called
+            // since ProduceStart() may set _autoChunk to true.
+            if (_autoChunk)
+            {
+                WriteChunkedResponseSuffix();
+            }
 
             if (!_keepAlive)
             {
@@ -440,7 +442,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         }
 
         private Tuple<ArraySegment<byte>, IDisposable> CreateResponseHeader(
-            string status, IEnumerable<KeyValuePair<string, string[]>> headers)
+            string status,
+            bool appCompleted,
+            IEnumerable<KeyValuePair<string, string[]>> headers)
         {
             var writer = new MemoryPoolTextWriter(Memory);
             writer.Write(HttpVersion);
@@ -488,6 +492,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                         }
                     }
                 }
+            }
+
+            if (appCompleted && !hasTransferEncoding && !hasContentLength)
+            {
+                // Since the app has completed and we are only now generating
+                // the headers we can safely set the Content-Length to 0.
+                writer.Write("Content-Length: 0\r\n");
+                hasContentLength = true;
             }
 
             if (_keepAlive && !hasTransferEncoding && !hasContentLength)

--- a/test/Microsoft.AspNet.Server.KestrelTests/ChunkedResponseTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/ChunkedResponseTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -71,5 +72,85 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 }
             }
         }
+
+        [Fact]
+        public async Task EmptyResponseBodyHandledCorrectlyWithZeroLengthWrite()
+        {
+            using (var server = new TestServer(async frame =>
+            {
+                frame.ResponseHeaders.Clear();
+                await frame.ResponseBody.WriteAsync(new byte[0], 0, 0);
+            }))
+            {
+                using (var connection = new TestConnection())
+                {
+                    await connection.SendEnd(
+                        "GET / HTTP/1.1",
+                        "",
+                        "");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 200 OK",
+                        "Transfer-Encoding: chunked",
+                        "",
+                        "0",
+                        "",
+                        "");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ConnectionClosedIfExeptionThrownAfterWrite()
+        {
+            using (var server = new TestServer(async frame =>
+            {
+                frame.ResponseHeaders.Clear();
+                await frame.ResponseBody.WriteAsync(Encoding.ASCII.GetBytes("Hello World!"), 0, 12);
+                throw new Exception();
+            }))
+            {
+                using (var connection = new TestConnection())
+                {
+                    // SendEnd is not called, so it isn't the client closing the connection.
+                    // client closing the connection.
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "",
+                        "");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 200 OK",
+                        "Transfer-Encoding: chunked",
+                        "",
+                        "c",
+                        "Hello World!",
+                        "");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ConnectionClosedIfExeptionThrownAfterZeroLengthWrite()
+        {
+            using (var server = new TestServer(async frame =>
+            {
+                frame.ResponseHeaders.Clear();
+                await frame.ResponseBody.WriteAsync(new byte[0], 0, 0);
+                throw new Exception();
+            }))
+            {
+                using (var connection = new TestConnection())
+                {
+                    // SendEnd is not called, so it isn't the client closing the connection.
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "",
+                        "");
+
+                    // Nothing (not even headers) are written, but the connection is closed.
+                    await connection.ReceiveEnd();
+                }
+            }
+        }
     }
 }
+


### PR DESCRIPTION
- Previously an incomplete chunked response would be written instead.
- Add test to verify Content-Length: 0 is set automatically.
- Add test to verify HTTP/1.0 keep-alive isn't used if no Content-Length
  is set for the response.
- Add tests to verify errors are handled properly after chunked writes.

#173