### PR TITLE
Made IKestrelServerInformation.ThreadCount nullable

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/IKestrelServerInformation.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/IKestrelServerInformation.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.Server.Kestrel
 {
     public interface IKestrelServerInformation
     {
-        int ThreadCount { get; set; }
+        int? ThreadCount { get; set; }
 
         bool NoDelay { get; set; }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelServer.cs
@@ -93,16 +93,17 @@ namespace Microsoft.AspNet.Server.Kestrel
                     threadCount = 16;
                 }
 
-                if (information.ThreadCount < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(information.ThreadCount),
-                        information.ThreadCount,
-                        "ThreadCount cannot be negative");
-                }
-                else if (information.ThreadCount > 0)
+                if (information.ThreadCount.HasValue)
                 {
                     // ThreadCount has been user set, use that value
-                    threadCount = information.ThreadCount;
+                    threadCount = information.ThreadCount.Value;
+
+                    if (threadCount < 0)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(information.ThreadCount),
+                            information.ThreadCount,
+                            "ThreadCount cannot be negative");
+                    }
                 }
 
                 engine.Start(threadCount);

--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelServer.cs
@@ -75,36 +75,7 @@ namespace Microsoft.AspNet.Server.Kestrel
                 _disposables.Push(engine);
                 _disposables.Push(dateHeaderValueManager);
 
-                // Actual core count would be a better number 
-                // rather than logical cores which includes hyper-threaded cores.
-                // Divide by 2 for hyper-threading, and good defaults (still need threads to do webserving).
-                // Can be user overriden using IKestrelServerInformation.ThreadCount
-                var threadCount = Environment.ProcessorCount >> 1;
-
-                if (threadCount < 1)
-                {
-                    // Ensure shifted value is at least one
-                    threadCount = 1;
-                }
-                else if (threadCount > 16)
-                {
-                    // Receive Side Scaling RSS Processor count currently maxes out at 16
-                    // would be better to check the NIC's current hardware queues; but xplat...
-                    threadCount = 16;
-                }
-
-                if (information.ThreadCount.HasValue)
-                {
-                    // ThreadCount has been user set, use that value
-                    threadCount = information.ThreadCount.Value;
-
-                    if (threadCount < 0)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(information.ThreadCount),
-                            information.ThreadCount,
-                            "ThreadCount cannot be negative");
-                    }
-                }
+                var threadCount = GetThreadCount(information);
 
                 engine.Start(threadCount);
                 var atLeastOneListener = false;
@@ -147,6 +118,46 @@ namespace Microsoft.AspNet.Server.Kestrel
                 }
                 _disposables = null;
             }
+        }
+
+        private static int GetThreadCount(IKestrelServerInformation information)
+        {
+            int threadCount;
+            if (information.ThreadCount.HasValue)
+            {
+                // ThreadCount has been user set, use that value
+                threadCount = information.ThreadCount.Value;
+
+                if (threadCount < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(information.ThreadCount),
+                        information.ThreadCount,
+                        "ThreadCount cannot be negative");
+                }
+
+                return threadCount;
+            }
+
+            // Actual core count would be a better number
+            // rather than logical cores which includes hyper-threaded cores.
+            // Divide by 2 for hyper-threading, and good defaults (still need threads to do webserving).
+            // Can be user overriden using IKestrelServerInformation.ThreadCount
+            threadCount = Environment.ProcessorCount >> 1;
+
+            if (threadCount < 1)
+            {
+                // Ensure shifted value is at least one
+                return 1;
+            }
+
+            if (threadCount > 16)
+            {
+                // Receive Side Scaling RSS Processor count currently maxes out at 16
+                // would be better to check the NIC's current hardware queues; but xplat...
+                return 16;
+            }
+
+            return threadCount;
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelServerInformation.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelServerInformation.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Server.Kestrel
     {
         public ICollection<string> Addresses { get; } = new List<string>();
 
-        public int ThreadCount { get; set; }
+        public int? ThreadCount { get; set; }
 
         public bool NoDelay { get; set; } = true;
 


### PR DESCRIPTION
Noticed this when looking at #378. I think this looks better than `if (information.ThreadCount > 0)` :smile: