### PR TITLE
Only use pooled buffers

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/SocketInputStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/SocketInputStream.cs
@@ -74,9 +74,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            var inputBuffer = _socketInput.IncomingStart(count);
-
-            Buffer.BlockCopy(buffer, offset, inputBuffer.Data.Array, inputBuffer.Data.Offset, count);
+            _socketInput.IncomingStart(buffer, offset, count);
 
             _socketInput.IncomingComplete(count, error: null);
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         private Libuv.uv_buf_t OnAlloc(UvStreamHandle handle, int suggestedSize)
         {
-            var result = _rawSocketInput.IncomingStart(2048);
+            var result = _rawSocketInput.IncomingRawStart();
 
             return handle.Libuv.buf_init(
                 result.DataPtr,

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerContext.cs
@@ -10,13 +10,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
     {
         public ListenerContext()
         {
-            Memory2 = new MemoryPool2();
         }
 
         public ListenerContext(ServiceContext serviceContext) 
             : base(serviceContext)
         {
-            Memory2 = new MemoryPool2();
         }
 
         public ListenerContext(ListenerContext listenerContext)
@@ -25,7 +23,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             ServerAddress = listenerContext.ServerAddress;
             Thread = listenerContext.Thread;
             Application = listenerContext.Application;
-            Memory2 = listenerContext.Memory2;
             Log = listenerContext.Log;
         }
 
@@ -35,6 +32,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public RequestDelegate Application { get; set; }
 
-        public MemoryPool2 Memory2 { get; set; }
+        public MemoryPool2 Memory2 => Thread.Memory2;
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -37,6 +37,7 @@ namespace Microsoft.AspNet.Server.Kestrel
         public KestrelThread(KestrelEngine engine)
         {
             _engine = engine;
+            Memory2 = new MemoryPool2();
             _appLifetime = engine.AppLifetime;
             _log = engine.Log;
             _loop = new UvLoopHandle(_log);
@@ -46,6 +47,9 @@ namespace Microsoft.AspNet.Server.Kestrel
         }
 
         public UvLoopHandle Loop { get { return _loop; } }
+
+        public MemoryPool2 Memory2 { get; }
+
         public ExceptionDispatchInfo FatalError { get { return _closeError; } }
 
         public Action<Action<IntPtr>, IntPtr> QueueCloseHandle { get; internal set; }
@@ -61,6 +65,7 @@ namespace Microsoft.AspNet.Server.Kestrel
         {
             if (!_initCompleted)
             {
+                Memory2.Dispose();
                 return;
             }
 
@@ -93,6 +98,8 @@ namespace Microsoft.AspNet.Server.Kestrel
                     }
                 }
             }
+
+            Memory2.Dispose();
 
             if (_closeError != null)
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
@@ -74,6 +74,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         /// </summary>
         public MemoryPoolBlock2 Next { get; set; }
 
+#if DEBUG
+        // See http://www.philosophicalgeek.com/2014/09/29/digging-into-net-object-allocation-fundamentals/ 
+        // for the cost of including a finalizer
         ~MemoryPoolBlock2()
         {
             Debug.Assert(!_pinHandle.IsAllocated, "Ad-hoc memory block wasn't unpinned");
@@ -96,6 +99,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                 });
             }
         }
+#endif
 
         /// <summary>
         /// Called to ensure that a block is pinned, and return the pointer to native memory just after

--- a/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolBlock2Tests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolBlock2Tests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             using (var pool = new MemoryPool2())
             {
-                var block = pool.Lease(256);
+                var block = pool.Lease();
                 foreach (var ch in Enumerable.Range(0, 256).Select(x => (byte)x))
                 {
                     block.Array[block.End++] = ch;
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             using (var pool = new MemoryPool2())
             {
-                var block = pool.Lease(256);
+                var block = pool.Lease();
                 block.End += 256;
                 TestAllLengths(block, 256);
                 pool.Return(block);
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 for (var fragment = 0; fragment < 256; fragment += 4)
                 {
                     var next = block;
-                    block = pool.Lease(4);
+                    block = pool.Lease();
                     block.Next = next;
                     block.End += 4;
                 }
@@ -84,8 +84,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             using (var pool = new MemoryPool2())
             {
-                var block1 = pool.Lease(256);
-                var block2 = block1.Next = pool.Lease(256);
+                var block1 = pool.Lease();
+                var block2 = block1.Next = pool.Lease();
 
                 block1.End += 100;
                 block2.End += 200;
@@ -122,8 +122,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             using (var pool = new MemoryPool2())
             {
-                var block1 = pool.Lease(128);
-                var block2 = block1.Next = pool.Lease(128);
+                var block1 = pool.Lease();
+                var block2 = block1.Next = pool.Lease();
 
                 for (int i = 0; i < 128; i++)
                 {
@@ -157,10 +157,10 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             using (var pool = new MemoryPool2())
             {
-                var block1 = pool.Lease(128);
-                var block2 = block1.Next = pool.Lease(128);
-                var block3 = block2.Next = pool.Lease(128);
-                var block4 = block3.Next = pool.Lease(128);
+                var block1 = pool.Lease();
+                var block2 = block1.Next = pool.Lease();
+                var block3 = block2.Next = pool.Lease();
+                var block4 = block3.Next = pool.Lease();
 
                 // There is no data in block2 or block4, so IsEnd should be true after 256 bytes are read.
                 block1.End += 128;

--- a/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolIterator2Tests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolIterator2Tests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [InlineData("/localhost:5000/PATH/PATH2/ HTTP/1.1", " %?", ' ', 27)]
         public void MemorySeek(string raw, string search, char expectResult, int expectIndex)
         {
-            var block = _pool.Lease(256);
+            var block = _pool.Lease();
             var chars = raw.ToCharArray().Select(c => (byte)c).ToArray();
             Buffer.BlockCopy(chars, 0, block.Array, block.Start, chars.Length);
             block.End += chars.Length;
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
             var blocks = new MemoryPoolBlock2[4];
             for (var i = 0; i < 4; ++i)
             {
-                blocks[i] = _pool.Lease(16);
+                blocks[i] = _pool.Lease();
                 blocks[i].End += 16;
 
                 for (var j = 0; j < blocks.Length; ++j)

--- a/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
@@ -19,66 +19,72 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void Http10ConnectionClose()
         {
-            var input = new TestInput();
-            var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
-            var stream = new FrameRequestStream(body);
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
+                var stream = new FrameRequestStream(body);
 
-            input.Add("Hello", true);
+                input.Add("Hello", true);
 
-            var buffer1 = new byte[1024];
-            var count1 = stream.Read(buffer1, 0, 1024);
-            AssertASCII("Hello", new ArraySegment<byte>(buffer1, 0, 5));
+                var buffer1 = new byte[1024];
+                var count1 = stream.Read(buffer1, 0, 1024);
+                AssertASCII("Hello", new ArraySegment<byte>(buffer1, 0, 5));
 
-            var buffer2 = new byte[1024];
-            var count2 = stream.Read(buffer2, 0, 1024);
-            Assert.Equal(0, count2);
+                var buffer2 = new byte[1024];
+                var count2 = stream.Read(buffer2, 0, 1024);
+                Assert.Equal(0, count2);
+            }
         }
 
         [Fact]
         public async Task Http10ConnectionCloseAsync()
         {
-            var input = new TestInput();
-            var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
-            var stream = new FrameRequestStream(body);
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
+                var stream = new FrameRequestStream(body);
 
-            input.Add("Hello", true);
+                input.Add("Hello", true);
 
-            var buffer1 = new byte[1024];
-            var count1 = await stream.ReadAsync(buffer1, 0, 1024);
-            AssertASCII("Hello", new ArraySegment<byte>(buffer1, 0, 5));
+                var buffer1 = new byte[1024];
+                var count1 = await stream.ReadAsync(buffer1, 0, 1024);
+                AssertASCII("Hello", new ArraySegment<byte>(buffer1, 0, 5));
 
-            var buffer2 = new byte[1024];
-            var count2 = await stream.ReadAsync(buffer2, 0, 1024);
-            Assert.Equal(0, count2);
+                var buffer2 = new byte[1024];
+                var count2 = await stream.ReadAsync(buffer2, 0, 1024);
+                Assert.Equal(0, count2);
+            }
         }
 
         [Fact]
         public async Task CanHandleLargeBlocks()
         {
-            var input = new TestInput();
-            var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
-            var stream = new FrameRequestStream(body);
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
+                var stream = new FrameRequestStream(body);
 
-            // Input needs to be greater than 4032 bytes to allocate a block not backed by a slab.
-            var largeInput = new string('a', 8192);
+                // Input needs to be greater than 4032 bytes to allocate a block not backed by a slab.
+                var largeInput = new string('a', 8192);
 
-            input.Add(largeInput, true);
-            // Add a smaller block to the end so that SocketInput attempts to return the large
-            // block to the memory pool.
-            input.Add("Hello", true);
+                input.Add(largeInput, true);
+                // Add a smaller block to the end so that SocketInput attempts to return the large
+                // block to the memory pool.
+                input.Add("Hello", true);
 
-            var readBuffer = new byte[8192];
+                var readBuffer = new byte[8192];
 
-            var count1 = await stream.ReadAsync(readBuffer, 0, 8192);
-            Assert.Equal(8192, count1);
-            AssertASCII(largeInput, new ArraySegment<byte>(readBuffer, 0, 8192));
+                var count1 = await stream.ReadAsync(readBuffer, 0, 8192);
+                Assert.Equal(8192, count1);
+                AssertASCII(largeInput, new ArraySegment<byte>(readBuffer, 0, 8192));
 
-            var count2 = await stream.ReadAsync(readBuffer, 0, 8192);
-            Assert.Equal(5, count2);
-            AssertASCII("Hello", new ArraySegment<byte>(readBuffer, 0, 5));
+                var count2 = await stream.ReadAsync(readBuffer, 0, 8192);
+                Assert.Equal(5, count2);
+                AssertASCII("Hello", new ArraySegment<byte>(readBuffer, 0, 5));
 
-            var count3 = await stream.ReadAsync(readBuffer, 0, 8192);
-            Assert.Equal(0, count3);
+                var count3 = await stream.ReadAsync(readBuffer, 0, 8192);
+                Assert.Equal(0, count3);
+            }
         }
 
         private void AssertASCII(string expected, ArraySegment<byte> actual)


### PR DESCRIPTION
Only use pooled blocks.
Don't finalize blocks outside debug.

For the cost of just including a finalizer on allocation see:  
http://www.philosophicalgeek.com/2014/09/29/digging-into-net-object-allocation-fundamentals/