### PR TITLE
Read to null buffer

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         private readonly object _onStartingSync = new Object();
         private readonly object _onCompletedSync = new Object();
         private readonly FrameRequestHeaders _requestHeaders = new FrameRequestHeaders();
+        private readonly byte[] _nullBuffer = new byte[4096];
         private readonly FrameResponseHeaders _responseHeaders = new FrameResponseHeaders();
 
         private List<KeyValuePair<Func<object, Task>, object>> _onStarting;
@@ -198,7 +199,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                             await ProduceEnd();
 
                             // Finish reading the request body in case the app did not.
-                            await RequestBody.CopyToAsync(Stream.Null);
+                            while (await RequestBody.ReadAsync(_nullBuffer, 0, _nullBuffer.Length) != 0)
+                            {
+                                ;
+                            }
                         }
 
                         terminated = !_keepAlive;

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -198,10 +198,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                             await ProduceEnd();
 
-                            // Finish reading the request body in case the app did not.
                             while (await RequestBody.ReadAsync(_nullBuffer, 0, _nullBuffer.Length) != 0)
                             {
-                                ;
+                                // Finish reading the request body in case the app did not.
                             }
                         }
 


### PR DESCRIPTION
Read to null buffer rather than Stream.Null as the CopyToAsync will
create a `new byte[]` on each call
https://github.com/dotnet/coreclr/blob/bc146608854d1db9cdbcc0b08029a87754e12b49/src/mscorlib/src/System/IO/Stream.cs#L218
of size 81920 bytes!
https://github.com/dotnet/coreclr/blob/bc146608854d1db9cdbcc0b08029a87754e12b49/src/mscorlib/src/System/IO/Stream.cs#L48