### PR TITLE
Use MemoryPool2 for SocketOutput Buffers

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/FilteredStreamAdapter.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/FilteredStreamAdapter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
             IKestrelTrace logger)
         {
             SocketInput = new SocketInput(memory);
-            SocketOutput = new StreamSocketOutput(filteredStream);
+            SocketOutput = new StreamSocketOutput(filteredStream, memory);
 
             _log = logger;
             _filteredStream = filteredStream;

--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamSocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamSocketOutput.cs
@@ -13,10 +13,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
     public class StreamSocketOutput : ISocketOutput
     {
         private readonly Stream _outputStream;
+        private readonly MemoryPool2 _memory;
+        private MemoryPoolBlock2 _producingBlock;
 
-        public StreamSocketOutput(Stream outputStream)
+        public StreamSocketOutput(Stream outputStream, MemoryPool2 memory)
         {
             _outputStream = outputStream;
+            _memory = memory;
         }
 
         void ISocketOutput.Write(ArraySegment<byte> buffer, bool immediate)
@@ -29,6 +32,28 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
             // TODO: Use _outputStream.WriteAsync
             _outputStream.Write(buffer.Array, buffer.Offset, buffer.Count);
             return TaskUtilities.CompletedTask;
+        }
+
+        public MemoryPoolIterator2 ProducingStart()
+        {
+            _producingBlock = _memory.Lease();
+            return new MemoryPoolIterator2(_producingBlock);
+        }
+
+        public void ProducingComplete(MemoryPoolIterator2 end, int count)
+        {
+            var block = _producingBlock;
+            while (block != end.Block)
+            {
+                _outputStream.Write(block.Data.Array, block.Data.Offset, block.Data.Count);
+
+                var returnBlock = block;
+                block = block.Next;
+                returnBlock.Pool?.Return(returnBlock);
+            }
+
+            _outputStream.Write(end.Block.Array, end.Block.Data.Offset, end.Index);
+            end.Block.Pool?.Return(end.Block);
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             _connectionId = Interlocked.Increment(ref _lastConnectionId);
 
             _rawSocketInput = new SocketInput(Memory2);
-            _rawSocketOutput = new SocketOutput(Thread, _socket, this, _connectionId, Log);
+            _rawSocketOutput = new SocketOutput(Thread, _socket, Memory2, this, _connectionId, Log);
         }
 
         public void Start()
@@ -116,7 +116,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 // called from a libuv thread.
                 ThreadPool.QueueUserWorkItem(state =>
                 {
-                    var connection = (Connection)this;
+                    var connection = (Connection)state;
                     connection._frame.Abort();
                 }, this);
             }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ISocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ISocketOutput.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -14,5 +15,22 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
     {
         void Write(ArraySegment<byte> buffer, bool immediate = true);
         Task WriteAsync(ArraySegment<byte> buffer, bool immediate = true, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Returns an iterator pointing to the tail of the response buffer. Response data can be appended
+        /// manually or by using <see cref="MemoryPoolIterator2.CopyFrom(ArraySegment{byte})"/>.
+        /// Be careful to ensure all appended blocks are backed by a <see cref="MemoryPoolSlab2"/>. 
+        /// </summary>
+        MemoryPoolIterator2 ProducingStart();
+
+        /// <summary>
+        /// Commits the response data appended to the iterator returned from <see cref="ProducingStart"/>.
+        /// All the data up to <paramref name="end"/> will be included in the response.
+        /// A write operation isn't guaranteed to be scheduled unless <see cref="Write(ArraySegment{byte}, bool)"/>
+        /// or <see cref="WriteAsync(ArraySegment{byte}, bool, CancellationToken)"/> is called afterwards.
+        /// </summary>
+        /// <param name="end">Points to the end of the committed data.</param>
+        /// <param name="count">The number of bytes added to the response.</param>
+        void ProducingComplete(MemoryPoolIterator2 end, int count);
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 {
                     _pinned = _tail;
                     var data = new ArraySegment<byte>(_pinned.Data.Array, _pinned.End, _pinned.Data.Offset + _pinned.Data.Count - _pinned.End);
-                    var dataPtr = _pinned.Pin();
+                    var dataPtr = _pinned.Pin() + _pinned.End;
                     return new IncomingBuffer
                     {
                         Data = data,
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             return new IncomingBuffer
             {
                 Data = _pinned.Data,
-                DataPtr = _pinned.Pin()
+                DataPtr = _pinned.Pin() + _pinned.End
             };
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
@@ -305,11 +305,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     var returnBlock = block;
                     block = block.Next;
 
-                    returnBlock.Unpin();
                     returnBlock.Pool?.Return(returnBlock);
                 }
-
-                _tail.Unpin();
 
                 if (_isProducing)
                 {
@@ -381,6 +378,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                 var writeReq = new UvWriteReq(Self._log);
                 writeReq.Init(Self._thread.Loop);
+
                 writeReq.Write(Self._socket, _lockedStart, _lockedEnd, _bufferCount, (_writeReq, status, error, state) =>
                 {
                     _writeReq.Dispose();
@@ -453,6 +451,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     returnBlock.Unpin();
                     returnBlock.Pool?.Return(returnBlock);
                 }
+
+                _lockedEnd.Block.Unpin();
             }
 
             private void LockWrite()

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPool2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPool2.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         /// <param name="minimumSize">The block returned must be at least this size. It may be larger than this minimum size, and if so,
         /// the caller may write to the block's entire size rather than being limited to the minumumSize requested.</param>
         /// <returns>The block that is reserved for the called. It must be passed to Return when it is no longer being used.</returns>
-        public MemoryPoolBlock2 Lease(int minimumSize)
+        public MemoryPoolBlock2 Lease(int minimumSize = _blockLength)
         {
             if (minimumSize > _blockLength)
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
@@ -105,14 +105,12 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         /// <returns></returns>
         public IntPtr Pin()
         {
+            Debug.Assert(!_pinHandle.IsAllocated);
+
             if (_dataArrayPtr != IntPtr.Zero)
             {
                 // this is a slab managed block - use the native address of the slab which is always locked
                 return _dataArrayPtr;
-            }
-            else if (_pinHandle.IsAllocated)
-            {
-                return _pinHandle.AddrOfPinnedObject();
             }
             else
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolBlock2.cs
@@ -98,24 +98,27 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         }
 
         /// <summary>
-        /// Called to ensure that a block is pinned, and return the pointer to native memory just after
-        /// the range of "active" bytes. This is where arriving data is read into.
+        /// Called to ensure that a block is pinned, and return the pointer to the native address
+        /// of the first byte of this block's Data memory. Arriving data is read into Pin() + End.
+        /// Outgoing data is read from Pin() + Start.
         /// </summary>
         /// <returns></returns>
         public IntPtr Pin()
         {
-            Debug.Assert(!_pinHandle.IsAllocated);
-
             if (_dataArrayPtr != IntPtr.Zero)
             {
                 // this is a slab managed block - use the native address of the slab which is always locked
-                return _dataArrayPtr + End;
+                return _dataArrayPtr;
+            }
+            else if (_pinHandle.IsAllocated)
+            {
+                return _pinHandle.AddrOfPinnedObject();
             }
             else
             {
                 // this is one-time-use memory - lock the managed memory until Unpin is called
                 _pinHandle = GCHandle.Alloc(Data.Array, GCHandleType.Pinned);
-                return _pinHandle.AddrOfPinnedObject() + End;
+                return _pinHandle.AddrOfPinnedObject();
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
@@ -85,6 +85,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
                 _callback = null;
                 _state = null;
                 Unpin(this);
+
+                var block = start.Block;
+                for (var index = 0; index < nBuffers; index++)
+                {
+                    block.Unpin();
+                    block = block.Next;
+                }
+
                 throw;
             }
         }

--- a/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
@@ -62,14 +62,24 @@ namespace Microsoft.AspNet.Server.KestrelTests
 
                 var writeRequest = new UvWriteReq(new KestrelTrace(new TestKestrelTrace()));
                 writeRequest.Init(loop);
+                var block = MemoryPoolBlock2.Create(
+                    new ArraySegment<byte>(new byte[] { 1, 2, 3, 4 }),
+                    dataPtr: IntPtr.Zero,
+                    pool: null,
+                    slab: null);
+                var start = new MemoryPoolIterator2(block, 0);
+                var end = new MemoryPoolIterator2(block, block.Data.Count);
                 writeRequest.Write(
                     serverConnectionPipe,
-                    new ArraySegment<ArraySegment<byte>>(new ArraySegment<byte>[] { new ArraySegment<byte>(new byte[] { 1, 2, 3, 4 }) }),
+                    start, 
+                    end,
+                    1,
                     (_3, status2, error2, _4) =>
                     {
                         writeRequest.Dispose();
                         serverConnectionPipe.Dispose();
                         serverListenPipe.Dispose();
+                        block.Unpin();
                     },
                     null);
 

--- a/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
@@ -201,12 +201,22 @@ namespace Microsoft.AspNet.Server.KestrelTests
                             {
                                 var req = new UvWriteReq(new KestrelTrace(new TestKestrelTrace()));
                                 req.Init(loop);
+                                var block = MemoryPoolBlock2.Create(
+                                    new ArraySegment<byte>(new byte[] { 65, 66, 67, 68, 69 }),
+                                    dataPtr: IntPtr.Zero,
+                                    pool: null,
+                                    slab: null);
+                                var start = new MemoryPoolIterator2(block, 0);
+                                var end = new MemoryPoolIterator2(block, block.Data.Count);
                                 req.Write(
                                     tcp2,
-                                    new ArraySegment<ArraySegment<byte>>(
-                                        new[] { new ArraySegment<byte>(new byte[] { 65, 66, 67, 68, 69 }) }
-                                        ),
-                                    (_1, _2, _3, _4) => { },
+                                    start,
+                                    end,
+                                    1,
+                                    (_1, _2, _3, _4) =>
+                                    {
+                                        block.Unpin();
+                                    },
                                     null);
                             }
                         }

--- a/test/Microsoft.AspNet.Server.KestrelTests/TestHelpers/MockLibuv.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/TestHelpers/MockLibuv.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Server.KestrelTests.TestHelpers
         private bool _stopLoop;
         private readonly ManualResetEventSlim _loopWh = new ManualResetEventSlim();
 
-        private Func<UvStreamHandle, ArraySegment<ArraySegment<byte>>, Action<int>, int> _onWrite;
+        private Func<UvStreamHandle, int, Action<int>, int> _onWrite;
 
         unsafe public MockLibuv()
         {
@@ -68,7 +68,7 @@ namespace Microsoft.AspNet.Server.KestrelTests.TestHelpers
             _uv_walk = (loop, callback, ignore) => 0;
         }
 
-        public Func<UvStreamHandle, ArraySegment<ArraySegment<byte>>, Action<int>, int> OnWrite
+        public Func<UvStreamHandle, int, Action<int>, int> OnWrite
         {
             get
             {
@@ -82,7 +82,7 @@ namespace Microsoft.AspNet.Server.KestrelTests.TestHelpers
 
         unsafe private int UvWrite(UvRequest req, UvStreamHandle handle, uv_buf_t* bufs, int nbufs, uv_write_cb cb)
         {
-            return _onWrite(handle, new ArraySegment<ArraySegment<byte>>(), status => cb(req.InternalGetHandle(), status));
+            return _onWrite(handle, nbufs, status => cb(req.InternalGetHandle(), status));
         }
     }
 }


### PR DESCRIPTION
Add ProducingStart and ProducingComplete methods to ISocketOutput.
These new methods can help prevent double buffering when encoding.