### PR TITLE
GC.Collect before pinning starts

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelServer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime;
 using Microsoft.AspNet.Hosting;
 using Microsoft.AspNet.Hosting.Server;
 using Microsoft.AspNet.Http;
@@ -81,6 +82,18 @@ namespace Microsoft.AspNet.Server.Kestrel
                         information.ThreadCount,
                         "ThreadCount cannot be negative");
                 }
+
+                // GC triple wash
+                GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
+                GC.WaitForPendingFinalizers();
+
+                GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
+                GC.WaitForPendingFinalizers();
+
+                GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
 
                 engine.Start(information.ThreadCount == 0 ? 1 : information.ThreadCount);
                 var atLeastOneListener = false;


### PR DESCRIPTION
After hitting with very heavy load Kestrel seems to idle lower

![gc-off](http://aoa.blob.core.windows.net/aspnet/gc-off.png)

to

![gc-on](http://aoa.blob.core.windows.net/aspnet/gc-on.png)

may just be coincidence/timing though...