### PR TITLE
Don't call uname repeatedly

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/PlatformApis.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/PlatformApis.cs
@@ -8,16 +8,24 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
 {
     public static class PlatformApis
     {
+        private static bool? _isWindows;
+
         public static bool IsWindows()
         {
+            if (!_isWindows.HasValue)
+            {
+
 #if DNXCORE50
-            // Until Environment.OSVersion.Platform is exposed on .NET Core, we
-            // try to call uname and if that fails we assume we are on Windows.
-            return GetUname() == string.Empty;
+                // Until Environment.OSVersion.Platform is exposed on .NET Core, we
+                // try to call uname and if that fails we assume we are on Windows.
+                _isWindows GetUname() == string.Empty;
 #else
-            var p = (int)Environment.OSVersion.Platform;
-            return (p != 4) && (p != 6) && (p != 128);
+                var p = (int)Environment.OSVersion.Platform;
+                _isWindows = (p != 4) && (p != 6) && (p != 128);
 #endif
+            }
+
+            return _isWindows.Value;
         }
 
         [DllImport("libc")]


### PR DESCRIPTION
We seem to call uname each time we want to allocate a buffer to
check we are running on non-Windows