### PR TITLE
Prototype: unescapse path

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -9,6 +9,7 @@
     "Microsoft.AspNet.Hosting": "1.0.0-*",
     "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
+    "Microsoft.Extensions.WebEncoders.Core": "1.0.0-*",
     "System.Numerics.Vectors": "4.1.1-beta-*",
     "Microsoft.StandardsPolice": {
       "version": "1.0.0-*",
@@ -16,7 +17,7 @@
     },
     "Microsoft.AspNet.Internal.libuv-Darwin": {
       "version": "1.0.0-*",
-        "type":"build"
+      "type": "build"
     },
     "Microsoft.AspNet.Internal.libuv-Windows": {
       "version": "1.0.0-*",
@@ -64,6 +65,6 @@
     "runtimes/win7-x64/native/": "runtimes/win7-x64/native/*",
     "runtimes/win7-x86/native/": "runtimes/win7-x86/native/*",
     "runtimes/win10-arm/native/": "runtimes/win10-arm/native/*",
-    "runtimes/osx/native/":  "runtimes/osx/native/*"
+    "runtimes/osx/native/": "runtimes/osx/native/*"
   }
 }


### PR DESCRIPTION
Issue #124 

To unescape the path while read the first line to the request. 

Note:
- Implementation of the decoding is in `HttpAbstraction`. It is currently being reviewed: https://github.com/aspnet/HttpAbstractions/pull/448.
- A new method is added to `MemoryPoolIterator2` to return the raw `char[]` instead of a `string` as a result the decoding is able to be operated in place to avoid additional allocation.
- The change will not increase additional memory allocation.

Follow up:
- [ ] Add test cases.
- [ ] Performance review afterwards.

/cc @halter73 @Tratcher @davidfowl @lodejard @muratg 