### PR TITLE
Don't block on shutdown

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -247,8 +247,15 @@ namespace Microsoft.AspNet.Server.Kestrel
                     IntPtr.Zero);
 
                 // Ensure the Dispose operations complete in the event loop.
-                var ran2 = _loop.Run();
+                // UV_RUN_NOWAIT - Poll for i/o once but don't block if there are no pending callbacks.
+                var ran2 = _loop.Run(2);
+                if (ran2 != 0)
+                {
+                    // Callbacks still outstanding tear down the loop
 
+                    // or wait?
+                    // ran2 = _loop.Run();
+                }
                 _loop.Dispose();
             }
             catch (Exception ex)


### PR DESCRIPTION
Addresses issue mentioned in  #373

> We're having issues with hangs on Travis and the CI after running functional tests on Mono. I've identified the reason for this, which is that KestrelThread.ThreadStart() hangs on the second call it makes to _loop.Run()