### PR TITLE
Remove UvAsyncHandle.DangerousClose

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvAsyncHandle.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvAsyncHandle.cs
@@ -26,12 +26,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             _uv.async_init(loop, this, _uv_async_cb);
         }
 
-        public void DangerousClose()
-        {
-            Dispose();
-            ReleaseHandle();
-        }
-
         public void Send()
         {
             _uv.async_send(this);


### PR DESCRIPTION
- This should stop the AVs we've been seeing in some of our test runs