### PR TITLE
Don't swallow too many exceptions

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -93,6 +93,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             catch (Exception ex)
             {
                 Log.LogError("Connection._frame.Consume ", ex);
+                throw;
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Listener.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             // If the event loop isn't running and we try to wait on this Post
             // to complete, then KestrelEngine will never be disposed and
             // the exception that stopped the event loop will never be surfaced.
-            if (Thread.FatalError == null)
+            if (Thread.FatalError == null && ListenSocket != null)
             {
                 var tcs = new TaskCompletionSource<int>();
                 Thread.Post(

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerPrimary.cs
@@ -1,11 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Server.Kestrel.Infrastructure;
-using Microsoft.AspNet.Server.Kestrel.Networking;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+using Microsoft.AspNet.Server.Kestrel.Networking;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -56,15 +57,18 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
             var dispatchPipe = new UvPipeHandle(Log);
             dispatchPipe.Init(Thread.Loop, true);
+
             try
             {
                 pipe.Accept(dispatchPipe);
             }
-            catch (Exception)
+            catch (UvException ex)
             {
                 dispatchPipe.Dispose();
+                Log.LogError("ListenerPrimary.OnListenPipe", ex);
                 return;
             }
+
             _dispatchPipes.Add(dispatchPipe);
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                                         {
                                             DispatchPipe.Accept(acceptSocket);
                                         }
-                                        catch (Exception ex)
+                                        catch (UvException ex)
                                         {
                                             Log.LogError("DispatchPipe.Accept", ex);
                                             acceptSocket.Dispose();

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListener.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -36,7 +38,16 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             var acceptSocket = new UvPipeHandle(Log);
             acceptSocket.Init(Thread.Loop, false);
-            listenSocket.Accept(acceptSocket);
+
+            try
+            {
+                listenSocket.Accept(acceptSocket);
+            }
+            catch (UvException ex)
+            {
+                Log.LogError("PipeListener.OnConnection", ex);
+                return;
+            }
 
             DispatchConnection(acceptSocket);
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerPrimary.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -36,7 +38,16 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             var acceptSocket = new UvPipeHandle(Log);
             acceptSocket.Init(Thread.Loop, false);
-            listenSocket.Accept(acceptSocket);
+
+            try
+            {
+                listenSocket.Accept(acceptSocket);
+            }
+            catch (UvException ex)
+            {
+                Log.LogError("ListenerPrimary.OnConnection", ex);
+                return;
+            }
 
             DispatchConnection(acceptSocket);
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListener.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net;
 using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -37,7 +39,16 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             var acceptSocket = new UvTcpHandle(Log);
             acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
-            listenSocket.Accept(acceptSocket);
+
+            try
+            {
+                listenSocket.Accept(acceptSocket);
+            }
+            catch (UvException ex)
+            {
+                Log.LogError("TcpListener.OnConnection", ex);
+                return;
+            }
 
             DispatchConnection(acceptSocket);
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerPrimary.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net;
 using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Server.Kestrel.Networking;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -37,7 +39,16 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             var acceptSocket = new UvTcpHandle(Log);
             acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
-            listenSocket.Accept(acceptSocket);
+
+            try
+            {
+                listenSocket.Accept(acceptSocket);
+            }
+            catch (UvException ex)
+            {
+                Log.LogError("TcpListenerPrimary.OnConnection", ex);
+                return;
+            }
 
             DispatchConnection(acceptSocket);
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -276,6 +276,7 @@ namespace Microsoft.AspNet.Server.Kestrel
                     else
                     {
                         _log.LogError("KestrelThread.DoPostWork", ex);
+                        throw;
                     }
                 }
             }
@@ -299,6 +300,7 @@ namespace Microsoft.AspNet.Server.Kestrel
                 catch (Exception ex)
                 {
                     _log.LogError("KestrelThread.DoPostCloseHandle", ex);
+                    throw;
                 }
             }
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             {
                 var errorName = err_name(statusCode);
                 var errorDescription = strerror(statusCode);
-                error = new Exception("Error " + statusCode + " " + errorName + " " + errorDescription);
+                error = new UvException("Error " + statusCode + " " + errorName + " " + errorDescription);
             }
             else
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvConnectRequest.cs
@@ -67,6 +67,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             catch (Exception ex)
             {
                 req._log.LogError("UvConnectRequest", ex);
+                throw;
             }
         }
     }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvException.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Server.Kestrel.Networking
+{
+    public class UvException : Exception
+    {
+        public UvException(string message) : base(message) { }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvStreamHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvStreamHandle.cs
@@ -133,6 +133,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             catch (Exception ex)
             {
                 stream._log.LogError("UvConnectionCb", ex);
+                throw;
             }
         }
 
@@ -172,6 +173,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             catch (Exception ex)
             {
                 stream._log.LogError("UbReadCb", ex);
+                throw;
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
@@ -167,6 +167,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             catch (Exception ex)
             {
                 req._log.LogError("UvWriteCb", ex);
+                throw;
             }
         }
     }


### PR DESCRIPTION
- Swallowing too many exceptions can end up hiding issues in Kestrel itself. It's better to let the process die.
- If we want to handle certain exceptions we should be as specific as possible with our try/catch blocks.
- Catch and log uv_accept errors