### PR TITLE
uv_pipe_connect returns void

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
@@ -243,13 +243,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void uv_connect_cb(IntPtr req, int status);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        unsafe protected delegate int uv_pipe_connect(UvConnectRequest req, UvPipeHandle handle, string name, uv_connect_cb cb);
+        unsafe protected delegate void uv_pipe_connect(UvConnectRequest req, UvPipeHandle handle, string name, uv_connect_cb cb);
         protected uv_pipe_connect _uv_pipe_connect = default(uv_pipe_connect);
         unsafe public void pipe_connect(UvConnectRequest req, UvPipeHandle handle, string name, uv_connect_cb cb)
         {
             req.Validate();
             handle.Validate();
-            Check(_uv_pipe_connect(req, handle, name, cb));
+            _uv_pipe_connect(req, handle, name, cb);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
This fix prevents Libuv.pipe_connect from throwing when the stack
memory that was previously incorrectly interpreted as the int return
value happens to be negative.

When pipe_connect threw, an assertion failure would follow since the
pipe handle would be closed prematurely.

http://docs.libuv.org/en/v1.x/pipe.html#c.uv_pipe_connect

#205