### PR TITLE
Refactor KestrelTrace and add to the ServiceContext. Close aspnet/KestrelHttpServer#141

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -4,13 +4,16 @@
 using System;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
+using Microsoft.Framework.Logging;
 
 namespace SampleApp
 {
     public class Startup
     {
-        public void Configure(IApplicationBuilder app)
+        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
+            loggerFactory.MinimumLevel = LogLevel.Debug;
+            loggerFactory.AddConsole(LogLevel.Debug);
             app.Run(context =>
             {
                 Console.WriteLine("{0} {1}{2}{3}",

--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -13,7 +13,9 @@ namespace SampleApp
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             loggerFactory.MinimumLevel = LogLevel.Debug;
+
             loggerFactory.AddConsole(LogLevel.Debug);
+
             app.Run(context =>
             {
                 Console.WriteLine("{0} {1}{2}{3}",

--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -1,7 +1,9 @@
 {
     "version": "1.0.0-*",
     "dependencies": {
-        "Microsoft.AspNet.Server.Kestrel": "1.0.0-*"
+        "Microsoft.AspNet.Server.Kestrel": "1.0.0-*",
+        "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
+        "Microsoft.Framework.Logging.Console": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": { },

--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -2,7 +2,6 @@
     "version": "1.0.0-*",
     "dependencies": {
         "Microsoft.AspNet.Server.Kestrel": "1.0.0-*",
-        "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
         "Microsoft.Framework.Logging.Console": "1.0.0-*"
     },
     "frameworks": {

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using Microsoft.AspNet.Server.Kestrel.Networking;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -75,7 +75,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                 if (errorDone && error != null)
                 {
-                    Trace.WriteLine("Connection.OnRead " + error.ToString());
+                    Log.LogError("Connection.OnRead", error);
                 }
             }
 
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("Connection._frame.Consume " + ex.ToString());
+                Log.LogError("Connection._frame.Consume ", ex);
             }
         }
 
@@ -121,7 +121,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                             {
                                 Log.ConnectionWriteFin(_connectionId, 1);
                                 var self = (Connection)state;
-                                var shutdown = new UvShutdownReq();
+                                var shutdown = new UvShutdownReq(Log);
                                 shutdown.Init(self.Thread.Loop);
                                 shutdown.Shutdown(self._socket, (req, status, _) =>
                                 {

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -3,11 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Framework.Logging;
 using Microsoft.Framework.Primitives;
 
 // ReSharper disable AccessToModifiedClosure
@@ -276,7 +276,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     {
                         if (error != null)
                         {
-                            Trace.WriteLine("WriteChunkPrefix" + error.ToString());
+                            Log.LogError("WriteChunkPrefix", error);
                         }
                     },
                     null,
@@ -290,7 +290,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     if (error != null)
                     {
-                        Trace.WriteLine("WriteChunkSuffix" + error.ToString());
+                        Log.LogError("WriteChunkSuffix", error);
                     }
                 },
                 null,
@@ -304,7 +304,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     if (error != null)
                     {
-                        Trace.WriteLine("WriteChunkedResponseSuffix" + error.ToString());
+                        Log.LogError("WriteChunkedResponseSuffix", error);
                     }
                 },
                 null,
@@ -338,7 +338,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     {
                         if (error != null)
                         {
-                            Trace.WriteLine("ProduceContinue " + error.ToString());
+                            Log.LogError("ProduceContinue ", error);
                         }
                     },
                     null);
@@ -361,7 +361,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     if (error != null)
                     {
-                        Trace.WriteLine("ProduceStart " + error.ToString());
+                        Log.LogError("ProduceStart ", error);
                     }
                     ((IDisposable)state).Dispose();
                 },

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
@@ -3,8 +3,8 @@
 
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -50,11 +50,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// </summary>
         protected abstract UvStreamHandle CreateListenSocket(string host, int port);
 
-        protected static void ConnectionCallback(UvStreamHandle stream, int status, Exception error, object state)
+        protected void ConnectionCallback(UvStreamHandle stream, int status, Exception error, object state)
         {
             if (error != null)
             {
-                Trace.WriteLine("Listener.ConnectionCallback " + error.ToString());
+                Log.LogError("Listener.ConnectionCallback ", error);
             }
             else
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
@@ -50,15 +50,16 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// </summary>
         protected abstract UvStreamHandle CreateListenSocket(string host, int port);
 
-        protected void ConnectionCallback(UvStreamHandle stream, int status, Exception error, object state)
+        protected static void ConnectionCallback(UvStreamHandle stream, int status, Exception error, object state)
         {
+            var listener = (Listener) state;
             if (error != null)
             {
-                Log.LogError("Listener.ConnectionCallback ", error);
+                listener.Log.LogError("Listener.ConnectionCallback ", error);
             }
             else
             {
-                ((Listener)state).OnConnection(stream, status);
+                listener.OnConnection(stream, status);
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -13,6 +14,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         public ListenerContext(ServiceContext serviceContext)
         {
             Memory = serviceContext.Memory;
+            Log = serviceContext.Log;
         }
 
         public ListenerContext(ListenerContext listenerContext)
@@ -20,6 +22,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             Thread = listenerContext.Thread;
             Application = listenerContext.Application;
             Memory = listenerContext.Memory;
+            Log = listenerContext.Log;
         }
 
         public KestrelThread Thread { get; set; }
@@ -27,5 +30,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         public Func<Frame, Task> Application { get; set; }
 
         public IMemoryPool Memory { get; set; }
+
+        public IKestrelTrace Log { get; }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerPrimary.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
             await Thread.PostAsync(_ =>
             {
-                ListenPipe = new UvPipeHandle();
+                ListenPipe = new UvPipeHandle(Log);
                 ListenPipe.Init(Thread.Loop, false);
                 ListenPipe.Bind(pipeName);
                 ListenPipe.Listen(Constants.ListenBacklog, OnListenPipe, null);
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 return;
             }
 
-            var dispatchPipe = new UvPipeHandle();
+            var dispatchPipe = new UvPipeHandle(Log);
             dispatchPipe.Init(Thread.Loop, true);
             try
             {
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             else
             {
                 var dispatchPipe = _dispatchPipes[index];
-                var write = new UvWriteReq();
+                var write = new UvWriteReq(Log);
                 write.Init(Thread.Loop);
                 write.Write2(
                     dispatchPipe,

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
@@ -3,9 +3,9 @@
 
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             Thread = thread;
             Application = application;
 
-            DispatchPipe = new UvPipeHandle();
+            DispatchPipe = new UvPipeHandle(Log);
 
             var tcs = new TaskCompletionSource<int>();
             Thread.Post(_ =>
@@ -37,7 +37,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 try
                 {
                     DispatchPipe.Init(Thread.Loop, true);
-                    var connect = new UvConnectRequest();
+                    var connect = new UvConnectRequest(Log);
                     connect.Init(Thread.Loop);
                     connect.Connect(
                         DispatchPipe,
@@ -75,7 +75,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                                         }
                                         catch (Exception ex)
                                         {
-                                            Trace.WriteLine("DispatchPipe.Accept " + ex.Message);
+                                            Log.LogError("DispatchPipe.Accept", ex);
                                             acceptSocket.Dispose();
                                             return;
                                         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListener.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// </summary>
         protected override UvStreamHandle CreateListenSocket(string host, int port)
         {
-            var socket = new UvPipeHandle();
+            var socket = new UvPipeHandle(Log);
             socket.Init(Thread.Loop, false);
             socket.Bind(host);
             socket.Listen(Constants.ListenBacklog, ConnectionCallback, this);
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// <param name="status">Connection status</param>
         protected override void OnConnection(UvStreamHandle listenSocket, int status)
         {
-            var acceptSocket = new UvPipeHandle();
+            var acceptSocket = new UvPipeHandle(Log);
             acceptSocket.Init(Thread.Loop, false);
             listenSocket.Accept(acceptSocket);
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerPrimary.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// </summary>
         protected override UvStreamHandle CreateListenSocket(string host, int port)
         {
-            var socket = new UvPipeHandle();
+            var socket = new UvPipeHandle(Log);
             socket.Init(Thread.Loop, false);
             socket.Bind(host);
             socket.Listen(Constants.ListenBacklog, ConnectionCallback, this);
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// <param name="status">Connection status</param>
         protected override void OnConnection(UvStreamHandle listenSocket, int status)
         {
-            var acceptSocket = new UvPipeHandle();
+            var acceptSocket = new UvPipeHandle(Log);
             acceptSocket.Init(Thread.Loop, false);
             listenSocket.Accept(acceptSocket);
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerSecondary.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// </summary>
         protected override UvStreamHandle CreateAcceptSocket()
         {
-            var acceptSocket = new UvPipeHandle();
+            var acceptSocket = new UvPipeHandle(Log);
             acceptSocket.Init(Thread.Loop, false);
             return acceptSocket;
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     buffers[i++] = buffer;
                 }
 
-                var writeReq = new UvWriteReq();
+                var writeReq = new UvWriteReq(_log);
                 writeReq.Init(_thread.Loop);
 
                 writeReq.Write(_socket, new ArraySegment<ArraySegment<byte>>(buffers), (r, status, error, state) =>

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
@@ -16,6 +17,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         private readonly KestrelThread _thread;
         private readonly UvStreamHandle _socket;
+        private readonly IKestrelTrace _log;
 
         // This locks access to to all of the below fields
         private readonly object _lockObj = new object();
@@ -29,10 +31,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         private WriteContext _nextWriteContext;
         private readonly Queue<CallbackContext> _callbacksPending;
 
-        public SocketOutput(KestrelThread thread, UvStreamHandle socket)
+        public SocketOutput(KestrelThread thread, UvStreamHandle socket, IKestrelTrace log)
         {
             _thread = thread;
             _socket = socket;
+            _log = log;
             _callbacksPending = new Queue<CallbackContext>();
         }
 
@@ -43,7 +46,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             Array.Copy(buffer.Array, buffer.Offset, copy, 0, buffer.Count);
             buffer = new ArraySegment<byte>(copy);
 
-            KestrelTrace.Log.ConnectionWrite(0, buffer.Count);
+            _log.ConnectionWrite(0, buffer.Count);
 
             bool triggerCallbackNow = false;
 
@@ -152,7 +155,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         // This is called on the libuv event loop
         private void OnWriteCompleted(Queue<ArraySegment<byte>> writtenBuffers, UvWriteReq req, int status, Exception error)
         {
-            KestrelTrace.Log.ConnectionWriteCallback(0, status);
+            _log.ConnectionWriteCallback(0, status);
 
             lock (_lockObj)
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListener.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// </summary>
         protected override UvStreamHandle CreateListenSocket(string host, int port)
         {
-            var socket = new UvTcpHandle();
+            var socket = new UvTcpHandle(Log);
             socket.Init(Thread.Loop, Thread.QueueCloseHandle);
             socket.Bind(new IPEndPoint(IPAddress.Any, port));
             socket.Listen(Constants.ListenBacklog, ConnectionCallback, this);
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// <param name="status">Connection status</param>
         protected override void OnConnection(UvStreamHandle listenSocket, int status)
         {
-            var acceptSocket = new UvTcpHandle();
+            var acceptSocket = new UvTcpHandle(Log);
             acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
             listenSocket.Accept(acceptSocket);
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerPrimary.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// </summary>
         protected override UvStreamHandle CreateListenSocket(string host, int port)
         {
-            var socket = new UvTcpHandle();
+            var socket = new UvTcpHandle(Log);
             socket.Init(Thread.Loop, Thread.QueueCloseHandle);
             socket.Bind(new IPEndPoint(IPAddress.Any, port));
             socket.Listen(Constants.ListenBacklog, ConnectionCallback, this);
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// <param name="status">Connection status</param>
         protected override void OnConnection(UvStreamHandle listenSocket, int status)
         {
-            var acceptSocket = new UvTcpHandle();
+            var acceptSocket = new UvTcpHandle(Log);
             acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
             listenSocket.Accept(acceptSocket);
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerSecondary.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         /// </summary>
         protected override UvStreamHandle CreateAcceptSocket()
         {
-            var acceptSocket = new UvTcpHandle();
+            var acceptSocket = new UvTcpHandle(Log);
             acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
             return acceptSocket;
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/IKestrelTrace.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/IKestrelTrace.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Framework.Logging;
+
+namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
+{
+    public interface IKestrelTrace : ILogger
+    {
+        void ConnectionStart(long connectionId);
+
+        void ConnectionStop(long connectionId);
+
+        void ConnectionRead(long connectionId, int status);
+
+        void ConnectionPause(long connectionId);
+
+        void ConnectionResume(long connectionId);
+
+        void ConnectionReadFin(long connectionId);
+
+        void ConnectionWriteFin(long connectionId, int step);
+
+        void ConnectionKeepAlive(long connectionId);
+
+        void ConnectionDisconnect(long connectionId);
+
+        void ConnectionWrite(long connectionId, int count);
+
+        void ConnectionWriteCallback(long connectionId, int status);
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelTrace.cs
@@ -1,85 +1,92 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-//using System.Diagnostics.Tracing;
+using System;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel
 {
     /// <summary>
     /// Summary description for KestrelTrace
     /// </summary>
-    public class KestrelTrace //: EventSource
+    public class KestrelTrace : IKestrelTrace
     {
-        public static KestrelTrace Log = new KestrelTrace();
-  //      static EventTask Connection = (EventTask)1;
-    //    static EventTask Frame = (EventTask)1;
+        private readonly ILogger _logger;
 
+        public KestrelTrace(ILogger logger)
+        {
+            _logger = logger;
+        }
 
-      //  [Event(13, Level = EventLevel.Informational, Message = "Id {0}")]
         public void ConnectionStart(long connectionId)
         {
-         //   WriteEvent(13, connectionId);
+            _logger.LogDebug(13, $"{nameof(ConnectionStart)} -> Id: {connectionId}");
         }
 
-      //  [Event(14, Level = EventLevel.Informational, Message = "Id {0}")]
         public void ConnectionStop(long connectionId)
         {
-       //     WriteEvent(14, connectionId);
+            _logger.LogDebug(14, $"{nameof(ConnectionStop)} -> Id: {connectionId}");
         }
 
-
-   //     [Event(4, Message = "Id {0} Status {1}")]
-        internal void ConnectionRead(long connectionId, int status)
+        public void ConnectionRead(long connectionId, int status)
         {
-     //       WriteEvent(4, connectionId, status);
+            _logger.LogDebug(4, $"{nameof(ConnectionRead)} -> Id: {connectionId}, Status: {status}");
         }
 
- //       [Event(5, Message = "Id {0}")]
-        internal void ConnectionPause(long connectionId)
+        public void ConnectionPause(long connectionId)
         {
-   //         WriteEvent(5, connectionId);
+            _logger.LogDebug(5, $"{nameof(ConnectionPause)} -> Id: {connectionId}");
         }
 
- //       [Event(6, Message = "Id {0}")]
-        internal void ConnectionResume(long connectionId)
+        public void ConnectionResume(long connectionId)
         {
-   //         WriteEvent(6, connectionId);
+            _logger.LogDebug(6, $"{nameof(ConnectionResume)} -> Id: {connectionId}");
         }
 
-  //      [Event(7, Message = "Id {0}")]
-        internal void ConnectionReadFin(long connectionId)
+        public void ConnectionReadFin(long connectionId)
         {
-    //        WriteEvent(7, connectionId);
+            _logger.LogDebug(7, $"{nameof(ConnectionReadFin)} -> Id: {connectionId}");
         }
 
-//        [Event(8, Message = "Id {0} Step {1}")]
-        internal void ConnectionWriteFin(long connectionId, int step)
+        public void ConnectionWriteFin(long connectionId, int step)
         {
-  //          WriteEvent(8, connectionId, step);
+            _logger.LogDebug(8, $"{nameof(ConnectionWriteFin)} -> Id: {connectionId}, Step: {step}");
         }
 
- //       [Event(9, Message = "Id {0}")]
-        internal void ConnectionKeepAlive(long connectionId)
+        public void ConnectionKeepAlive(long connectionId)
         {
-   //         WriteEvent(9, connectionId);
+            _logger.LogDebug(9, $"{nameof(ConnectionKeepAlive)} -> Id: {connectionId}");
         }
 
- //       [Event(10, Message = "Id {0}")]
-        internal void ConnectionDisconnect(long connectionId)
+        public void ConnectionDisconnect(long connectionId)
         {
-   //         WriteEvent(10, connectionId);
+            _logger.LogDebug(10, $"{nameof(ConnectionDisconnect)} -> Id: {connectionId}");
         }
 
-  //      [Event(11, Message = "Id {0} Count {1}")]
-        internal void ConnectionWrite(long connectionId, int count)
+        public void ConnectionWrite(long connectionId, int count)
         {
-    //        WriteEvent(11, connectionId, count);
+            _logger.LogDebug(11, $"{nameof(ConnectionWrite)} -> Id: {connectionId}, Count: {count}");
         }
 
- //       [Event(12, Message = "Id {0} Status {1}")]
-        internal void ConnectionWriteCallback(long connectionId, int status)
+        public void ConnectionWriteCallback(long connectionId, int status)
         {
-   //         WriteEvent(12, connectionId, status);
+            _logger.LogDebug(12, $"{nameof(ConnectionWriteCallback)} -> Id: {connectionId}, Status: {status}");
+        }
+
+        public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+            _logger.Log(logLevel, eventId, state, exception, formatter);
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return _logger.IsEnabled(logLevel);
+        }
+
+        public IDisposable BeginScopeImpl(object state)
+        {
+            return _logger.BeginScopeImpl(state);
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNet.Server.Kestrel.Http;
 using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using Microsoft.Dnx.Runtime;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel
 {
@@ -16,8 +17,8 @@ namespace Microsoft.AspNet.Server.Kestrel
     {
         private readonly ServiceContext _serviceContext;
 
-        public KestrelEngine(ILibraryManager libraryManager, IApplicationShutdown appShutdownService)
-            : this(appShutdownService)
+        public KestrelEngine(ILibraryManager libraryManager, IApplicationShutdown appShutdownService, ILogger logger)
+            : this(appShutdownService, logger)
         {
             Libuv = new Libuv();
 
@@ -62,18 +63,19 @@ namespace Microsoft.AspNet.Server.Kestrel
         }
 
         // For testing
-        internal KestrelEngine(Libuv uv, IApplicationShutdown appShutdownService)
-           : this(appShutdownService)
+        internal KestrelEngine(Libuv uv, IApplicationShutdown appShutdownService, ILogger logger)
+           : this(appShutdownService, logger)
         {
             Libuv = uv;
         }
 
-        private KestrelEngine(IApplicationShutdown appShutdownService)
+        private KestrelEngine(IApplicationShutdown appShutdownService, ILogger logger)
         {
             _serviceContext = new ServiceContext
             {
                 AppShutdown = appShutdownService,
-                Memory = new MemoryPool()
+                Memory = new MemoryPool(),
+                Log = new KestrelTrace(logger)
             };
 
             Threads = new List<KestrelThread>();

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvAsyncHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvAsyncHandle.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
@@ -9,6 +10,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     {
         private static Libuv.uv_async_cb _uv_async_cb = AsyncCb;
         private Action _callback;
+
+        public UvAsyncHandle(IKestrelTrace logger) : base(logger)
+        {
+        }
 
         public void Init(UvLoopHandle loop, Action callback)
         {

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             Libuv.pipe_connect(this, pipe, name, _uv_connect_cb);
         }
 
-        private  static void UvConnectCb(IntPtr ptr, int status)
+        private static void UvConnectCb(IntPtr ptr, int status)
         {
             var req = FromIntPtr<UvConnectRequest>(ptr);
             req.Unpin();

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
@@ -12,14 +12,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     /// </summary>
     public class UvConnectRequest : UvRequest
     {
-        private readonly Libuv.uv_connect_cb _uv_connect_cb;
+        private readonly static Libuv.uv_connect_cb _uv_connect_cb = UvConnectCb;
 
         private Action<UvConnectRequest, int, Exception, object> _callback;
         private object _state;
 
         public UvConnectRequest(IKestrelTrace logger) : base (logger)
         {
-            _uv_connect_cb = UvConnectCb;
         }
 
         public void Init(UvLoopHandle loop)
@@ -44,7 +43,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             Libuv.pipe_connect(this, pipe, name, _uv_connect_cb);
         }
 
-        private void UvConnectCb(IntPtr ptr, int status)
+        private  static void UvConnectCb(IntPtr ptr, int status)
         {
             var req = FromIntPtr<UvConnectRequest>(ptr);
             req.Unpin();
@@ -67,7 +66,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                _log.LogError("UvConnectRequest", ex);
+                req._log.LogError("UvConnectRequest", ex);
             }
         }
     }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
@@ -2,9 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
@@ -13,10 +12,15 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     /// </summary>
     public class UvConnectRequest : UvRequest
     {
-        private readonly static Libuv.uv_connect_cb _uv_connect_cb = UvConnectCb;
+        private readonly Libuv.uv_connect_cb _uv_connect_cb;
 
         private Action<UvConnectRequest, int, Exception, object> _callback;
         private object _state;
+
+        public UvConnectRequest(IKestrelTrace logger) : base (logger)
+        {
+            _uv_connect_cb = UvConnectCb;
+        }
 
         public void Init(UvLoopHandle loop)
         {
@@ -40,7 +44,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             Libuv.pipe_connect(this, pipe, name, _uv_connect_cb);
         }
 
-        private static void UvConnectCb(IntPtr ptr, int status)
+        private void UvConnectCb(IntPtr ptr, int status)
         {
             var req = FromIntPtr<UvConnectRequest>(ptr);
             req.Unpin();
@@ -63,7 +67,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("UvConnectRequest " + ex.ToString());
+                _log.LogError("UvConnectRequest", ex);
             }
         }
     }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvHandle.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
@@ -10,6 +11,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     {
         private static Libuv.uv_close_cb _destroyMemory = DestroyMemory;
         private Action<Action<IntPtr>, IntPtr> _queueCloseHandle;
+
+        protected UvHandle(IKestrelTrace logger) : base (logger)
+        {
+        }
 
         unsafe protected void CreateHandle(
             Libuv uv,

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvLoopHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvLoopHandle.cs
@@ -3,11 +3,16 @@
 
 using System;
 using System.Threading;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
     public class UvLoopHandle : UvHandle
     {
+        public UvLoopHandle(IKestrelTrace logger) : base(logger)
+        {
+        }
+
         public void Init(Libuv uv)
         {
             CreateMemory(

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvMemory.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvMemory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
@@ -15,9 +16,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     {
         protected Libuv _uv;
         protected int _threadId;
+        protected IKestrelTrace _log;
 
-        public UvMemory() : base(IntPtr.Zero, true)
+        protected UvMemory(IKestrelTrace logger) : base(IntPtr.Zero, true)
         {
+            _log = logger;
         }
 
         public Libuv Libuv { get { return _uv; } }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvPipeHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvPipeHandle.cs
@@ -3,11 +3,16 @@
 
 using System;
 using System.Net;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
     public class UvPipeHandle : UvStreamHandle
     {
+        public UvPipeHandle(IKestrelTrace logger) : base(logger)
+        {
+        }
+
         public void Init(UvLoopHandle loop, bool ipc)
         {
             CreateMemory(

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvRequest.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvRequest.cs
@@ -1,14 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
     public class UvRequest : UvMemory
     {
         private GCHandle _pin;
+
+        protected UvRequest(IKestrelTrace logger) : base (logger)
+        {
+        }
 
         protected override bool ReleaseHandle()
         {

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvShutdownReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvShutdownReq.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Runtime.InteropServices;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
@@ -15,6 +15,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
 
         private Action<UvShutdownReq, int, object> _callback;
         private object _state;
+
+        public UvShutdownReq(IKestrelTrace logger) : base (logger)
+        {
+        }
 
         public void Init(UvLoopHandle loop)
         {

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvStreamHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvStreamHandle.cs
@@ -10,9 +10,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
     public abstract class UvStreamHandle : UvHandle
     {
-        private readonly Libuv.uv_connection_cb _uv_connection_cb;
-        private readonly Libuv.uv_alloc_cb _uv_alloc_cb;
-        private readonly Libuv.uv_read_cb _uv_read_cb;
+        private readonly static Libuv.uv_connection_cb _uv_connection_cb = UvConnectionCb;
+        private readonly static Libuv.uv_alloc_cb _uv_alloc_cb = UvAllocCb;
+        private readonly static Libuv.uv_read_cb _uv_read_cb = UvReadCb;
 
         public Action<UvStreamHandle, int, Exception, object> _listenCallback;
         public object _listenState;
@@ -25,9 +25,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
 
         protected UvStreamHandle(IKestrelTrace logger) : base(logger)
         {
-            _uv_connection_cb = UvConnectionCb;
-            _uv_alloc_cb = UvAllocCb;
-            _uv_read_cb = UvReadCb;
         }
 
         protected override bool ReleaseHandle()
@@ -122,7 +119,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
         }
 
 
-        private void UvConnectionCb(IntPtr handle, int status)
+        private static void UvConnectionCb(IntPtr handle, int status)
         {
             var stream = FromIntPtr<UvStreamHandle>(handle);
 
@@ -135,12 +132,12 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                _log.LogError("UvConnectionCb", ex);
+                stream._log.LogError("UvConnectionCb", ex);
             }
         }
 
 
-        private void UvAllocCb(IntPtr handle, int suggested_size, out Libuv.uv_buf_t buf)
+        private static void UvAllocCb(IntPtr handle, int suggested_size, out Libuv.uv_buf_t buf)
         {
             var stream = FromIntPtr<UvStreamHandle>(handle);
             try
@@ -149,13 +146,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                _log.LogError("UvAllocCb", ex);
+                stream._log.LogError("UvAllocCb", ex);
                 buf = stream.Libuv.buf_init(IntPtr.Zero, 0);
                 throw;
             }
         }
 
-        private void UvReadCb(IntPtr handle, int nread, ref Libuv.uv_buf_t buf)
+        private static void UvReadCb(IntPtr handle, int nread, ref Libuv.uv_buf_t buf)
         {
             var stream = FromIntPtr<UvStreamHandle>(handle);
 
@@ -174,7 +171,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                _log.LogError("UbReadCb", ex);
+                stream._log.LogError("UbReadCb", ex);
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvTcpHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvTcpHandle.cs
@@ -3,11 +3,16 @@
 
 using System;
 using System.Net;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
     public class UvTcpHandle : UvStreamHandle
     {
+        public UvTcpHandle(IKestrelTrace logger) : base(logger)
+        {
+        }
+
         public void Init(UvLoopHandle loop)
         {
             CreateMemory(

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     /// </summary>
     public class UvWriteReq : UvRequest
     {
-        private readonly Libuv.uv_write_cb _uv_write_cb;
+        private readonly static Libuv.uv_write_cb _uv_write_cb = UvWriteCb;
 
         private IntPtr _bufs;
 
@@ -26,7 +26,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
 
         public UvWriteReq(IKestrelTrace logger) : base(logger)
         {
-            _uv_write_cb = UvWriteCb;
         }
 
         public void Init(UvLoopHandle loop)
@@ -144,7 +143,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             req._pins.Clear();
         }
 
-        private void UvWriteCb(IntPtr ptr, int status)
+        private static void UvWriteCb(IntPtr ptr, int status)
         {
             var req = FromIntPtr<UvWriteReq>(ptr);
             Unpin(req);
@@ -167,7 +166,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                _log.LogError("UvWriteCb", ex);
+                req._log.LogError("UvWriteCb", ex);
             }
         }
     }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
@@ -13,7 +14,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     /// </summary>
     public class UvWriteReq : UvRequest
     {
-        private readonly static Libuv.uv_write_cb _uv_write_cb = UvWriteCb;
+        private readonly Libuv.uv_write_cb _uv_write_cb;
 
         private IntPtr _bufs;
 
@@ -22,6 +23,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
         private const int BUFFER_COUNT = 4;
 
         private List<GCHandle> _pins = new List<GCHandle>();
+
+        public UvWriteReq(IKestrelTrace logger) : base(logger)
+        {
+            _uv_write_cb = UvWriteCb;
+        }
 
         public void Init(UvLoopHandle loop)
         {
@@ -138,7 +144,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             req._pins.Clear();
         }
 
-        private static void UvWriteCb(IntPtr ptr, int status)
+        private void UvWriteCb(IntPtr ptr, int status)
         {
             var req = FromIntPtr<UvWriteReq>(ptr);
             Unpin(req);
@@ -161,7 +167,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("UvWriteCb " + ex.ToString());
+                _log.LogError("UvWriteCb", ex);
             }
         }
     }

--- a/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/ServerFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNet.Hosting.Server;
 using Microsoft.AspNet.Http.Features;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Framework.Configuration;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel
 {
@@ -18,11 +19,13 @@ namespace Microsoft.AspNet.Server.Kestrel
     {
         private readonly ILibraryManager _libraryManager;
         private readonly IApplicationShutdown _appShutdownService;
+        private readonly ILogger _logger;
 
-        public ServerFactory(ILibraryManager libraryManager, IApplicationShutdown appShutdownService)
+        public ServerFactory(ILibraryManager libraryManager, IApplicationShutdown appShutdownService, ILoggerFactory loggerFactory)
         {
             _libraryManager = libraryManager;
             _appShutdownService = appShutdownService;
+            _logger = loggerFactory.CreateLogger("Microsoft.AspNet.Server.Kestrel");
         }
 
         public IFeatureCollection Initialize(IConfiguration configuration)
@@ -48,7 +51,7 @@ namespace Microsoft.AspNet.Server.Kestrel
             try
             {
                 var information = (KestrelServerInformation)serverFeatures.Get<IKestrelServerInformation>();
-                var engine = new KestrelEngine(_libraryManager, _appShutdownService);
+                var engine = new KestrelEngine(_libraryManager, _appShutdownService, _logger);
 
                 disposables.Push(engine);
 

--- a/src/Microsoft.AspNet.Server.Kestrel/ServiceContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/ServiceContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Server.Kestrel.Http;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.Dnx.Runtime;
 
 namespace Microsoft.AspNet.Server.Kestrel
@@ -11,5 +12,7 @@ namespace Microsoft.AspNet.Server.Kestrel
         public IApplicationShutdown AppShutdown { get; set; }
 
         public IMemoryPool Memory { get; set; }
+
+        public IKestrelTrace Log { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -8,11 +8,11 @@
     "dependencies": {
         "Microsoft.AspNet.Hosting": "1.0.0-*",
         "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*",
+        "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
         "Microsoft.StandardsPolice": {
             "version": "1.0.0-*",
             "type": "build"
-        },
-        "Microsoft.Framework.Logging.Abstractions": "1.0.0-*"
+        }
     },
     "frameworks": {
         "dnx451": { },

--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -11,7 +11,8 @@
         "Microsoft.StandardsPolice": {
             "version": "1.0.0-*",
             "type": "build"
-        }
+        },
+        "Microsoft.Framework.Logging.Abstractions": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": { },

--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void EngineCanStartAndStop()
         {
-            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented());
+            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented(), new TestLogger());
             engine.Start(1);
             engine.Dispose();
         }
@@ -94,7 +94,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void ListenerCanCreateAndDispose()
         {
-            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented());
+            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented(), new TestLogger());
             engine.Start(1);
             var started = engine.CreateServer("http", "localhost", 54321, App);
             started.Dispose();
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void ConnectionCanReadAndWrite()
         {
-            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented());
+            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented(), new TestLogger());
             engine.Start(1);
             var started = engine.CreateServer("http", "localhost", 54321, App);
 

--- a/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         Libuv _uv;
         public MultipleLoopTests()
         {
-            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented());
+            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented(), new TestLogger());
             _uv = engine.Libuv;
         }
 

--- a/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.AspNet.Server.Kestrel;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Runtime.Infrastructure;
@@ -13,7 +14,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
 {
     public class MultipleLoopTests
     {
-        Libuv _uv;
+        private readonly Libuv _uv;
+        private readonly IKestrelTrace _logger = new KestrelTrace(new TestLogger());
         public MultipleLoopTests()
         {
             var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented(), new TestLogger());
@@ -41,8 +43,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void InitAndCloseServerPipe()
         {
-            var loop = new UvLoopHandle();
-            var pipe = new UvPipeHandle();
+            var loop = new UvLoopHandle(_logger);
+            var pipe = new UvPipeHandle(_logger);
 
             loop.Init(_uv);
             pipe.Init(loop, true);
@@ -59,15 +61,15 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void ServerPipeListenForConnections()
         {
-            var loop = new UvLoopHandle();
-            var serverListenPipe = new UvPipeHandle();
+            var loop = new UvLoopHandle(_logger);
+            var serverListenPipe = new UvPipeHandle(_logger);
 
             loop.Init(_uv);
             serverListenPipe.Init(loop, false);
             serverListenPipe.Bind(@"\\.\pipe\ServerPipeListenForConnections");
             serverListenPipe.Listen(128, (_1, status, error, _2) =>
             {
-                var serverConnectionPipe = new UvPipeHandle();
+                var serverConnectionPipe = new UvPipeHandle(_logger);
                 serverConnectionPipe.Init(loop, true);
                 try
                 {
@@ -79,7 +81,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                     return;
                 }
 
-                var writeRequest = new UvWriteReq();
+                var writeRequest = new UvWriteReq(new KestrelTrace(new TestLogger()));
                 writeRequest.Init(loop);
                 writeRequest.Write(
                     serverConnectionPipe,
@@ -96,9 +98,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
 
             var worker = new Thread(() =>
             {
-                var loop2 = new UvLoopHandle();
-                var clientConnectionPipe = new UvPipeHandle();
-                var connect = new UvConnectRequest();
+                var loop2 = new UvLoopHandle(_logger);
+                var clientConnectionPipe = new UvPipeHandle(_logger);
+                var connect = new UvConnectRequest(new KestrelTrace(new TestLogger()));
 
                 loop2.Init(_uv);
                 clientConnectionPipe.Init(loop2, true);
@@ -134,19 +136,19 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             var pipeName = @"\\.\pipe\ServerPipeDispatchConnections" + Guid.NewGuid().ToString("n");
 
-            var loop = new UvLoopHandle();
+            var loop = new UvLoopHandle(_logger);
             loop.Init(_uv);
 
             var serverConnectionPipe = default(UvPipeHandle);
             var serverConnectionPipeAcceptedEvent = new ManualResetEvent(false);
             var serverConnectionTcpDisposedEvent = new ManualResetEvent(false);
 
-            var serverListenPipe = new UvPipeHandle();
+            var serverListenPipe = new UvPipeHandle(_logger);
             serverListenPipe.Init(loop, false);
             serverListenPipe.Bind(pipeName);
             serverListenPipe.Listen(128, (_1, status, error, _2) =>
             {
-                serverConnectionPipe = new UvPipeHandle();
+                serverConnectionPipe = new UvPipeHandle(_logger);
                 serverConnectionPipe.Init(loop, true);
                 try
                 {
@@ -161,18 +163,18 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 }
             }, null);
 
-            var serverListenTcp = new UvTcpHandle();
+            var serverListenTcp = new UvTcpHandle(_logger);
             serverListenTcp.Init(loop);
             serverListenTcp.Bind(new IPEndPoint(0, 54321));
             serverListenTcp.Listen(128, (_1, status, error, _2) =>
             {
-                var serverConnectionTcp = new UvTcpHandle();
+                var serverConnectionTcp = new UvTcpHandle(_logger);
                 serverConnectionTcp.Init(loop);
                 serverListenTcp.Accept(serverConnectionTcp);
 
                 serverConnectionPipeAcceptedEvent.WaitOne();
 
-                var writeRequest = new UvWriteReq();
+                var writeRequest = new UvWriteReq(new KestrelTrace(new TestLogger()));
                 writeRequest.Init(loop);
                 writeRequest.Write2(
                     serverConnectionPipe,
@@ -192,9 +194,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
 
             var worker = new Thread(() =>
             {
-                var loop2 = new UvLoopHandle();
-                var clientConnectionPipe = new UvPipeHandle();
-                var connect = new UvConnectRequest();
+                var loop2 = new UvLoopHandle(_logger);
+                var clientConnectionPipe = new UvPipeHandle(_logger);
+                var connect = new UvConnectRequest(new KestrelTrace(new TestLogger()));
 
                 loop2.Init(_uv);
                 clientConnectionPipe.Init(loop2, true);
@@ -216,7 +218,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                                 clientConnectionPipe.Dispose();
                                 return;
                             }
-                            var clientConnectionTcp = new UvTcpHandle();
+                            var clientConnectionTcp = new UvTcpHandle(_logger);
                             clientConnectionTcp.Init(loop2);
                             clientConnectionPipe.Accept(clientConnectionTcp);
                             var buf2 = loop2.Libuv.buf_init(Marshal.AllocHGlobal(64), 64);

--- a/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         Libuv _uv;
         public NetworkingTests()
         {
-            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented());
+            var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented(), new TestLogger());
             _uv = engine.Libuv;
         }
 

--- a/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Server.Kestrel;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Runtime.Infrastructure;
@@ -19,7 +20,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
     /// </summary>
     public class NetworkingTests
     {
-        Libuv _uv;
+        private readonly Libuv _uv;
+        private readonly IKestrelTrace _logger = new KestrelTrace(new TestLogger());
         public NetworkingTests()
         {
             var engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented(), new TestLogger());
@@ -47,7 +49,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void LoopCanBeInitAndClose()
         {
-            var loop = new UvLoopHandle();
+            var loop = new UvLoopHandle(_logger);
             loop.Init(_uv);
             loop.Run();
             loop.Dispose();
@@ -56,9 +58,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void AsyncCanBeSent()
         {
-            var loop = new UvLoopHandle();
+            var loop = new UvLoopHandle(_logger);
             loop.Init(_uv);
-            var trigger = new UvAsyncHandle();
+            var trigger = new UvAsyncHandle(_logger);
             var called = false;
             trigger.Init(loop, () =>
             {
@@ -74,9 +76,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void SocketCanBeInitAndClose()
         {
-            var loop = new UvLoopHandle();
+            var loop = new UvLoopHandle(_logger);
             loop.Init(_uv);
-            var tcp = new UvTcpHandle();
+            var tcp = new UvTcpHandle(_logger);
             tcp.Init(loop);
             tcp.Bind(new IPEndPoint(IPAddress.Loopback, 0));
             tcp.Dispose();
@@ -88,14 +90,14 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public async Task SocketCanListenAndAccept()
         {
-            var loop = new UvLoopHandle();
+            var loop = new UvLoopHandle(_logger);
             loop.Init(_uv);
-            var tcp = new UvTcpHandle();
+            var tcp = new UvTcpHandle(_logger);
             tcp.Init(loop);
             tcp.Bind(new IPEndPoint(IPAddress.Loopback, 54321));
             tcp.Listen(10, (stream, status, error, state) =>
             {
-                var tcp2 = new UvTcpHandle();
+                var tcp2 = new UvTcpHandle(_logger);
                 tcp2.Init(loop);
                 stream.Accept(tcp2);
                 tcp2.Dispose();
@@ -125,15 +127,15 @@ namespace Microsoft.AspNet.Server.KestrelTests
         public async Task SocketCanRead()
         {
             int bytesRead = 0;
-            var loop = new UvLoopHandle();
+            var loop = new UvLoopHandle(_logger);
             loop.Init(_uv);
-            var tcp = new UvTcpHandle();
+            var tcp = new UvTcpHandle(_logger);
             tcp.Init(loop);
             tcp.Bind(new IPEndPoint(IPAddress.Loopback, 54321));
             tcp.Listen(10, (_, status, error, state) =>
             {
                 Console.WriteLine("Connected");
-                var tcp2 = new UvTcpHandle();
+                var tcp2 = new UvTcpHandle(_logger);
                 tcp2.Init(loop);
                 tcp.Accept(tcp2);
                 var data = Marshal.AllocCoTaskMem(500);
@@ -181,15 +183,15 @@ namespace Microsoft.AspNet.Server.KestrelTests
         public async Task SocketCanReadAndWrite()
         {
             int bytesRead = 0;
-            var loop = new UvLoopHandle();
+            var loop = new UvLoopHandle(_logger);
             loop.Init(_uv);
-            var tcp = new UvTcpHandle();
+            var tcp = new UvTcpHandle(_logger);
             tcp.Init(loop);
             tcp.Bind(new IPEndPoint(IPAddress.Loopback, 54321));
             tcp.Listen(10, (_, status, error, state) =>
             {
                 Console.WriteLine("Connected");
-                var tcp2 = new UvTcpHandle();
+                var tcp2 = new UvTcpHandle(_logger);
                 tcp2.Init(loop);
                 tcp.Accept(tcp2);
                 var data = Marshal.AllocCoTaskMem(500);
@@ -206,7 +208,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                         {
                             for (var x = 0; x != 2; ++x)
                             {
-                                var req = new UvWriteReq();
+                                var req = new UvWriteReq(new KestrelTrace(new TestLogger()));
                                 req.Init(loop);
                                 req.Write(
                                     tcp2,

--- a/test/Microsoft.AspNet.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/SocketOutputTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.AspNet.Server.Kestrel;
 using Microsoft.AspNet.Server.Kestrel.Http;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
 using Microsoft.AspNet.Server.KestrelTests.TestHelpers;
 using Xunit;
@@ -36,7 +37,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 kestrelEngine.Start(count: 1);
 
                 var kestrelThread = kestrelEngine.Threads[0];
-                var socket = new MockSocket(kestrelThread.Loop.ThreadId);
+                var socket = new MockSocket(kestrelThread.Loop.ThreadId, new KestrelTrace(new TestLogger()));
                 var trace = new KestrelTrace(new TestLogger());
                 var socketOutput = new SocketOutput(kestrelThread, socket, trace);
 
@@ -81,7 +82,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 kestrelEngine.Start(count: 1);
 
                 var kestrelThread = kestrelEngine.Threads[0];
-                var socket = new MockSocket(kestrelThread.Loop.ThreadId);
+                var socket = new MockSocket(kestrelThread.Loop.ThreadId, new KestrelTrace(new TestLogger()));
                 var trace = new KestrelTrace(new TestLogger());
                 var socketOutput = new SocketOutput(kestrelThread, socket, trace);
 
@@ -117,7 +118,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
 
         private class MockSocket : UvStreamHandle
         {
-            public MockSocket(int threadId)
+            public MockSocket(int threadId, IKestrelTrace logger) : base(logger)
             {
                 // Set the handle to something other than IntPtr.Zero
                 // so handle.Validate doesn't fail in Libuv.write

--- a/test/Microsoft.AspNet.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/SocketOutputTests.cs
@@ -31,13 +31,14 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 }
             };
 
-            using (var kestrelEngine = new KestrelEngine(mockLibuv, new ShutdownNotImplemented()))
+            using (var kestrelEngine = new KestrelEngine(mockLibuv, new ShutdownNotImplemented(), new TestLogger()))
             {
                 kestrelEngine.Start(count: 1);
 
                 var kestrelThread = kestrelEngine.Threads[0];
                 var socket = new MockSocket(kestrelThread.Loop.ThreadId);
-                var socketOutput = new SocketOutput(kestrelThread, socket);
+                var trace = new KestrelTrace(new TestLogger());
+                var socketOutput = new SocketOutput(kestrelThread, socket, trace);
 
                 // I doubt _maxBytesPreCompleted will ever be over a MB. If it is, we should change this test.
                 var bufferSize = 1048576;
@@ -75,13 +76,14 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 }
             };
 
-            using (var kestrelEngine = new KestrelEngine(mockLibuv, new ShutdownNotImplemented()))
+            using (var kestrelEngine = new KestrelEngine(mockLibuv, new ShutdownNotImplemented(), new TestLogger()))
             {
                 kestrelEngine.Start(count: 1);
 
                 var kestrelThread = kestrelEngine.Threads[0];
                 var socket = new MockSocket(kestrelThread.Loop.ThreadId);
-                var socketOutput = new SocketOutput(kestrelThread, socket);
+                var trace = new KestrelTrace(new TestLogger());
+                var socketOutput = new SocketOutput(kestrelThread, socket, trace);
 
                 var bufferSize = maxBytesPreCompleted;
                 var buffer = new ArraySegment<byte>(new byte[bufferSize], 0, bufferSize);

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestLogger.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestLogger.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.AspNet.Server.Kestrel;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.AspNet.Server.KestrelTests
+{
+    public class TestLogger : ILogger
+    {
+        public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScopeImpl(object state)
+        {
+            return new Disposable(() => { });
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestLogger.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestLogger.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            return true;
+            return false;
         }
 
         public IDisposable BeginScopeImpl(object state)

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestServer.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestServer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
 
         public void Create(Func<Frame, Task> app)
         {
-            _engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented());
+            _engine = new KestrelEngine(LibraryManager, new ShutdownNotImplemented(), new TestLogger());
             _engine.Start(1);
             _server = _engine.CreateServer(
                 "http",


### PR DESCRIPTION
- Remove singleton implementation from KestrelTrace
- Inject KestrelTrace instance through ServiceContext
- Update Sample application to show LoggerFactory possibilities
- Inject IKestrelTrace in to SocketOutput