### PR TITLE
Don't allocate Exceptions unnecessarily

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                                 DispatchPipe.ReadStart(
                                     (_1, _2, _3) => buf,
-                                    (_1, status2, errCode, error2, state2) =>
+                                    (_1, status2, state2) =>
                                     {
                                         if (status2 < 0)
                                         {

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/IKestrelTrace.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/IKestrelTrace.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 
         void ConnectionStop(long connectionId);
 
-        void ConnectionRead(long connectionId, int status);
+        void ConnectionRead(long connectionId, int count);
 
         void ConnectionPause(long connectionId);
 

--- a/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                     connect.Dispose();
                     clientConnectionPipe.ReadStart(
                         (_3, cb, _4) => buf,
-                        (_3, status2, errCode, error2, _4) =>
+                        (_3, status2, _4) =>
                         {
                             if (status2 == 0)
                             {
@@ -213,7 +213,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
 
                     clientConnectionPipe.ReadStart(
                         (_3, cb, _4) => buf,
-                        (_3, status2, errCode2, error2, _4) =>
+                        (_3, status2, _4) =>
                         {
                             if (status2 == 0)
                             {
@@ -226,7 +226,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                             var buf2 = loop2.Libuv.buf_init(Marshal.AllocHGlobal(64), 64);
                             clientConnectionTcp.ReadStart(
                                 (_5, cb, _6) => buf2,
-                                (_5, status3, errCode3, error3, _6) =>
+                                (_5, status3, _6) =>
                                 {
                                     if (status3 == 0)
                                     {

--- a/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
@@ -129,7 +129,6 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public async Task SocketCanRead()
         {
-            int bytesRead = 0;
             var loop = new UvLoopHandle(_logger);
             loop.Init(_uv);
             var tcp = new UvTcpHandle(_logger);
@@ -145,10 +144,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 var data = Marshal.AllocCoTaskMem(500);
                 tcp2.ReadStart(
                     (a, b, c) => _uv.buf_init(data, 500),
-                    (__, nread, errCode, error2, state2) =>
+                    (__, nread, state2) =>
                     {
-                        bytesRead += nread;
-                        if (nread == 0)
+                        if (nread <= 0)
                         {
                             tcp2.Dispose();
                         }
@@ -186,7 +184,6 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public async Task SocketCanReadAndWrite()
         {
-            int bytesRead = 0;
             var loop = new UvLoopHandle(_logger);
             loop.Init(_uv);
             var tcp = new UvTcpHandle(_logger);
@@ -202,10 +199,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 var data = Marshal.AllocCoTaskMem(500);
                 tcp2.ReadStart(
                     (a, b, c) => tcp2.Libuv.buf_init(data, 500),
-                    (__, nread, errCode, error2, state2) =>
+                    (__, nread, state2) =>
                     {
-                        bytesRead += nread;
-                        if (nread == 0)
+                        if (nread <= 0)
                         {
                             tcp2.Dispose();
                         }


### PR DESCRIPTION
- Allocate Exceptions in the ReadStart callbacks if necessary instead
  of in UvStreamHandle.
- This also fixes a bug in ListenerSecondary where it should have
  previously been looking at the error code instead of the read count.

#237