### PR TITLE
Add LoggingConnectionFilter

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Features;
 using Microsoft.AspNet.Server.Kestrel;
-using Microsoft.AspNet.Server.Kestrel.Https;
+using Microsoft.AspNet.Server.Kestrel.Filter;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.PlatformAbstractions;
 
@@ -38,6 +38,8 @@ namespace SampleApp
             {
                 Console.WriteLine("Could not find certificate at '{0}'. HTTPS is not enabled.", testCertPath);
             }
+
+            app.UseKestrelConnectionLogging();
 
             app.Run(async context =>
             {

--- a/src/Microsoft.AspNet.Server.Kestrel.Https/HttpsApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel.Https/HttpsApplicationBuilderExtensions.cs
@@ -4,9 +4,9 @@
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http.Features;
-using Microsoft.AspNet.Server.Kestrel.Filter;
+using Microsoft.AspNet.Server.Kestrel.Https;
 
-namespace Microsoft.AspNet.Server.Kestrel.Https
+namespace Microsoft.AspNet.Server.Kestrel.Filter
 {
     public static class HttpsApplicationBuilderExtensions
     {

--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/LoggingConnectionFilter.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/LoggingConnectionFilter.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNet.Server.Kestrel.Filter
+{
+    public class LoggingConnectionFilter : IConnectionFilter
+    {
+        private readonly ILogger _logger;
+        private readonly IConnectionFilter _previous;
+
+        public LoggingConnectionFilter(ILogger logger, IConnectionFilter previous)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+            if (previous == null)
+            {
+                throw new ArgumentNullException(nameof(previous));
+            }
+
+            _logger = logger;
+            _previous = previous;
+        }
+
+        public async Task OnConnection(ConnectionFilterContext context)
+        {
+            await _previous.OnConnection(context);
+
+            context.Connection = new LoggingStream(context.Connection, _logger);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/LoggingFilterApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/LoggingFilterApplicationBuilderExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNet.Server.Kestrel.Filter
+{
+    public static class LoggingFilterApplicationBuilderExtensions
+    {
+        /// <summary>
+        /// Emits verbose logs for bytes read from and written to the connection.
+        /// </summary>
+        /// <returns></returns>
+        public static IApplicationBuilder UseKestrelConnectionLogging(this IApplicationBuilder app)
+        {
+            return app.UseKestrelConnectionLogging(nameof(LoggingConnectionFilter));
+        }
+
+        /// <summary>
+        /// Emits verbose logs for bytes read from and written to the connection.
+        /// </summary>
+        /// <returns></returns>
+        public static IApplicationBuilder UseKestrelConnectionLogging(this IApplicationBuilder app, string loggerName)
+        {
+            var serverInfo = app.ServerFeatures.Get<IKestrelServerInformation>();
+            if (serverInfo != null)
+            {
+                var prevFilter = serverInfo.ConnectionFilter ?? new NoOpConnectionFilter();
+                var loggerFactory = app.ApplicationServices.GetRequiredService<ILoggerFactory>();
+                var logger = loggerFactory.CreateLogger(loggerName ?? nameof(LoggingConnectionFilter));
+                serverInfo.ConnectionFilter = new LoggingConnectionFilter(logger, prevFilter);
+            }
+            return app;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/LoggingStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/LoggingStream.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNet.Server.Kestrel.Filter
+{
+    internal class LoggingStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly ILogger _logger;
+
+        public LoggingStream(Stream inner, ILogger logger)
+        {
+            _inner = inner;
+            _logger = logger;
+        }
+
+        public override bool CanRead
+        {
+            get
+            {
+                return _inner.CanRead;
+            }
+        }
+
+        public override bool CanSeek
+        {
+            get
+            {
+                return _inner.CanSeek;
+            }
+        }
+
+        public override bool CanWrite
+        {
+            get
+            {
+                return _inner.CanWrite;
+            }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                return _inner.Length;
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                return _inner.Position;
+            }
+
+            set
+            {
+                _inner.Position = value;
+            }
+        }
+
+        public override void Flush()
+        {
+            _inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int read = _inner.Read(buffer, offset, count);
+            Log("Read", read, buffer, offset);
+            return read;
+        }
+
+        public async override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            int read = await _inner.ReadAsync(buffer, offset, count, cancellationToken);
+            Log("ReadAsync", read, buffer, offset);
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _inner.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            _inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            Log("Write", count, buffer, offset);
+            _inner.Write(buffer, offset, count);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            Log("WriteAsync", count, buffer, offset);
+            return _inner.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        private void Log(string method, int count, byte[] buffer, int offset)
+        {
+            var builder = new StringBuilder($"{method}[{count}] ");
+
+            // Write the hex
+            for (int i = offset; i < offset + count; i++)
+            {
+                builder.Append(buffer[i].ToString("X2"));
+                builder.Append(" ");
+            }
+            builder.AppendLine();
+            // Write the bytes as if they were ASCII
+            for (int i = offset; i < offset + count; i++)
+            {
+                builder.Append((char)buffer[i]);
+            }
+
+            _logger.LogVerbose(builder.ToString());
+        }
+    }
+}


### PR DESCRIPTION
This is a connection filter I developed during RC1 sign-off to help debug wire-level issues even on localhost.
```
verb: Microsoft.AspNet.Server.Kestrel.Filter.LoggingConnectionFilter[0]
      ReadAsync[1]47
      G
verb: Microsoft.AspNet.Server.Kestrel.Filter.LoggingConnectionFilter[0]
      ReadAsync[315]45 54 20 2f 66 61 76 69 63 6f 6e 2e 69 63 6f 20 48 54 54 50 2f 31 2e 31 d a 48 6f 73 74 3a 20 6c 6f 63 61 6c 68 6f 73 74 3a 35 30 30 31 d a 43 6f 6e 6e 65 63 74 69 6f 6e 3a 20 6b 65 65 70 2d 61 6c 69 76 65 d a 55 73 65 72 2d 41 67 65 6e 74 3a 20 4d 6f 7a 69 6c 6c 61 2f 35 2e 30 20 28 57 69 6e 64 6f 77 73 20 4e 54 20 31 30 2e 30 3b 20 57 4f 57 36 34 29 20 41 70 70 6c 65 57 65 62 4b 69 74 2f 35 33 37 2e 33 36 20 28 4b 48 54 4d 4c 2c 20 6c 69 6b 65 20 47 65 63 6b 6f 29 20 43 68 72 6f 6d 65 2f 34 36 2e 30 2e 32 34 39 30 2e 38 36 20 53 61 66 61 72 69 2f 35 33 37 2e 33 36 d a 41 63 63 65 70 74 3a 20 2a 2f 2a d a 52 65 66 65 72 65 72 3a 20 68 74 74 70 73 3a 2f 2f 6c 6f 63 61 6c 68 6f 73 74 3a 35 30 30 31 2f d a 41 63 63 65 70 74 2d 45 6e 63 6f 64 69 6e 67 3a 20 67 7a 69 70 2c 20 64 65 66 6c 61 74 65 2c 20 73 64 63 68 d a 41 63 63 65 70 74 2d 4c 61 6e 67 75 61 67 65 3a 20 65 6e 2d 55 53 2c 65 6e 3b 71 3d 30 2e 38 d a d a
      ET /favicon.ico HTTP/1.1
      Host: localhost:5001
      Connection: keep-alive
      User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.86 Safari/537.36
      Accept: */*
      Referer: https://localhost:5001/
      Accept-Encoding: gzip, deflate, sdch
      Accept-Language: en-US,en;q=0.8

....
verb: Microsoft.AspNet.Server.Kestrel.Filter.LoggingConnectionFilter[0]
      Write[119]48 54 54 50 2f 31 2e 31 20 32 30 30 20 4f 4b d a 44 61 74 65 3a 20 4d 6f 6e 2c 20 31 36 20 4e 6f 76 20 32 30 31 35 20 32 33 3a 30 39 3a 30 37 20 47 4d 54 d a 43 6f 6e 74 65 6e 74 2d 4c 65 6e 67 74 68 3a 20 31 31 d a 43 6f 6e 74 65 6e 74 2d 54 79 70 65 3a 20 74 65 78 74 2f 70 6c 61 69 6e d a 53 65 72 76 65 72 3a 20 4b 65 73 74 72 65 6c d a d a
      HTTP/1.1 200 OK
      Date: Mon, 16 Nov 2015 23:09:07 GMT
      Content-Length: 11
      Content-Type: text/plain
      Server: Kestrel


verb: Microsoft.AspNet.Server.Kestrel.Filter.LoggingConnectionFilter[0]
      Write[11]48 65 6c 6c 6f 20 77 6f 72 6c 64
      Hello world
```
@halter73 @lodejard 

On a related note, why does kestrel do a ReadAsync(1)?