### PR TITLE
Enable TCP Loopback Fast Path (Windows)

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -158,9 +158,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 host.Start();
 
-                using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                using (var socket = TestConnection.CreateConnectedLoopbackSocket(port))
                 {
-                    socket.Connect(new IPEndPoint(IPAddress.Loopback, port));
                     socket.Send(Encoding.ASCII.GetBytes("GET /%41%CC%8A/A/../B/%41%CC%8A HTTP/1.1\r\n\r\n"));
                     socket.Shutdown(SocketShutdown.Send);
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/TestConnection.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.AspNetCore.Server.Kestrel.Networking;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
+{
+    public class TestConnection
+    {
+        public static Socket CreateConnectedLoopbackSocket(int port)
+        {
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            if (PlatformApis.IsWindows)
+            {
+                const int SIO_LOOPBACK_FAST_PATH = -1744830448;
+                var optionInValue = BitConverter.GetBytes(1);
+                try
+                {
+                    socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
+                }
+                catch
+                {
+                    // If the operating system version on this machine did
+                    // not support SIO_LOOPBACK_FAST_PATH (i.e. version
+                    // prior to Windows 8 / Windows Server 2012), handle the exception
+                }
+            }
+            socket.Connect(new IPEndPoint(IPAddress.Loopback, port));
+            return socket;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
@@ -118,24 +118,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var started = engine.CreateServer(address);
 
             Console.WriteLine("Started");
-            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            if (PlatformApis.IsWindows)
-            {
-                const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
-                var optionInValue = BitConverter.GetBytes(1);
-                try
-                {
-                    socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
-                }
-                catch
-                {
-                    // If the operating system version on this machine did
-                    // not support SIO_LOOPBACK_FAST_PATH (i.e. version
-                    // prior to Windows 8 / Windows Server 2012), handle the exception
-                }
-            }
-            socket.NoDelay = true;
-            socket.Connect(new IPEndPoint(IPAddress.Loopback, port));
+            var socket = TestConnection.CreateConnectedLoopbackSocket(port);
             socket.Send(Encoding.ASCII.GetBytes("POST / HTTP/1.0\r\n\r\nHello World"));
             socket.Shutdown(SocketShutdown.Send);
             var buffer = new byte[8192];
@@ -491,24 +474,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var server = new TestServer(App, testContext))
             {
-                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-                if (PlatformApis.IsWindows)
-                {
-                    const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
-                    var optionInValue = BitConverter.GetBytes(1);
-                    try
-                    {
-                        socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
-                    }
-                    catch
-                    {
-                        // If the operating system version on this machine did
-                        // not support SIO_LOOPBACK_FAST_PATH (i.e. version
-                        // prior to Windows 8 / Windows Server 2012), handle the exception
-                    }
-                }
-                socket.NoDelay = true;
-                socket.Connect(IPAddress.Loopback, server.Port);
+                var socket = TestConnection.CreateConnectedLoopbackSocket(server.Port);
                 await Task.Delay(200);
                 socket.Dispose();
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MultipleLoopTests.cs
@@ -235,6 +235,22 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     serverConnectionPipeAcceptedEvent.WaitOne();
 
                     var socket = new Socket(SocketType.Stream, ProtocolType.IP);
+                    if (PlatformApis.IsWindows)
+                    {
+                        const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
+                        var optionInValue = BitConverter.GetBytes(1);
+                        try
+                        {
+                            socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
+                        }
+                        catch
+                        {
+                            // If the operating system version on this machine did
+                            // not support SIO_LOOPBACK_FAST_PATH (i.e. version
+                            // prior to Windows 8 / Windows Server 2012), handle the exception
+                        }
+                    }
+                    socket.NoDelay = true;
                     socket.Connect(IPAddress.Loopback, 54321);
                     socket.Send(new byte[] { 6, 7, 8, 9 });
                     socket.Shutdown(SocketShutdown.Send);

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
@@ -87,38 +87,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 tcp2.Dispose();
                 stream.Dispose();
             }, null);
-            var t = Task.Run(async () =>
+            var t = Task.Run(() =>
             {
-                var socket = new Socket(
-                    AddressFamily.InterNetwork,
-                    SocketType.Stream,
-                    ProtocolType.Tcp);
-                if (PlatformApis.IsWindows)
-                {
-                    const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
-                    var optionInValue = BitConverter.GetBytes(1);
-                    try
-                    {
-                        socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
-                    }
-                    catch
-                    {
-                        // If the operating system version on this machine did
-                        // not support SIO_LOOPBACK_FAST_PATH (i.e. version
-                        // prior to Windows 8 / Windows Server 2012), handle the exception
-                    }
-                }
-                socket.NoDelay = true;
-#if DNX451
-                await Task.Factory.FromAsync(
-                    socket.BeginConnect,
-                    socket.EndConnect,
-                    new IPEndPoint(IPAddress.Loopback, port),
-                    null,
-                    TaskCreationOptions.None);
-#else
-                await socket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, port));
-#endif
+                var socket = TestConnection.CreateConnectedLoopbackSocket(port);
                 socket.Dispose();
             });
             loop.Run();
@@ -159,33 +130,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Console.WriteLine("Task.Run");
             var t = Task.Run(async () =>
             {
-                var socket = new Socket(
-                    AddressFamily.InterNetwork,
-                    SocketType.Stream,
-                    ProtocolType.Tcp);
-                if (PlatformApis.IsWindows)
-                {
-                    const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
-                    var optionInValue = BitConverter.GetBytes(1);
-                    try
-                    {
-                        socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
-                    }
-                    catch
-                    {
-                        // If the operating system version on this machine did
-                        // not support SIO_LOOPBACK_FAST_PATH (i.e. version
-                        // prior to Windows 8 / Windows Server 2012), handle the exception
-                    }
-                }
-                socket.NoDelay = true;
+                var socket = TestConnection.CreateConnectedLoopbackSocket(port);
 #if DNX451
-                await Task.Factory.FromAsync(
-                    socket.BeginConnect,
-                    socket.EndConnect,
-                    new IPEndPoint(IPAddress.Loopback, port),
-                    null,
-                    TaskCreationOptions.None);
                 await Task.Factory.FromAsync(
                     socket.BeginSend,
                     socket.EndSend,
@@ -194,7 +140,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     null,
                     TaskCreationOptions.None);
 #else
-                await socket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, port));
                 await socket.SendAsync(new[] { new ArraySegment<byte>(new byte[] { 1, 2, 3, 4, 5 }) },
                                        SocketFlags.None);
 #endif
@@ -262,33 +207,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Console.WriteLine("Task.Run");
             var t = Task.Run(async () =>
             {
-                var socket = new Socket(
-                    AddressFamily.InterNetwork,
-                    SocketType.Stream,
-                    ProtocolType.Tcp);
-                if (PlatformApis.IsWindows)
-                {
-                    const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
-                    var optionInValue = BitConverter.GetBytes(1);
-                    try
-                    {
-                        socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
-                    }
-                    catch
-                    {
-                        // If the operating system version on this machine did
-                        // not support SIO_LOOPBACK_FAST_PATH (i.e. version
-                        // prior to Windows 8 / Windows Server 2012), handle the exception
-                    }
-                }
-                socket.NoDelay = true;
+                var socket = TestConnection.CreateConnectedLoopbackSocket(port);
 #if DNX451
-                await Task.Factory.FromAsync(
-                    socket.BeginConnect,
-                    socket.EndConnect,
-                    new IPEndPoint(IPAddress.Loopback, port),
-                    null,
-                    TaskCreationOptions.None);
                 await Task.Factory.FromAsync(
                     socket.BeginSend,
                     socket.EndSend,
@@ -297,7 +217,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     null,
                     TaskCreationOptions.None);
 #else
-                await socket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, port));
                 await socket.SendAsync(new[] { new ArraySegment<byte>(new byte[] { 1, 2, 3, 4, 5 }) },
                                        SocketFlags.None);
 #endif

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
@@ -93,6 +93,22 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     AddressFamily.InterNetwork,
                     SocketType.Stream,
                     ProtocolType.Tcp);
+                if (PlatformApis.IsWindows)
+                {
+                    const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
+                    var optionInValue = BitConverter.GetBytes(1);
+                    try
+                    {
+                        socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
+                    }
+                    catch
+                    {
+                        // If the operating system version on this machine did
+                        // not support SIO_LOOPBACK_FAST_PATH (i.e. version
+                        // prior to Windows 8 / Windows Server 2012), handle the exception
+                    }
+                }
+                socket.NoDelay = true;
 #if DNX451
                 await Task.Factory.FromAsync(
                     socket.BeginConnect,
@@ -147,6 +163,22 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     AddressFamily.InterNetwork,
                     SocketType.Stream,
                     ProtocolType.Tcp);
+                if (PlatformApis.IsWindows)
+                {
+                    const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
+                    var optionInValue = BitConverter.GetBytes(1);
+                    try
+                    {
+                        socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
+                    }
+                    catch
+                    {
+                        // If the operating system version on this machine did
+                        // not support SIO_LOOPBACK_FAST_PATH (i.e. version
+                        // prior to Windows 8 / Windows Server 2012), handle the exception
+                    }
+                }
+                socket.NoDelay = true;
 #if DNX451
                 await Task.Factory.FromAsync(
                     socket.BeginConnect,
@@ -234,6 +266,22 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     AddressFamily.InterNetwork,
                     SocketType.Stream,
                     ProtocolType.Tcp);
+                if (PlatformApis.IsWindows)
+                {
+                    const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
+                    var optionInValue = BitConverter.GetBytes(1);
+                    try
+                    {
+                        socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
+                    }
+                    catch
+                    {
+                        // If the operating system version on this machine did
+                        // not support SIO_LOOPBACK_FAST_PATH (i.e. version
+                        // prior to Windows 8 / Windows Server 2012), handle the exception
+                    }
+                }
+                socket.NoDelay = true;
 #if DNX451
                 await Task.Factory.FromAsync(
                     socket.BeginConnect,

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestConnection.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Networking;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -29,6 +30,22 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void Create(int port)
         {
             _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            if (PlatformApis.IsWindows)
+            {
+                const int SIO_LOOPBACK_FAST_PATH = (-1744830448);
+                var optionInValue = BitConverter.GetBytes(1);
+                try
+                {
+                    _socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
+                }
+                catch
+                {
+                    // If the operating system version on this machine did
+                    // not support SIO_LOOPBACK_FAST_PATH (i.e. version
+                    // prior to Windows 8 / Windows Server 2012), handle the exception
+                }
+            }
+            _socket.NoDelay = true;
             _socket.Connect(new IPEndPoint(IPAddress.Loopback, port));
 
             _stream = new NetworkStream(_socket, false);


### PR DESCRIPTION
Enable TCP Loopback Fast Path; where the IP layer is skipped, for lower latency for localhost comms. For example when fronted by the HttpPlatformHandler+IIS reverse proxy

TCP Loopback Fast Path reference: http://blogs.technet.com/b/wincat/archive/2012/12/05/fast-tcp-loopback-performance-and-low-latency-with-windows-server-2012-tcp-loopback-fast-path.aspx

Recommended work around for open issue in libuv *"Enable Fast TCP Loopback on Win"* libuv/libuv#489

Related: *"Confirm HttpPlatformHandler uses Fast TCP Loopback"* aspnet/IISIntegration#29

Resolves #420