### PR TITLE
Better handle blocks not taken taken from slabs

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/SocketInputStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/SocketInputStream.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
     public class SocketInputStream : Stream
     {
         private static Task _emptyTask = Task.FromResult<object>(null);
-        private static byte[] _emptyBuffer = new byte[0];
 
         private readonly SocketInput _socketInput;
 
@@ -91,8 +90,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
 
         protected override void Dispose(bool disposing)
         {
-            // Close _socketInput with a 0-length write.
-            Write(_emptyBuffer, 0, 0);
+            // Close _socketInput with a fake zero-length write that will result in a zero-length read.
+            _socketInput.IncomingComplete(0, error: null);
             base.Dispose(disposing);
         }
     }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
@@ -90,6 +90,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 // Unpin may called without an earlier Pin 
                 if (_pinned != null)
                 {
+                    _pinned.Unpin();
+
                     _pinned.End += count;
                     if (_head == null)
                     {
@@ -170,7 +172,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             {
                 var returnBlock = returnStart;
                 returnStart = returnStart.Next;
-                returnBlock.Pool.Return(returnBlock);
+                returnBlock.Pool?.Return(returnBlock);
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
@@ -130,15 +130,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
             }
         }
 
-        public static MemoryPoolBlock2 Create(int size, MemoryPool2 pool)
-        {
-            return new MemoryPoolBlock2
-            {
-                Data = new ArraySegment<byte>(new byte[size]),
-                Pool = pool
-            };
-        }
-
         public static MemoryPoolBlock2 Create(
             ArraySegment<byte> data,
             IntPtr dataPtr,


### PR DESCRIPTION
- If the block needs to be larger than 4032 bytes it won't be backed by a slab
- Previously, MemoryPoolBlock2.Unpin was never called, but this doesn't really matter unless the block isn't backed by a slab
- Remove unused create function
- Optimize SocketInputStream.Dispose()
- If we want to add a test to verify blocks are unpinned, we will need to make some changes to MemoryPool2 so it can be mocked.