### PR TITLE
Fix bug #191 introduced by b25d2d9

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameResponseStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameResponseStream.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public override bool CanSeek => false;
 
-        public override bool CanWrite => false;
+        public override bool CanWrite => true;
 
         public override long Length
         {


### PR DESCRIPTION
CanWrite [was true](https://github.com/aspnet/KestrelHttpServer/commit/b25d2d97721aca7e6137de3619cdc875e37eac77#diff-4d4d276981c056bacc1a401293b08a93L107) before