### PR TITLE
Sanitize loops

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         /// Array of "minus one" bytes of the length of SIMD operations on the current hardware. Used as an argument in the
         /// vector dot product that counts matching character occurence.
         /// </summary>
-        private static Vector<byte> _dotCount = new Vector<byte>(Byte.MaxValue);
+        private static Vector<byte> _dotCount = new Vector<byte>(Byte.MaxValue); 
 
         /// <summary>
         /// Array of negative numbers starting at 0 and continuing for the length of SIMD operations on the current hardware.
@@ -51,12 +51,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                 }
                 else
                 {
-                    for (var block = _block.Next; block != null; block = block.Next)
+                    var block = _block.Next;
+                    while (block != null)
                     {
                         if (block.Start < block.End)
                         {
                             return true;
                         }
+                        block = block.Next;
                     }
                     return true;
                 }
@@ -188,7 +190,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                             following = vectorStride;
                         }
                     }
-                    for (; following != 0; following--, index++)
+                    while (following > 0)
                     {
                         if (block.Array[index] == byte0)
                         {
@@ -196,6 +198,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                             _index = index;
                             return char0;
                         }
+                        following--;
+                        index++;
                     }
                 }
             }
@@ -269,7 +273,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                             following = vectorStride;
                         }
                     }
-                    for (; following != 0; following--, index++)
+                    while (following > 0)
                     {
                         var byteIndex = block.Array[index];
                         if (byteIndex == byte0)
@@ -284,6 +288,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                             _index = index;
                             return char1;
                         }
+                        following--;
+                        index++;
                     }
                 }
             }

--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelEngine.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.Server.Kestrel
 
         public void Start(int count)
         {
-            for (var index = 0; index != count; ++index)
+            for (var index = 0; index < count; index++)
             {
                 Threads.Add(new KestrelThread(this));
             }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
                     pBuffers = (Libuv.uv_buf_t*)gcHandle.AddrOfPinnedObject();
                 }
 
-                for (var index = 0; index != nBuffers; ++index)
+                for (var index = 0; index < nBuffers; index++)
                 {
                     // create and pin each segment being written
                     var buf = bufs.Array[bufs.Offset + index];
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
                     pBuffers = (Libuv.uv_buf_t*)gcHandle.AddrOfPinnedObject();
                 }
 
-                for (var index = 0; index != nBuffers; ++index)
+                for (var index = 0; index < nBuffers; index++)
                 {
                     // create and pin each segment being written
                     var buf = bufs.Array[bufs.Offset + index];

--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
             socket.Send(Encoding.ASCII.GetBytes("POST / HTTP/1.0\r\n\r\nHello World"));
             socket.Shutdown(SocketShutdown.Send);
             var buffer = new byte[8192];
-            for (;;)
+            while (true)
             {
                 var length = socket.Receive(buffer);
                 if (length == 0) { break; }

--- a/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolBlock2Tests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolBlock2Tests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 pool.Return(block);
                 block = null;
 
-                for (var fragment = 0; fragment != 256; fragment += 4)
+                for (var fragment = 0; fragment < 256; fragment += 4)
                 {
                     var next = block;
                     block = pool.Lease(4);

--- a/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
             var encoding = Encoding.ASCII;
             var bytes = encoding.GetBytes(expected);
             Assert.Equal(bytes.Length, actual.Count);
-            for (var index = 0; index != bytes.Length; ++index)
+            for (var index = 0; index < bytes.Length; index++)
             {
                 Assert.Equal(bytes[index], actual.Array[actual.Offset + index]);
             }

--- a/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
@@ -207,7 +207,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                         }
                         else
                         {
-                            for (var x = 0; x != 2; ++x)
+                            for (var x = 0; x < 2; x++)
                             {
                                 var req = new UvWriteReq(new KestrelTrace(new TestKestrelTrace()));
                                 req.Init(loop);
@@ -246,7 +246,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                     TaskCreationOptions.None);
                 socket.Shutdown(SocketShutdown.Send);
                 var buffer = new ArraySegment<byte>(new byte[2048]);
-                for (; ;)
+                while (true)
                 {
                     var count = await Task.Factory.FromAsync(
                         socket.BeginReceive,

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestConnection.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestConnection.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             var text = String.Join("\r\n", lines);
             var writer = new StreamWriter(_stream, Encoding.ASCII);
-            for (var index = 0; index != text.Length; ++index)
+            for (var index = 0; index < text.Length; index++)
             {
                 var ch = text[index];
                 await writer.WriteAsync(ch);

--- a/tools/Microsoft.AspNet.Server.Kestrel.GeneratedCode/KnownHeaders.cs
+++ b/tools/Microsoft.AspNet.Server.Kestrel.GeneratedCode/KnownHeaders.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Server.Kestrel.GeneratedCode
             {
                 ulong mask = 0;
                 ulong comp = 0;
-                for (var scan = 0; scan != count; ++scan)
+                for (var scan = 0; scan < count; scan++)
                 {
                     var ch = (byte)name[offset + count - scan - 1];
                     var isAlpha = (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');


### PR DESCRIPTION
Use jit recognised ```for (var i; i < a.length; i++)``` for bounds check elimination.
Make some loop constructs more clear with intent e.g. ```while(true)``` vs ```for( ; ; )```