### PR TITLE
Add functional tests, bind to IPv6Any

### DIFF
--- a/KestrelHttpServer.sln
+++ b/KestrelHttpServer.sln
@@ -35,6 +35,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Server.Kes
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Server.Kestrel.Https", "src\Microsoft.AspNet.Server.Kestrel.Https\Microsoft.AspNet.Server.Kestrel.Https.xproj", "{5F64B3C3-0C2E-431A-B820-A81BBFC863DA}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Server.Kestrel.FunctionalTests", "test\Microsoft.AspNet.Server.Kestrel.FunctionalTests\Microsoft.AspNet.Server.Kestrel.FunctionalTests.xproj", "{9559A5F1-080C-4909-B6CF-7E4B3DC55748}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{5F64B3C3-0C2E-431A-B820-A81BBFC863DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5F64B3C3-0C2E-431A-B820-A81BBFC863DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5F64B3C3-0C2E-431A-B820-A81BBFC863DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9559A5F1-080C-4909-B6CF-7E4B3DC55748}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9559A5F1-080C-4909-B6CF-7E4B3DC55748}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9559A5F1-080C-4909-B6CF-7E4B3DC55748}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9559A5F1-080C-4909-B6CF-7E4B3DC55748}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,5 +92,6 @@ Global
 		{82295647-7C1C-4671-BAB6-0FEF58F949EC} = {327F7880-D9AF-46BD-B45C-3B7E34A01DFD}
 		{8CBA6FE3-3CC9-4420-8AA3-123E983734C2} = {327F7880-D9AF-46BD-B45C-3B7E34A01DFD}
 		{5F64B3C3-0C2E-431A-B820-A81BBFC863DA} = {2D5D5227-4DBD-499A-96B1-76A36B03B750}
+		{9559A5F1-080C-4909-B6CF-7E4B3DC55748} = {D3273454-EA07-41D2-BF0B-FCC3675C2483}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvTcpHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvTcpHandle.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
                 }
                 else
                 {
-                    ip = IPAddress.Any;
+                    ip = IPAddress.IPv6Any;
                 }
             }
 

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Hosting;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Extensions;
+using Microsoft.Dnx.Runtime.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
+{
+    public class AddressRegistrationTests
+    {
+        [Theory, MemberData(nameof(AddressRegistrationData))]
+        public async Task RegisterAddresses_Success(string addressInput, string[] testUrls)
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "server.urls", addressInput }
+                })
+                .Build();
+
+            var hostBuilder = new WebHostBuilder(CallContextServiceLocator.Locator.ServiceProvider, config);
+            hostBuilder.UseServer("Microsoft.AspNet.Server.Kestrel");
+            hostBuilder.UseStartup(ConfigureEchoAddress);            
+
+            using (var app = hostBuilder.Build().Start())
+            {
+                using (var client = new HttpClient())
+                {
+                    foreach (var testUrl in testUrls)
+                    {
+                        var responseText = await client.GetStringAsync(testUrl);
+                        Assert.Equal(testUrl, responseText);
+                    }
+                }
+            }
+        }
+
+        public static TheoryData<string, string[]> AddressRegistrationData
+        {
+            get
+            {
+                var dataset = new TheoryData<string, string[]>();
+                dataset.Add("8787", new[] { "http://localhost:8787/" });
+                dataset.Add("8787;8788", new[] { "http://localhost:8787/", "http://localhost:8788/" });
+                dataset.Add("http://*:8787/", new[] { "http://localhost:8787/", "http://127.0.0.1:8787/", "http://[::1]:8787/" });
+                dataset.Add("http://localhost:8787/", new[] { "http://localhost:8787/", "http://127.0.0.1:8787/",
+                    /* // https://github.com/aspnet/KestrelHttpServer/issues/231
+                    "http://[::1]:8787/"
+                    */ });
+                dataset.Add("http://127.0.0.1:8787/", new[] { "http://127.0.0.1:8787/", });
+                dataset.Add("http://[::1]:8787/", new[] { "http://[::1]:8787/", });
+                dataset.Add("http://127.0.0.1:8787/;http://[::1]:8787/", new[] { "http://127.0.0.1:8787/", "http://[::1]:8787/" });
+                dataset.Add("http://localhost:8787/base/path", new[] { "http://localhost:8787/base/path" });
+
+                return dataset;
+            }
+        }
+
+        private void ConfigureEchoAddress(IApplicationBuilder app)
+        {
+            app.Run(context =>
+            {
+                return context.Response.WriteAsync(context.Request.GetDisplayUrl());
+            });
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/Microsoft.AspNet.Server.Kestrel.FunctionalTests.xproj
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/Microsoft.AspNet.Server.Kestrel.FunctionalTests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9559a5f1-080c-4909-b6cf-7e4b3dc55748</ProjectGuid>
+    <RootNamespace>Microsoft.AspNet.Server.Kestrel.FunctionalTests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Hosting;
+using Microsoft.AspNet.Http;
+using Microsoft.Dnx.Runtime.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
+{
+    public class RequestTests
+    {
+        [Fact(Skip = "https://github.com/aspnet/KestrelHttpServer/issues/234")]
+        public async Task LargeUpload()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "server.urls", "http://localhost:8791/" }
+                })
+                .Build();
+
+            var hostBuilder = new WebHostBuilder(CallContextServiceLocator.Locator.ServiceProvider, config);
+            hostBuilder.UseServer("Microsoft.AspNet.Server.Kestrel");
+            hostBuilder.UseStartup(app =>
+            {
+                app.Run(async context =>
+                {
+                    // Read the full request body
+                    var total = 0;
+                    var bytes = new byte[1024];
+                    var count = await context.Request.Body.ReadAsync(bytes, 0, bytes.Length);
+                    while (count > 0)
+                    {
+                        for (int i = 0; i < count; i++)
+                        {
+                            Assert.Equal(total % 256, bytes[i]);
+                            total++;
+                        }
+                        count = await context.Request.Body.ReadAsync(bytes, 0, bytes.Length);
+                    }
+
+                    await context.Response.WriteAsync(total.ToString(CultureInfo.InvariantCulture));
+                });
+            });            
+
+            using (var app = hostBuilder.Build().Start())
+            {
+                using (var client = new HttpClient())
+                {
+                    var bytes = new byte[1024 * 1024];
+                    for (int i = 0; i < bytes.Length; i++)
+                    {
+                        bytes[i] = (byte)i;
+                    }
+                        
+                    var response = await client.PostAsync("http://localhost:8791/", new ByteArrayContent(bytes));
+                    response.EnsureSuccessStatusCode();
+                    var sizeString = await response.Content.ReadAsStringAsync();
+                    Assert.Equal(sizeString, bytes.Length.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Hosting;
+using Microsoft.Dnx.Runtime.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
+{
+    public class ResponseTests
+    {
+        [Fact]
+        public async Task LargeDownload()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "server.urls", "http://localhost:8792/" }
+                })
+                .Build();
+
+            var hostBuilder = new WebHostBuilder(CallContextServiceLocator.Locator.ServiceProvider, config);
+            hostBuilder.UseServer("Microsoft.AspNet.Server.Kestrel");
+            hostBuilder.UseStartup(app =>
+            {
+                app.Run(async context =>
+                {
+                    var bytes = new byte[1024];
+                    for (int i = 0; i < bytes.Length; i++)
+                    {
+                        bytes[i] = (byte)i;
+                    }
+
+                    context.Response.ContentLength = bytes.Length * 1024;
+
+                    for (int i = 0; i < 1024; i++)
+                    {
+                        await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
+                    }
+                });
+            });            
+
+            using (var app = hostBuilder.Build().Start())
+            {
+                using (var client = new HttpClient())
+                {
+                    var response = await client.GetAsync("http://localhost:8792/");
+                    response.EnsureSuccessStatusCode();
+                    var responseBody = await response.Content.ReadAsStreamAsync();
+
+                    // Read the full response body
+                    var total = 0;
+                    var bytes = new byte[1024];
+                    var count = await responseBody.ReadAsync(bytes, 0, bytes.Length);
+                    while (count > 0)
+                    {
+                        for (int i = 0; i < count; i++)
+                        {
+                            Assert.Equal(total % 256, bytes[i]);
+                            total++;
+                        }
+                        count = await responseBody.ReadAsync(bytes, 0, bytes.Length);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ThreadCountTests.cs
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ThreadCountTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Hosting;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Features;
+using Microsoft.Dnx.Runtime.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
+{
+    public class ThreadCountTests
+    {
+        [Theory(Skip = "https://github.com/aspnet/KestrelHttpServer/issues/232"), MemberData(nameof(OneToTen))]
+        public async Task ZeroToTenThreads(int threadCount)
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "server.urls", "http://localhost:8790/" }
+                })
+                .Build();
+
+            var hostBuilder = new WebHostBuilder(CallContextServiceLocator.Locator.ServiceProvider, config);
+            hostBuilder.UseServer("Microsoft.AspNet.Server.Kestrel");
+            hostBuilder.UseStartup(app =>
+            {
+                var serverInfo = app.ServerFeatures.Get<IKestrelServerInformation>();
+                serverInfo.ThreadCount = threadCount;
+                app.Run(context =>
+                {
+                    return context.Response.WriteAsync("Hello World");
+                });
+            });            
+
+            using (var app = hostBuilder.Build().Start())
+            {
+                using (var client = new HttpClient())
+                {
+                    // Send 20 requests just to make sure we don't get any failures
+                    var requestTasks = new List<Task<string>>();
+                    for (int i = 0; i < 20; i++)
+                    {
+                        var requestTask = client.GetStringAsync("http://localhost:8790/");
+                        requestTasks.Add(requestTask);
+                    }
+                    
+                    foreach (var result in await Task.WhenAll(requestTasks))
+                    {
+                        Assert.Equal("Hello World", result);
+                    }
+                }
+            }
+        }
+
+        public static TheoryData<int> OneToTen
+        {
+            get
+            {
+                var dataset = new TheoryData<int>();
+                for (int i = 1; i <= 10; i++)
+                {
+                    dataset.Add(i);
+                }
+                return dataset;
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/project.json
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/project.json
@@ -1,0 +1,19 @@
+﻿{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.AspNet.Http.Abstractions": "1.0.0-*",
+    "Microsoft.AspNet.Server.Kestrel": "1.0.0-*",
+    "System.Net.Http": "4.0.1-beta-*",
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  },
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": { }
+  },
+  "compilationOptions": {
+    "allowUnsafe": true
+  },
+  "commands": {
+    "test": "xunit.runner.aspnet -parallel none"
+  }
+}

--- a/test/Microsoft.AspNet.Server.KestrelTests/CreateIPEndpointTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/CreateIPEndpointTests.cs
@@ -11,12 +11,13 @@ namespace Microsoft.AspNet.Server.KestrelTests
     public class CreateIPEndpointTests
     {
         [Theory]
-        [InlineData("localhost", "127.0.0.1")]
+        [InlineData("localhost", "127.0.0.1")] // https://github.com/aspnet/KestrelHttpServer/issues/231
         [InlineData("10.10.10.10", "10.10.10.10")]
-        [InlineData("randomhost", "0.0.0.0")]
+        [InlineData("[::1]", "::1")]
+        [InlineData("randomhost", "::")] // "::" is IPAddress.IPv6Any
+        [InlineData("*", "::")] // "::" is IPAddress.IPv6Any
         public void CorrectIPEndpointsAreCreated(string host, string expectedAddress)
         {
-            // "0.0.0.0" is IPAddress.Any
             var endpoint = UvTcpHandle.CreateIPEndpoint(ServerAddress.FromUrl($"http://{host}:5000/"));
             Assert.NotNull(endpoint);
             Assert.Equal(IPAddress.Parse(expectedAddress), endpoint.Address);

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestInput.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestInput.cs
@@ -66,16 +66,18 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
         }
 
-        async Task IFrameControl.WriteAsync(ArraySegment<byte> data, CancellationToken cancellationToken)
+        Task IFrameControl.WriteAsync(ArraySegment<byte> data, CancellationToken cancellationToken)
         {
+            return Task.FromResult(0);
         }
 
         void IFrameControl.Flush()
         {
         }
 
-        async Task IFrameControl.FlushAsync(CancellationToken cancellationToken)
+        Task IFrameControl.FlushAsync(CancellationToken cancellationToken)
         {
+            return Task.FromResult(0);
         }
     }
 }


### PR DESCRIPTION
Functional tests for address bindings and a partial fix for #231 by binding to IPv6 by default. It uses dual mode sockets so binding to IPv6Any will also accept IPv4 requests.

Also includes disabled functional tests that repro #234 and #232.

@halter73 @lodejard @muratg 