### PR TITLE
Skip tests on Mono to prevent CI hangs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: csharp
-sudo: false
+sudo: required
+dist: trusty
+addons:
+  apt:
+    packages:
+      - libunwind8
 install:
   - curl -sSL https://github.com/libuv/libuv/archive/v1.4.2.tar.gz | tar zxfv - -C /tmp && cd /tmp/libuv-1.4.2/
   - sh autogen.sh
@@ -9,4 +14,5 @@ install:
   - export LD_LIBRARY_PATH="$HOME/libuvinstall/lib"
   - cd $OLDPWD
 script:
+  - export KOREBUILD_TEST_DNXCORE=1
   - ./build.sh --quiet verify

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/IPv6SupportedConditionAttribute.cs
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/IPv6SupportedConditionAttribute.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.AspNet.Testing.xunit;
+
+namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class IPv6SupportedConditionAttribute : Attribute, ITestCondition
+    {
+        private static Lazy<bool> _ipv6Supported = new Lazy<bool>(CanBindToIPv6Address);
+
+        public bool IsMet
+        {
+            get
+            {
+                return _ipv6Supported.Value;
+            }
+        }
+
+        public string SkipReason
+        {
+            get
+            {
+                return "IPv6 not supported on the host.";
+            }
+        }
+
+        private static bool CanBindToIPv6Address()
+        {
+            try
+            {
+                using (var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 8787));
+                    return true;
+                }
+            }
+            catch (SocketException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Hosting;
 using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,7 +18,8 @@ namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
 {
     public class RequestTests
     {
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task LargeUpload()
         {
             var config = new ConfigurationBuilder()
@@ -69,15 +71,18 @@ namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("127.0.0.1", "127.0.0.1", "8792")]
         [InlineData("localhost", "127.0.0.1", "8792")]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public Task RemoteIPv4Address(string requestAddress, string expectAddress, string port)
         {
             return TestRemoteIPAddress("localhost", requestAddress, expectAddress, port);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [IPv6SupportedCondition]
         public Task RemoteIPv6Address()
         {
             return TestRemoteIPAddress("[::1]", "[::1]", "::1", "8792");
@@ -92,7 +97,7 @@ namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
 
             var builder = new WebHostBuilder(config)
                 .UseServerFactory("Microsoft.AspNet.Server.Kestrel")
-                .UseStartup(app => 
+                .UseStartup(app =>
                 {
                     app.Run(async context =>
                     {

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Hosting;
+using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -13,7 +14,8 @@ namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
 {
     public class ResponseTests
     {
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on mono.")]
         public async Task LargeDownload()
         {
             var config = new ConfigurationBuilder()

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/project.json
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/project.json
@@ -3,7 +3,9 @@
   "dependencies": {
     "Microsoft.AspNet.Http.Abstractions": "1.0.0-*",
     "Microsoft.AspNet.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNet.Testing": "1.0.0-*",
     "System.Net.Http": "4.0.1-*",
+    "System.Net.NameResolution": "4.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "frameworks": {

--- a/test/Microsoft.AspNet.Server.KestrelTests/ChunkedResponseTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/ChunkedResponseTests.cs
@@ -4,13 +4,15 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNet.Server.KestrelTests
 {
     public class ChunkedResponseTests
     {
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ResponsesAreChunkedAutomatically()
         {
             using (var server = new TestServer(async httpContext =>
@@ -42,7 +44,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ZeroLengthWritesAreIgnored()
         {
             using (var server = new TestServer(async httpContext =>
@@ -75,7 +78,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task EmptyResponseBodyHandledCorrectlyWithZeroLengthWrite()
         {
             using (var server = new TestServer(async httpContext =>
@@ -102,7 +106,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ConnectionClosedIfExeptionThrownAfterWrite()
         {
             using (var server = new TestServer(async httpContext =>
@@ -132,7 +137,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ConnectionClosedIfExeptionThrownAfterZeroLengthWrite()
         {
             using (var server = new TestServer(async httpContext =>

--- a/test/Microsoft.AspNet.Server.KestrelTests/ConnectionFilterTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/ConnectionFilterTests.cs
@@ -3,9 +3,10 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Server.Kestrel.Filter;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Features;
+using Microsoft.AspNet.Server.Kestrel.Filter;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNet.Server.KestrelTests
@@ -29,7 +30,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task CanReadAndWriteWithRewritingConnectionFilter()
         {
             var filter = new RewritingConnectionFilter();
@@ -55,7 +57,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             Assert.Equal(sendString.Length, filter.BytesRead);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task CanReadAndWriteWithAsyncConnectionFilter()
         {
             var serviceContext = new TestServiceContext()

--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Server.Kestrel;
 using Microsoft.AspNet.Server.Kestrel.Filter;
+using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -75,8 +76,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             return Task.FromResult<object>(null);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public void EngineCanStartAndStop(ServiceContext testContext)
         {
             var engine = new KestrelEngine(testContext);
@@ -84,8 +86,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             engine.Dispose();
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public void ListenerCanCreateAndDispose(ServiceContext testContext)
         {
             var engine = new KestrelEngine(testContext);
@@ -96,8 +99,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             engine.Dispose();
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public void ConnectionCanReadAndWrite(ServiceContext testContext)
         {
             var engine = new KestrelEngine(testContext);
@@ -122,8 +126,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
         }
 
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -143,8 +148,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
         }
 
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http11(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -171,8 +177,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10ContentLength(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -192,8 +199,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10TransferEncoding(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -213,8 +221,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10KeepAlive(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -242,8 +251,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10KeepAliveNotUsedIfResponseContentLengthNotSet(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -272,8 +282,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10KeepAliveContentLength(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -303,8 +314,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10KeepAliveTransferEncoding(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -335,8 +347,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Expect100ContinueForBody(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -361,8 +374,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task DisconnectingClient(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -385,8 +399,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ZeroContentLengthSetAutomaticallyAfterNoWrites(ServiceContext testContext)
         {
             using (var server = new TestServer(EmptyApp, testContext))
@@ -413,8 +428,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ZeroContentLengthNotSetAutomaticallyForNonKeepAliveRequests(ServiceContext testContext)
         {
             using (var server = new TestServer(EmptyApp, testContext))
@@ -447,8 +463,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ZeroContentLengthNotSetAutomaticallyForHeadRequests(ServiceContext testContext)
         {
             using (var server = new TestServer(EmptyApp, testContext))
@@ -467,8 +484,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ZeroContentLengthNotSetAutomaticallyForCertainStatusCodes(ServiceContext testContext)
         {
             using (var server = new TestServer(async httpContext =>
@@ -520,8 +538,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingResultsIn500Response(ServiceContext testContext)
         {
             bool onStartingCalled = false;
@@ -577,8 +596,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingAfterWritingKillsConnection(ServiceContext testContext)
         {
             bool onStartingCalled = false;
@@ -619,8 +639,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingAfterPartialWriteKillsConnection(ServiceContext testContext)
         {
             bool onStartingCalled = false;
@@ -661,8 +682,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ConnectionClosesWhenFinReceived(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -688,8 +710,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ConnectionClosesWhenFinReceivedBeforeRequestCompletes(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -730,8 +753,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingInOnStartingResultsInFailedWritesAnd500Response(ServiceContext testContext)
         {
             var onStartingCallCount1 = 0;
@@ -803,7 +827,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingInOnCompletedIsLoggedAndClosesConnection(ServiceContext testContext)
         {
             var onCompletedCalled1 = false;
@@ -852,8 +878,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task RequestBodyIsConsumedAutomaticallyIfAppDoesntConsumeItFully(ServiceContext testContext)
         {
             using (var server = new TestServer(async httpContext =>


### PR DESCRIPTION
We're having issues with hangs on Travis and the CI after running functional tests on Mono. I've identified the reason for this, which is that KestrelThread.ThreadStart() hangs on the second call it makes to _loop.Run(). However, I haven't found a solution to this yet, so I'd like to disable these tests on Mono for now, so we can get past the hangs that we've been seeing.

cc @halter73 @lodejard @Tratcher 