### PR TITLE
OnCompleted doesn't need threadpool

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
@@ -200,6 +200,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             else
             {
                 // THIS IS AN ERROR STATE - ONLY ONE WAITER CAN WAIT
+                throw new InvalidOperationException("Already an awaited read");
             }
         }
 


### PR DESCRIPTION
Is called by the awaiting thread, rather than the awaiter's thread