### PR TITLE
Dispose of MemoryPool2; suppress its finalizers

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
@@ -10,13 +10,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
     {
         public ListenerContext()
         {
-            Memory2 = new MemoryPool2();
         }
 
         public ListenerContext(ServiceContext serviceContext) 
             : base(serviceContext)
         {
-            Memory2 = new MemoryPool2();
         }
 
         public ListenerContext(ListenerContext listenerContext)
@@ -25,7 +23,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             ServerAddress = listenerContext.ServerAddress;
             Thread = listenerContext.Thread;
             Application = listenerContext.Application;
-            Memory2 = listenerContext.Memory2;
             Log = listenerContext.Log;
         }
 
@@ -35,6 +32,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public RequestDelegate Application { get; set; }
 
-        public MemoryPool2 Memory2 { get; set; }
+        public MemoryPool2 Memory2 => Thread.Memory2;
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -37,6 +37,7 @@ namespace Microsoft.AspNet.Server.Kestrel
         public KestrelThread(KestrelEngine engine)
         {
             _engine = engine;
+            Memory2 = new MemoryPool2();
             _appLifetime = engine.AppLifetime;
             _log = engine.Log;
             _loop = new UvLoopHandle(_log);
@@ -46,6 +47,9 @@ namespace Microsoft.AspNet.Server.Kestrel
         }
 
         public UvLoopHandle Loop { get { return _loop; } }
+
+        public MemoryPool2 Memory2 { get; }
+
         public ExceptionDispatchInfo FatalError { get { return _closeError; } }
 
         public Action<Action<IntPtr>, IntPtr> QueueCloseHandle { get; internal set; }
@@ -61,6 +65,7 @@ namespace Microsoft.AspNet.Server.Kestrel
         {
             if (!_initCompleted)
             {
+                Memory2.Dispose();
                 return;
             }
 
@@ -93,6 +98,8 @@ namespace Microsoft.AspNet.Server.Kestrel
                     }
                 }
             }
+
+            Memory2.Dispose();
 
             if (_closeError != null)
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
@@ -173,5 +173,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         {
             return new MemoryPoolIterator2(this);
         }
+
+        internal void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/test/Microsoft.AspNet.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/FrameTests.cs
@@ -48,22 +48,25 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [InlineData("Connection:\r\n \r\nCookie \r\n", 1)]
         public void EmptyHeaderValuesCanBeParsed(string rawHeaders, int numHeaders)
         {
-            var socketInput = new SocketInput(new MemoryPool2());
-            var headerCollection = new FrameRequestHeaders();
+            using (var memory = new MemoryPool2())
+            {
+                var socketInput = new SocketInput(memory);
+                var headerCollection = new FrameRequestHeaders();
 
-            var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
-            var inputBuffer = socketInput.IncomingStart(headerArray.Length);
-            Buffer.BlockCopy(headerArray, 0, inputBuffer.Data.Array, inputBuffer.Data.Offset, headerArray.Length);
-            socketInput.IncomingComplete(headerArray.Length, null);
+                var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
+                var inputBuffer = socketInput.IncomingStart(headerArray.Length);
+                Buffer.BlockCopy(headerArray, 0, inputBuffer.Data.Array, inputBuffer.Data.Offset, headerArray.Length);
+                socketInput.IncomingComplete(headerArray.Length, null);
 
-            var success = Frame.TakeMessageHeaders(socketInput, headerCollection);
+                var success = Frame.TakeMessageHeaders(socketInput, headerCollection);
 
-            Assert.True(success);
-            Assert.Equal(numHeaders, headerCollection.Count());
+                Assert.True(success);
+                Assert.Equal(numHeaders, headerCollection.Count());
 
-            // Assert TakeMessageHeaders consumed all the input
-            var scan = socketInput.ConsumingStart();
-            Assert.True(scan.IsEnd);
+                // Assert TakeMessageHeaders consumed all the input
+                var scan = socketInput.ConsumingStart();
+                Assert.True(scan.IsEnd);
+            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
@@ -19,66 +19,72 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void Http10ConnectionClose()
         {
-            var input = new TestInput();
-            var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
-            var stream = new FrameRequestStream(body);
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
+                var stream = new FrameRequestStream(body);
 
-            input.Add("Hello", true);
+                input.Add("Hello", true);
 
-            var buffer1 = new byte[1024];
-            var count1 = stream.Read(buffer1, 0, 1024);
-            AssertASCII("Hello", new ArraySegment<byte>(buffer1, 0, 5));
+                var buffer1 = new byte[1024];
+                var count1 = stream.Read(buffer1, 0, 1024);
+                AssertASCII("Hello", new ArraySegment<byte>(buffer1, 0, 5));
 
-            var buffer2 = new byte[1024];
-            var count2 = stream.Read(buffer2, 0, 1024);
-            Assert.Equal(0, count2);
+                var buffer2 = new byte[1024];
+                var count2 = stream.Read(buffer2, 0, 1024);
+                Assert.Equal(0, count2);
+            }
         }
 
         [Fact]
         public async Task Http10ConnectionCloseAsync()
         {
-            var input = new TestInput();
-            var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
-            var stream = new FrameRequestStream(body);
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
+                var stream = new FrameRequestStream(body);
 
-            input.Add("Hello", true);
+                input.Add("Hello", true);
 
-            var buffer1 = new byte[1024];
-            var count1 = await stream.ReadAsync(buffer1, 0, 1024);
-            AssertASCII("Hello", new ArraySegment<byte>(buffer1, 0, 5));
+                var buffer1 = new byte[1024];
+                var count1 = await stream.ReadAsync(buffer1, 0, 1024);
+                AssertASCII("Hello", new ArraySegment<byte>(buffer1, 0, 5));
 
-            var buffer2 = new byte[1024];
-            var count2 = await stream.ReadAsync(buffer2, 0, 1024);
-            Assert.Equal(0, count2);
+                var buffer2 = new byte[1024];
+                var count2 = await stream.ReadAsync(buffer2, 0, 1024);
+                Assert.Equal(0, count2);
+            }
         }
 
         [Fact]
         public async Task CanHandleLargeBlocks()
         {
-            var input = new TestInput();
-            var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
-            var stream = new FrameRequestStream(body);
+            using (var input = new TestInput()) 
+            {
+                var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
+                var stream = new FrameRequestStream(body);
 
-            // Input needs to be greater than 4032 bytes to allocate a block not backed by a slab.
-            var largeInput = new string('a', 8192);
+                // Input needs to be greater than 4032 bytes to allocate a block not backed by a slab.
+                var largeInput = new string('a', 8192);
 
-            input.Add(largeInput, true);
-            // Add a smaller block to the end so that SocketInput attempts to return the large
-            // block to the memory pool.
-            input.Add("Hello", true);
+                input.Add(largeInput, true);
+                // Add a smaller block to the end so that SocketInput attempts to return the large
+                // block to the memory pool.
+                input.Add("Hello", true);
 
-            var readBuffer = new byte[8192];
+                var readBuffer = new byte[8192];
 
-            var count1 = await stream.ReadAsync(readBuffer, 0, 8192);
-            Assert.Equal(8192, count1);
-            AssertASCII(largeInput, new ArraySegment<byte>(readBuffer, 0, 8192));
+                var count1 = await stream.ReadAsync(readBuffer, 0, 8192);
+                Assert.Equal(8192, count1);
+                AssertASCII(largeInput, new ArraySegment<byte>(readBuffer, 0, 8192));
 
-            var count2 = await stream.ReadAsync(readBuffer, 0, 8192);
-            Assert.Equal(5, count2);
-            AssertASCII("Hello", new ArraySegment<byte>(readBuffer, 0, 5));
+                var count2 = await stream.ReadAsync(readBuffer, 0, 8192);
+                Assert.Equal(5, count2);
+                AssertASCII("Hello", new ArraySegment<byte>(readBuffer, 0, 5));
 
-            var count3 = await stream.ReadAsync(readBuffer, 0, 8192);
-            Assert.Equal(0, count3);
+                var count3 = await stream.ReadAsync(readBuffer, 0, 8192);
+                Assert.Equal(0, count3);
+            }
         }
 
         private void AssertASCII(string expected, ArraySegment<byte> actual)

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestInput.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestInput.cs
@@ -9,19 +9,26 @@ using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.KestrelTests
 {
-    class TestInput : IConnectionControl, IFrameControl
+    class TestInput : IConnectionControl, IFrameControl, IDisposable
     {
+        private readonly MemoryPool2 _memory2;
+
         public TestInput()
         {
             var memory = new MemoryPool();
-            var memory2 = new MemoryPool2();
+            _memory2 = new MemoryPool2();
             FrameContext = new FrameContext
             {
-                SocketInput = new SocketInput(memory2),
+                SocketInput = new SocketInput(_memory2),
                 Memory = memory,
                 ConnectionControl = this,
                 FrameControl = this
             };
+        }
+
+        public void Dispose()
+        {
+            _memory2.Dispose();
         }
 
         public FrameContext FrameContext { get; set; }


### PR DESCRIPTION
This is to unpin the MemoryPoolSlab2 buffers and SuppressFinalize on all the MemoryPoolBlock2 objects