### PR TITLE
Use ILogger to log message

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -4,13 +4,16 @@
 using System;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
+using Microsoft.Framework.Logging;
 
 namespace SampleApp
 {
     public class Startup
     {
-        public void Configure(IApplicationBuilder app)
+        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
+            loggerFactory.MinimumLevel = LogLevel.Debug;
+            loggerFactory.AddConsole(LogLevel.Debug);
             app.Run(context =>
             {
                 Console.WriteLine("{0} {1}{2}{3}",

--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -1,7 +1,9 @@
 {
     "version": "1.0.0-*",
     "dependencies": {
-        "Microsoft.AspNet.Server.Kestrel": "1.0.0-*"
+        "Microsoft.AspNet.Server.Kestrel": "1.0.0-*",
+        "Microsoft.Framework.Logging": "1.0.0-*",
+        "Microsoft.Framework.Logging.Console": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": { },

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using System.Diagnostics;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -75,18 +76,17 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                 if (errorDone && error != null)
                 {
-                    Trace.WriteLine("Connection.OnRead " + error.ToString());
+                    KestrelTrace.Log.LogError("Connection.OnRead " + error, error);
                 }
             }
-
-
+            
             try
             {
                 _frame.Consume();
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("Connection._frame.Consume " + ex.ToString());
+                KestrelTrace.Log.LogError("Connection._frame.Consume " + ex, ex);
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Framework.Logging;
 
 // ReSharper disable AccessToModifiedClosure
 
@@ -298,7 +299,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     {
                         if (error != null)
                         {
-                            Trace.WriteLine("WriteChunkPrefix" + error.ToString());
+                            KestrelTrace.Log.LogError("WriteChunkPrefix" + error, error);
                         }
                     },
                     null,
@@ -315,7 +316,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     if (error != null)
                     {
-                        Trace.WriteLine("WriteChunkSuffix" + error.ToString());
+                        KestrelTrace.Log.LogError("WriteChunkSuffix" + error, error);
                     }
                 },
                 null,
@@ -329,7 +330,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     if (error != null)
                     {
-                        Trace.WriteLine("WriteChunkedResponseSuffix" + error.ToString());
+                        KestrelTrace.Log.LogError("WriteChunkedResponseSuffix" + error, error);
                     }
                 },
                 null,
@@ -368,7 +369,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     {
                         if (error != null)
                         {
-                            Trace.WriteLine("ProduceContinue " + error.ToString());
+                            KestrelTrace.Log.LogError("ProduceContinue " + error, error);
                         }
                     },
                     null);
@@ -391,7 +392,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     if (error != null)
                     {
-                        Trace.WriteLine("ProduceStart " + error.ToString());
+                        KestrelTrace.Log.LogError("ProduceStart " + error, error);
                     }
                     ((IDisposable)x).Dispose();
                 },

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNet.Server.Kestrel.Networking;
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -20,7 +21,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             if (error != null)
             {
-                Trace.WriteLine("Listener.ConnectionCallback " + error.ToString());
+                KestrelTrace.Log.LogError("Listener.ConnectionCallback " + error, error);
             }
             else
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -76,7 +77,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                                         }
                                         catch (Exception ex)
                                         {
-                                            Trace.WriteLine("DispatchPipe.Accept " + ex.Message);
+                                            KestrelTrace.Log.LogError("DispatchPipe.Accept " + ex.Message, ex);
                                             acceptSocket.Dispose();
                                             return;
                                         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel
 {
@@ -231,7 +232,7 @@ namespace Microsoft.AspNet.Server.Kestrel
                     }
                     else
                     {
-                        Trace.WriteLine("KestrelThread.DoPostWork " + ex.ToString());
+                        KestrelTrace.Log.LogError("KestrelThread.DoPostWork " + ex, ex);
                     }
                 }
             }
@@ -254,7 +255,7 @@ namespace Microsoft.AspNet.Server.Kestrel
                 }
                 catch (Exception ex)
                 {
-                    Trace.WriteLine("KestrelThread.DoPostCloseHandle " + ex.ToString());
+                    KestrelTrace.Log.LogError("KestrelThread.DoPostCloseHandle " + ex, ex);
                 }
             }
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
@@ -1,85 +1,117 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-//using System.Diagnostics.Tracing;
+using System;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel
 {
     /// <summary>
     /// Summary description for KestrelTrace
     /// </summary>
-    public class KestrelTrace //: EventSource
+    public class KestrelTrace : ILogger
     {
-        public static KestrelTrace Log = new KestrelTrace();
-  //      static EventTask Connection = (EventTask)1;
-    //    static EventTask Frame = (EventTask)1;
+        public readonly ILogger _logger; 
 
+        public KestrelTrace(ILogger logger)
+        {
+            _logger = logger;
+            Log = this;
+        }
 
-      //  [Event(13, Level = EventLevel.Informational, Message = "Id {0}")]
+        public static KestrelTrace Log;
+  
         public void ConnectionStart(long connectionId)
         {
-         //   WriteEvent(13, connectionId);
+            this.LogDebug(13, $"{nameof(ConnectionStart)}: Id: {connectionId}");
         }
 
       //  [Event(14, Level = EventLevel.Informational, Message = "Id {0}")]
         public void ConnectionStop(long connectionId)
         {
-       //     WriteEvent(14, connectionId);
+            this.LogDebug(14, $"ConnectionStop(connectionId: {connectionId})");
+            //     WriteEvent(14, connectionId);
         }
 
 
    //     [Event(4, Message = "Id {0} Status {1}")]
         internal void ConnectionRead(long connectionId, int status)
         {
-     //       WriteEvent(4, connectionId, status);
+            this.LogDebug(4, $"ConnectionStop(connectionId: {connectionId}, status: {status})");
+            //       WriteEvent(4, connectionId, status);
         }
 
  //       [Event(5, Message = "Id {0}")]
         internal void ConnectionPause(long connectionId)
         {
-   //         WriteEvent(5, connectionId);
+            this.LogDebug(5, $"ConnectionPause(connectionId: {connectionId})");
+            //         WriteEvent(5, connectionId);
         }
 
  //       [Event(6, Message = "Id {0}")]
         internal void ConnectionResume(long connectionId)
         {
-   //         WriteEvent(6, connectionId);
+            this.LogDebug(6, $"ConnectionResume(connectionId: {connectionId})");
+            //         WriteEvent(6, connectionId);
         }
 
   //      [Event(7, Message = "Id {0}")]
         internal void ConnectionReadFin(long connectionId)
         {
-    //        WriteEvent(7, connectionId);
+            this.LogDebug(7, $"ConnectionReadFin(connectionId: {connectionId})");
+            //        WriteEvent(7, connectionId);
         }
 
 //        [Event(8, Message = "Id {0} Step {1}")]
         internal void ConnectionWriteFin(long connectionId, int step)
         {
-  //          WriteEvent(8, connectionId, step);
+            this.LogDebug(8, $"{nameof(ConnectionWriteFin)}({nameof(connectionId)}: {connectionId}, {nameof(step)}: {step})");
+            //          WriteEvent(8, connectionId, step);
         }
 
  //       [Event(9, Message = "Id {0}")]
         internal void ConnectionKeepAlive(long connectionId)
         {
-   //         WriteEvent(9, connectionId);
+            this.LogDebug(9, $"{nameof(ConnectionKeepAlive)}({nameof(connectionId)}: {connectionId})");
+            //         WriteEvent(9, connectionId);
         }
 
  //       [Event(10, Message = "Id {0}")]
         internal void ConnectionDisconnect(long connectionId)
         {
-   //         WriteEvent(10, connectionId);
+            this.LogDebug(10, $"{nameof(ConnectionDisconnect)}({nameof(connectionId)}: {connectionId})");
+            //         WriteEvent(10, connectionId);
         }
 
   //      [Event(11, Message = "Id {0} Count {1}")]
         internal void ConnectionWrite(long connectionId, int count)
         {
-    //        WriteEvent(11, connectionId, count);
+            this.LogDebug(11,
+                $"{nameof(ConnectionWrite)}({nameof(connectionId)}: {connectionId}, {nameof(count)}: {count})");
+            //        WriteEvent(11, connectionId, count);
         }
 
  //       [Event(12, Message = "Id {0} Status {1}")]
         internal void ConnectionWriteCallback(long connectionId, int status)
         {
-   //         WriteEvent(12, connectionId, status);
+            this.LogDebug(11,
+                $"{nameof(ConnectionWriteCallback)}({nameof(connectionId)}: {connectionId}, {nameof(status)}: {status})");
+            //         WriteEvent(12, connectionId, status);
+        }
+
+        void ILogger.Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+            _logger.Log(logLevel, eventId, state, exception, formatter);
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return _logger.IsEnabled(logLevel);
+        }
+
+        public IDisposable BeginScopeImpl(object state)
+        {
+            return _logger.BeginScopeImpl(state);
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
@@ -11,92 +11,84 @@ namespace Microsoft.AspNet.Server.Kestrel
     /// </summary>
     public class KestrelTrace : ILogger
     {
-        public readonly ILogger _logger; 
+        private static ILogger _logger;
+        private static readonly KestrelTrace _instance = new KestrelTrace();
 
-        public KestrelTrace(ILogger logger)
+        public static void Initialize(ILogger logger)
         {
             _logger = logger;
-            Log = this;
         }
 
-        public static KestrelTrace Log;
-  
+        private KestrelTrace()
+        {
+        }
+
+        public static KestrelTrace Log
+        {
+            get
+            {
+                if (_logger == null)
+                {
+                    throw new InvalidOperationException($"{nameof(KestrelTrace)} is not initialized. Please call {nameof(Initialize)}({nameof(ILogger)}) method first.");
+                }
+
+                return _instance;
+            }
+        }
+
         public void ConnectionStart(long connectionId)
         {
-            this.LogDebug(13, $"{nameof(ConnectionStart)}: Id: {connectionId}");
+            this.LogDebug(13, $"{nameof(ConnectionStart)} -> Id: {connectionId}");
         }
 
-      //  [Event(14, Level = EventLevel.Informational, Message = "Id {0}")]
         public void ConnectionStop(long connectionId)
         {
-            this.LogDebug(14, $"ConnectionStop(connectionId: {connectionId})");
-            //     WriteEvent(14, connectionId);
+            this.LogDebug(14, $"{nameof(ConnectionStop)} -> Id: {connectionId}");
         }
 
-
-   //     [Event(4, Message = "Id {0} Status {1}")]
         internal void ConnectionRead(long connectionId, int status)
         {
-            this.LogDebug(4, $"ConnectionStop(connectionId: {connectionId}, status: {status})");
-            //       WriteEvent(4, connectionId, status);
+            this.LogDebug(4, $"{nameof(ConnectionRead)} -> Id: {connectionId}, Status: {status}");
         }
 
- //       [Event(5, Message = "Id {0}")]
         internal void ConnectionPause(long connectionId)
         {
-            this.LogDebug(5, $"ConnectionPause(connectionId: {connectionId})");
-            //         WriteEvent(5, connectionId);
+            this.LogDebug(5, $"{nameof(ConnectionPause)} -> Id: {connectionId}");
         }
 
- //       [Event(6, Message = "Id {0}")]
         internal void ConnectionResume(long connectionId)
         {
-            this.LogDebug(6, $"ConnectionResume(connectionId: {connectionId})");
-            //         WriteEvent(6, connectionId);
+            this.LogDebug(6, $"{nameof(ConnectionResume)} -> Id: {connectionId}");
         }
 
-  //      [Event(7, Message = "Id {0}")]
         internal void ConnectionReadFin(long connectionId)
         {
-            this.LogDebug(7, $"ConnectionReadFin(connectionId: {connectionId})");
-            //        WriteEvent(7, connectionId);
+            this.LogDebug(7, $"{nameof(ConnectionReadFin)} -> Id: {connectionId}");
         }
 
-//        [Event(8, Message = "Id {0} Step {1}")]
         internal void ConnectionWriteFin(long connectionId, int step)
         {
-            this.LogDebug(8, $"{nameof(ConnectionWriteFin)}({nameof(connectionId)}: {connectionId}, {nameof(step)}: {step})");
-            //          WriteEvent(8, connectionId, step);
+            this.LogDebug(8, $"{nameof(ConnectionWriteFin)} -> Id: {connectionId}, Step: {step}");
         }
 
- //       [Event(9, Message = "Id {0}")]
         internal void ConnectionKeepAlive(long connectionId)
         {
-            this.LogDebug(9, $"{nameof(ConnectionKeepAlive)}({nameof(connectionId)}: {connectionId})");
-            //         WriteEvent(9, connectionId);
+            this.LogDebug(9, $"{nameof(ConnectionKeepAlive)} -> Id: {connectionId}");
         }
 
- //       [Event(10, Message = "Id {0}")]
         internal void ConnectionDisconnect(long connectionId)
         {
-            this.LogDebug(10, $"{nameof(ConnectionDisconnect)}({nameof(connectionId)}: {connectionId})");
-            //         WriteEvent(10, connectionId);
+            this.LogDebug(10, $"{nameof(ConnectionDisconnect)} -> Id: {connectionId}");
         }
 
-  //      [Event(11, Message = "Id {0} Count {1}")]
         internal void ConnectionWrite(long connectionId, int count)
         {
-            this.LogDebug(11,
-                $"{nameof(ConnectionWrite)}({nameof(connectionId)}: {connectionId}, {nameof(count)}: {count})");
-            //        WriteEvent(11, connectionId, count);
+            this.LogDebug(11, $"{nameof(ConnectionWrite)} -> Id: {connectionId}, Count: {count}");
         }
 
- //       [Event(12, Message = "Id {0} Status {1}")]
         internal void ConnectionWriteCallback(long connectionId, int status)
         {
-            this.LogDebug(11,
-                $"{nameof(ConnectionWriteCallback)}({nameof(connectionId)}: {connectionId}, {nameof(status)}: {status})");
-            //         WriteEvent(12, connectionId, status);
+            this.LogDebug(12, $"{nameof(ConnectionWriteCallback)} -> Id: {connectionId}, Status: {status}");
         }
 
         void ILogger.Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
@@ -38,57 +38,57 @@ namespace Microsoft.AspNet.Server.Kestrel
 
         public void ConnectionStart(long connectionId)
         {
-            this.LogDebug(13, $"{nameof(ConnectionStart)} -> Id: {connectionId}");
+            _logger.LogDebug(13, $"{nameof(ConnectionStart)} -> Id: {connectionId}");
         }
 
         public void ConnectionStop(long connectionId)
         {
-            this.LogDebug(14, $"{nameof(ConnectionStop)} -> Id: {connectionId}");
+            _logger.LogDebug(14, $"{nameof(ConnectionStop)} -> Id: {connectionId}");
         }
 
         internal void ConnectionRead(long connectionId, int status)
         {
-            this.LogDebug(4, $"{nameof(ConnectionRead)} -> Id: {connectionId}, Status: {status}");
+            _logger.LogDebug(4, $"{nameof(ConnectionRead)} -> Id: {connectionId}, Status: {status}");
         }
 
         internal void ConnectionPause(long connectionId)
         {
-            this.LogDebug(5, $"{nameof(ConnectionPause)} -> Id: {connectionId}");
+            _logger.LogDebug(5, $"{nameof(ConnectionPause)} -> Id: {connectionId}");
         }
 
         internal void ConnectionResume(long connectionId)
         {
-            this.LogDebug(6, $"{nameof(ConnectionResume)} -> Id: {connectionId}");
+            _logger.LogDebug(6, $"{nameof(ConnectionResume)} -> Id: {connectionId}");
         }
 
         internal void ConnectionReadFin(long connectionId)
         {
-            this.LogDebug(7, $"{nameof(ConnectionReadFin)} -> Id: {connectionId}");
+            _logger.LogDebug(7, $"{nameof(ConnectionReadFin)} -> Id: {connectionId}");
         }
 
         internal void ConnectionWriteFin(long connectionId, int step)
         {
-            this.LogDebug(8, $"{nameof(ConnectionWriteFin)} -> Id: {connectionId}, Step: {step}");
+            _logger.LogDebug(8, $"{nameof(ConnectionWriteFin)} -> Id: {connectionId}, Step: {step}");
         }
 
         internal void ConnectionKeepAlive(long connectionId)
         {
-            this.LogDebug(9, $"{nameof(ConnectionKeepAlive)} -> Id: {connectionId}");
+            _logger.LogDebug(9, $"{nameof(ConnectionKeepAlive)} -> Id: {connectionId}");
         }
 
         internal void ConnectionDisconnect(long connectionId)
         {
-            this.LogDebug(10, $"{nameof(ConnectionDisconnect)} -> Id: {connectionId}");
+            _logger.LogDebug(10, $"{nameof(ConnectionDisconnect)} -> Id: {connectionId}");
         }
 
         internal void ConnectionWrite(long connectionId, int count)
         {
-            this.LogDebug(11, $"{nameof(ConnectionWrite)} -> Id: {connectionId}, Count: {count}");
+            _logger.LogDebug(11, $"{nameof(ConnectionWrite)} -> Id: {connectionId}, Count: {count}");
         }
 
         internal void ConnectionWriteCallback(long connectionId, int status)
         {
-            this.LogDebug(12, $"{nameof(ConnectionWriteCallback)} -> Id: {connectionId}, Status: {status}");
+            _logger.LogDebug(12, $"{nameof(ConnectionWriteCallback)} -> Id: {connectionId}, Status: {status}");
         }
 
         void ILogger.Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)

--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNet.Server.Kestrel.Http;
 using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using Microsoft.Dnx.Runtime;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel
 {

--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNet.Server.Kestrel.Http;
 using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using Microsoft.Dnx.Runtime;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel
 {

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
@@ -63,7 +64,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("UvConnectRequest " + ex.ToString());
+                KestrelTrace.Log.LogError("UvConnectRequest " + ex, ex);
             }
         }
     }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvStreamHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvStreamHandle.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
@@ -127,7 +128,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("UvConnectionCb " + ex.ToString());
+                KestrelTrace.Log.LogError("UvConnectionCb " + ex, ex);
             }
         }
 
@@ -141,7 +142,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("UvAllocCb " + ex.ToString());
+                KestrelTrace.Log.LogError("UvAllocCb " + ex, ex);
                 buf = stream.Libuv.buf_init(IntPtr.Zero, 0);
                 throw;
             }
@@ -166,7 +167,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("UbReadCb " + ex.ToString());
+                KestrelTrace.Log.LogError("UbReadCb " + ex, ex);
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
@@ -161,7 +162,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("UvWriteCb " + ex.ToString());
+                KestrelTrace.Log.LogError("UvWriteCb " + ex, ex);
             }
         }
     }

--- a/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
@@ -20,16 +20,18 @@ namespace Microsoft.AspNet.Server.Kestrel
     {
         private readonly ILibraryManager _libraryManager;
         private readonly IApplicationShutdown _appShutdownService;
-        
+        private readonly ILoggerFactory _loggerFactory;
+
         public ServerFactory(ILibraryManager libraryManager, IApplicationShutdown appShutdownService, ILoggerFactory loggerFactory)
         {
             _libraryManager = libraryManager;
             _appShutdownService = appShutdownService;
-            KestrelTrace.Initialize(loggerFactory.CreateLogger(nameof(Kestrel)));
+            _loggerFactory = loggerFactory;
         }
 
         public IServerInformation Initialize(IConfiguration configuration)
         {
+            KestrelTrace.Initialize(_loggerFactory.CreateLogger("Microsoft.AspNet.Server.Kestrel"));
             var information = new ServerInformation();
             information.Initialize(configuration);
             return information;

--- a/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNet.Hosting.Server;
 using Microsoft.AspNet.Http.Features;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Framework.Configuration;
+using Microsoft.Framework.Logging;
 using Constants = Microsoft.AspNet.Server.Kestrel.Infrastructure.Constants;
 
 namespace Microsoft.AspNet.Server.Kestrel
@@ -19,11 +20,12 @@ namespace Microsoft.AspNet.Server.Kestrel
     {
         private readonly ILibraryManager _libraryManager;
         private readonly IApplicationShutdown _appShutdownService;
-
-        public ServerFactory(ILibraryManager libraryManager, IApplicationShutdown appShutdownService)
+        
+        public ServerFactory(ILibraryManager libraryManager, IApplicationShutdown appShutdownService, ILogger<KestrelEngine> logger)
         {
             _libraryManager = libraryManager;
             _appShutdownService = appShutdownService;
+            KestrelTrace.Log = new KestrelTrace(logger);
         }
 
         public IServerInformation Initialize(IConfiguration configuration)

--- a/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
@@ -21,11 +21,11 @@ namespace Microsoft.AspNet.Server.Kestrel
         private readonly ILibraryManager _libraryManager;
         private readonly IApplicationShutdown _appShutdownService;
         
-        public ServerFactory(ILibraryManager libraryManager, IApplicationShutdown appShutdownService, ILogger<KestrelEngine> logger)
+        public ServerFactory(ILibraryManager libraryManager, IApplicationShutdown appShutdownService, ILoggerFactory loggerFactory)
         {
             _libraryManager = libraryManager;
             _appShutdownService = appShutdownService;
-            KestrelTrace.Log = new KestrelTrace(logger);
+            KestrelTrace.Initialize(loggerFactory.CreateLogger(nameof(Kestrel)));
         }
 
         public IServerInformation Initialize(IConfiguration configuration)

--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -7,7 +7,8 @@
     },
     "dependencies": {
         "Microsoft.AspNet.Hosting": "1.0.0-*",
-        "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*"
+        "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*",
+        "Microsoft.Framework.Logging": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": { },

--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "Microsoft.AspNet.Hosting": "1.0.0-*",
         "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*",
-        "Microsoft.Framework.Logging": "1.0.0-*"
+        "Microsoft.Framework.Logging.Abstractions": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": { },

--- a/test/Microsoft.AspNet.Server.KestrelTests/ChunkedResponseTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/ChunkedResponseTests.cs
@@ -4,12 +4,18 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel;
 using Xunit;
 
 namespace Microsoft.AspNet.Server.KestrelTests
 {
     public class ChunkedResponseTests
     {
+        public ChunkedResponseTests()
+        {
+            KestrelTrace.Initialize(new TestLogger());
+        }
+
         [Fact]
         public async Task ResponsesAreChunkedAutomatically()
         {

--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -20,6 +20,11 @@ namespace Microsoft.AspNet.Server.KestrelTests
     /// </summary>
     public class EngineTests
     {
+        public EngineTests()
+        {
+            KestrelTrace.Initialize(new TestLogger());
+        }
+
         private async Task App(Frame frame)
         {
             frame.ResponseHeaders.Clear();

--- a/test/Microsoft.AspNet.Server.KestrelTests/FrameRequestHeadersTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/FrameRequestHeadersTests.cs
@@ -1,13 +1,18 @@
 ﻿using Microsoft.AspNet.Server.Kestrel.Http;
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using Microsoft.AspNet.Server.Kestrel;
 using Xunit;
 
 namespace Microsoft.AspNet.Server.KestrelTests
 {
     public class FrameRequestHeadersTests
     {
+        public FrameRequestHeadersTests()
+        {
+            KestrelTrace.Initialize(new TestLogger());
+        }
+
         [Fact]
         public void InitialDictionaryIsEmpty()
         {

--- a/test/Microsoft.AspNet.Server.KestrelTests/FrameResponseHeadersTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/FrameResponseHeadersTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNet.Server.Kestrel;
 using Microsoft.AspNet.Server.Kestrel.Http;
 using Xunit;
 
@@ -10,6 +11,11 @@ namespace Microsoft.AspNet.Server.KestrelTests
 {
     public class FrameResponseHeadersTests
     {
+        public FrameResponseHeadersTests()
+        {
+            KestrelTrace.Initialize(new TestLogger());
+        }
+
         [Fact]
         public void InitialDictionaryContainsServerAndDate()
         {

--- a/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyExchangerTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyExchangerTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNet.Server.Kestrel.Http;
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel;
 using Xunit;
 
 namespace Microsoft.AspNet.Server.KestrelTests
@@ -13,6 +14,11 @@ namespace Microsoft.AspNet.Server.KestrelTests
     /// </summary>
     public class MessageBodyExchangerTests
     {
+        public MessageBodyExchangerTests()
+        {
+            KestrelTrace.Initialize(new TestLogger());
+        }
+
 	    [Fact]
         public async Task CallingReadAsyncBeforeTransfer()
         {

--- a/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel;
 using Xunit;
 
 namespace Microsoft.AspNet.Server.KestrelTests
@@ -15,6 +16,11 @@ namespace Microsoft.AspNet.Server.KestrelTests
     /// </summary>
     public class MessageBodyTests
     {
+        public MessageBodyTests()
+        {
+            KestrelTrace.Initialize(new TestLogger());
+        }
+
         [Fact]
         public void Http10ConnectionClose()
         {

--- a/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         Libuv _uv;
         public MultipleLoopTests()
         {
+            KestrelTrace.Initialize(new TestLogger());
             var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented());
             _uv = engine.Libuv;
         }

--- a/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         Libuv _uv;
         public NetworkingTests()
         {
+            KestrelTrace.Initialize(new TestLogger());
             var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented());
             _uv = engine.Libuv;
         }

--- a/test/Microsoft.AspNet.Server.KestrelTests/Program.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/Program.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNet.Server.Kestrel;
 using Microsoft.Dnx.Runtime;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.KestrelTests
 {
@@ -14,10 +16,11 @@ namespace Microsoft.AspNet.Server.KestrelTests
         private readonly IApplicationEnvironment env;
         private readonly IServiceProvider sp;
 
-        public Program(IApplicationEnvironment env, IServiceProvider sp)
+        public Program(IApplicationEnvironment env, IServiceProvider sp, ILoggerFactory loggerFactory)
         {
             this.env = env;
             this.sp = sp;
+            KestrelTrace.Initialize(loggerFactory.CreateLogger(nameof(KestrelTests)));
         }
 
         public int Main()

--- a/test/Microsoft.AspNet.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/SocketOutputTests.cs
@@ -14,6 +14,11 @@ namespace Microsoft.AspNet.Server.KestrelTests
 {
     public class SocketOutputTests
     {
+        public SocketOutputTests()
+        {
+            KestrelTrace.Initialize(new TestLogger());
+        }
+
         [Fact]
         public void CanWrite1MB()
         {

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestLogger.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestLogger.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.AspNet.Server.Kestrel;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.AspNet.Server.KestrelTests
+{
+    public class TestLogger : ILogger
+    {
+        public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScopeImpl(object state)
+        {
+            return new Disposable(() => { });
+        }
+    }
+}


### PR DESCRIPTION
- KestrelTrace uses ILogger to log messages
- Trace.WriteLine replaced with ILogger (throug KestrelTrace)
- Enable Console logger in SampleApp to test logging through Microsoft.Framework.Logging framework
- Tests modified to support new logging mechanism