### PR TITLE
Pass cancellation tokens down consistently

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/LibuvStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/LibuvStream.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token)
         {
             var segment = new ArraySegment<byte>(buffer, offset, count);
-            return _output.WriteAsync(segment);
+            return _output.WriteAsync(segment, cancellationToken: token);
         }
 
         public override void Flush()

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -349,7 +349,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         public async Task FlushAsync(CancellationToken cancellationToken)
         {
             await ProduceStartAndFireOnStarting(immediate: false);
-            await SocketOutput.WriteAsync(_emptyData, immediate: true);
+            await SocketOutput.WriteAsync(_emptyData, immediate: true, cancellationToken: cancellationToken);
         }
 
         public void Write(ArraySegment<byte> data)

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameRequestStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameRequestStream.cs
@@ -68,14 +68,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             return ((Task<int>)asyncResult).Result;
         }
-#endif
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return _body.ReadAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
-        }
-
-        public Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, object state)
+        private Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, object state)
         {
             var tcs = new TaskCompletionSource<int>(state);
             var task = _body.ReadAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
@@ -96,6 +90,12 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 }
             }, tcs, cancellationToken);
             return tcs.Task;
+        }
+#endif
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _body.ReadAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameRequestStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameRequestStream.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     tcs2.SetResult(task2.Result);
                 }
-            }, tcs);
+            }, tcs, cancellationToken);
             return tcs.Task;
         }
 


### PR DESCRIPTION
I'm assuming these are oversights since the usage is inconsistent, but it's possible there's a reason here. If there is, this PR serves only as a mild waste of time - in which case: sorry!