### PR TITLE
Don't call RequestBody.CopyToAsync(Stream.Null) unnecessarily

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -197,8 +197,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                             await ProduceEnd();
 
-                            // Finish reading the request body in case the app did not.
-                            await RequestBody.CopyToAsync(Stream.Null);
+                            if (!MessageBody.LocalIntakeFin)
+                            {
+                                // Finish reading the request body in case the app did not.
+                                await RequestBody.CopyToAsync(Stream.Null);
+                            }
                         }
 
                         terminated = !_keepAlive;


### PR DESCRIPTION
- The default CopyToAsync implementation allocates an ~82KB buffer

https://github.com/aspnet/KestrelHttpServer/issues/296