### PR TITLE
Task.Run -> ThreadPool.QueueUserWorkItem

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
@@ -128,7 +128,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             if (awaitableState != _awaitableIsCompleted &&
                 awaitableState != _awaitableIsNotCompleted)
             {
-                Task.Run(awaitableState);
+                ThreadPool.QueueUserWorkItem((o) => ((Action)o)(), awaitableState);
             }
         }
 
@@ -194,7 +194,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             }
             else if (awaitableState == _awaitableIsCompleted)
             {
-                Task.Run(continuation);
+                ThreadPool.QueueUserWorkItem((o) => ((Action)o)(), continuation);
             }
             else
             {


### PR DESCRIPTION
Task.Run eventually ends up being QueueUserWorkItem.
The returned task is ignored, so no added goodness.
Short running item.

Cut out the middleman