### PR TITLE
Remove KestrelThread locks

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,11 +24,8 @@ namespace Microsoft.AspNet.Server.Kestrel
         private Thread _thread;
         private UvLoopHandle _loop;
         private UvAsyncHandle _post;
-        private Queue<Work> _workAdding = new Queue<Work>();
-        private Queue<Work> _workRunning = new Queue<Work>();
-        private Queue<CloseHandle> _closeHandleAdding = new Queue<CloseHandle>();
-        private Queue<CloseHandle> _closeHandleRunning = new Queue<CloseHandle>();
-        private object _workSync = new Object();
+        private ConcurrentQueue<Work> _workCurrent = new ConcurrentQueue<Work>();
+        private ConcurrentQueue<CloseHandle> _closeHandlesCurrent = new ConcurrentQueue<CloseHandle>();
         private bool _stopImmediate = false;
         private bool _initCompleted = false;
         private ExceptionDispatchInfo _closeError;
@@ -113,40 +110,36 @@ namespace Microsoft.AspNet.Server.Kestrel
 
         public void Post(Action<object> callback, object state)
         {
-            lock (_workSync)
-            {
-                _workAdding.Enqueue(new Work { CallbackAdapter = _objectCallbackAdapter, Callback = callback, State = state });
-            }
+            _workCurrent.Enqueue(new Work { CallbackAdapter = _objectCallbackAdapter, Callback = callback, State = state });
+
             _post.Send();
         }
 
         public void Post<T>(Action<T> callback, T state)
         {
-            lock (_workSync)
+
+            _workCurrent.Enqueue(new Work
             {
-                _workAdding.Enqueue(new Work
-                {
-                    CallbackAdapter = (callback2, state2) => ((Action<T>)callback2).Invoke((T)state2),
-                    Callback = callback,
-                    State = state
-                });
-            }
+                CallbackAdapter = (callback2, state2) => ((Action<T>)callback2).Invoke((T)state2),
+                Callback = callback,
+                State = state
+            });
+
             _post.Send();
         }
 
         public Task PostAsync(Action<object> callback, object state)
         {
             var tcs = new TaskCompletionSource<int>();
-            lock (_workSync)
+
+            _workCurrent.Enqueue(new Work
             {
-                _workAdding.Enqueue(new Work
-                {
-                    CallbackAdapter = _objectCallbackAdapter,
-                    Callback = callback,
-                    State = state,
-                    Completion = tcs
-                });
-            }
+                CallbackAdapter = _objectCallbackAdapter,
+                Callback = callback,
+                State = state,
+                Completion = tcs
+            });
+
             _post.Send();
             return tcs.Task;
         }
@@ -154,16 +147,15 @@ namespace Microsoft.AspNet.Server.Kestrel
         public Task PostAsync<T>(Action<T> callback, T state)
         {
             var tcs = new TaskCompletionSource<int>();
-            lock (_workSync)
+
+            _workCurrent.Enqueue(new Work
             {
-                _workAdding.Enqueue(new Work
-                {
-                    CallbackAdapter = (state1, state2) => ((Action<T>)state1).Invoke((T)state2),
-                    Callback = callback,
-                    State = state,
-                    Completion = tcs
-                });
-            }
+                CallbackAdapter = (state1, state2) => ((Action<T>)state1).Invoke((T)state2),
+                Callback = callback,
+                State = state,
+                Completion = tcs
+            });
+
             _post.Send();
             return tcs.Task;
         }
@@ -182,10 +174,8 @@ namespace Microsoft.AspNet.Server.Kestrel
 
         private void PostCloseHandle(Action<IntPtr> callback, IntPtr handle)
         {
-            lock (_workSync)
-            {
-                _closeHandleAdding.Enqueue(new CloseHandle { Callback = callback, Handle = handle });
-            }
+            _closeHandlesCurrent.Enqueue(new CloseHandle { Callback = callback, Handle = handle });
+            
             _post.Send();
         }
 
@@ -253,16 +243,9 @@ namespace Microsoft.AspNet.Server.Kestrel
 
         private void DoPostWork()
         {
-            Queue<Work> queue;
-            lock (_workSync)
+            Work work;
+            while (_workCurrent.TryDequeue(out work))
             {
-                queue = _workAdding;
-                _workAdding = _workRunning;
-                _workRunning = queue;
-            }
-            while (queue.Count != 0)
-            {
-                var work = queue.Dequeue();
                 try
                 {
                     work.CallbackAdapter(work.Callback, work.State);
@@ -280,7 +263,7 @@ namespace Microsoft.AspNet.Server.Kestrel
                 {
                     if (work.Completion != null)
                     {
-                        ThreadPool.QueueUserWorkItem(_ => work.Completion.SetException(ex), null);
+                        ThreadPool.QueueUserWorkItem(tcs => ((TaskCompletionSource<int>)tcs).SetException(ex), work.Completion);
                     }
                     else
                     {
@@ -292,16 +275,9 @@ namespace Microsoft.AspNet.Server.Kestrel
         }
         private void DoPostCloseHandle()
         {
-            Queue<CloseHandle> queue;
-            lock (_workSync)
+            CloseHandle closeHandle;
+            while (_closeHandlesCurrent.TryDequeue(out closeHandle))
             {
-                queue = _closeHandleAdding;
-                _closeHandleAdding = _closeHandleRunning;
-                _closeHandleRunning = queue;
-            }
-            while (queue.Count != 0)
-            {
-                var closeHandle = queue.Dequeue();
                 try
                 {
                     closeHandle.Callback(closeHandle.Handle);


### PR DESCRIPTION
Remove KestrelThread locks, high contention locks are expensive, low contention cheap. ConcurrentQueue in producer/consumer contention as add and remove are seperated