### PR TITLE
Fix get IPAddress for Darwin

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/SockAddr.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/SockAddr.cs
@@ -53,6 +53,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             // 0000 0000 0000 0000     the second unint8 field for sa family type
             // 0000 0000 0000 0000     http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/bsd/sys/socket.h
             // 0000 0000 0000 0000
+            //
+            // Reference:
+            //  - Windows: https://msdn.microsoft.com/en-us/library/windows/desktop/ms740506(v=vs.85).aspx
+            //  - Linux: https://github.com/torvalds/linux/blob/master/include/linux/socket.h
+            //  - Apple: http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/bsd/sys/socket.h
 
             // Quick calculate the port by mask the field and locate the byte 3 and byte 4
             // and then shift them to correct place to form a int.

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/SockAddr.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/SockAddr.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             //
             // Reference:
             //  - Windows: https://msdn.microsoft.com/en-us/library/windows/desktop/ms740506(v=vs.85).aspx
-            //  - Linux: https://github.com/torvalds/linux/blob/master/include/linux/socket.h
+            //  - Linux: https://github.com/torvalds/linux/blob/6a13feb9c82803e2b815eca72fa7a9f5561d7861/include/linux/socket.h
             //  - Apple: http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/bsd/sys/socket.h
 
             // Quick calculate the port by mask the field and locate the byte 3 and byte 4


### PR DESCRIPTION
The `sockaddr` on Darwin is different from the one on Windows and Linux, which uses a 8-bit integer as the first field representing length.
``` C++
struct sockaddr {
	__uint8_t	sa_len;		/* total length */
	sa_family_t	sa_family;	/* [XSI] address family */
	char		sa_data[14];	/* [XSI] addr value (actually larger) */
};
```
Source: [socket.h](http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/bsd/sys/socket.h)
