### PR TITLE
Minor perf and logging support changes

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.FeatureCollection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.FeatureCollection.cs
@@ -266,15 +266,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             StatusCode = 101;
             ReasonPhrase = "Switching Protocols";
-            ResponseHeaders["Connection"] = "Upgrade";
-            if (!ResponseHeaders.ContainsKey("Upgrade"))
+            _responseHeaders.HeaderConnection = "Upgrade";
+
+            if (StringValues.IsNullOrEmpty(_responseHeaders.HeaderUpgrade) &&
+                !StringValues.IsNullOrEmpty(_requestHeaders.HeaderUpgrade))
             {
-                StringValues values;
-                if (RequestHeaders.TryGetValue("Upgrade", out values))
-                {
-                    ResponseHeaders["Upgrade"] = values;
-                }
+                _responseHeaders.HeaderUpgrade = _requestHeaders.HeaderUpgrade;
             }
+
             ProduceStart();
             return Task.FromResult(DuplexStream);
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -402,12 +402,16 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             if (_responseStarted) return;
 
-            StringValues expect;
-            if (HttpVersion.Equals("HTTP/1.1") &&
-                RequestHeaders.TryGetValue("Expect", out expect) &&
-                (expect.FirstOrDefault() ?? "").Equals("100-continue", StringComparison.OrdinalIgnoreCase))
+            if (HttpVersion.Equals("HTTP/1.1"))
             {
-                SocketOutput.Write(_continueBytes);
+                foreach(var expect in _requestHeaders.HeaderExpect)
+                {
+                    if (expect.Equals("100-continue", StringComparison.OrdinalIgnoreCase))
+                    {
+                        SocketOutput.Write(_continueBytes);
+                        return;
+                    }
+                }
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameResponseStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameResponseStream.cs
@@ -23,13 +23,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public override bool CanWrite => true;
 
-        public override long Length
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public override long Length => Position;
 
         public override long Position { get; set; }
 
@@ -60,11 +54,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public override void Write(byte[] buffer, int offset, int count)
         {
+            Position += count;
             _context.FrameControl.Write(new ArraySegment<byte>(buffer, offset, count));
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
+            Position += count;
             return _context.FrameControl.WriteAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
         }
     }

--- a/tools/Microsoft.AspNet.Server.Kestrel.GeneratedCode/FrameFeatureCollection.cs
+++ b/tools/Microsoft.AspNet.Server.Kestrel.GeneratedCode/FrameFeatureCollection.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.Http.Features;
 using Microsoft.Dnx.Compilation.CSharp;
-using Microsoft.AspNet.Http.Features.Internal;
 using Microsoft.AspNet.Http.Features.Authentication;
 
 namespace Microsoft.AspNet.Server.Kestrel.GeneratedCode


### PR DESCRIPTION
Uses header properties directly in a few places

Provides a value for Response.Stream.Length in support of that logging the response content size
