### PR TITLE
Don't throw exception out of threadpool

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -114,11 +114,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             {
                 // Frame.Abort calls user code while this method is always
                 // called from a libuv thread.
-                ThreadPool.QueueUserWorkItem(state =>
-                {
-                    var connection = (Connection)this;
-                    connection._frame.Abort();
-                }, this);
+                TaskUtilities.AbortOnThreadPool(_frame);
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
@@ -128,7 +128,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             if (awaitableState != _awaitableIsCompleted &&
                 awaitableState != _awaitableIsNotCompleted)
             {
-                ThreadPool.QueueUserWorkItem((o) => ((Action)o)(), awaitableState);
+                TaskUtilities.RunOnThreadPool(awaitableState);
             }
         }
 
@@ -210,7 +210,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             }
             else if (awaitableState == _awaitableIsCompleted)
             {
-                ThreadPool.QueueUserWorkItem((o) => ((Action)o)(), continuation);
+                TaskUtilities.RunOnThreadPool(continuation);
             }
             else
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
@@ -224,16 +224,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                     if (_lastWriteError == null)
                     {
-                        ThreadPool.QueueUserWorkItem(
-                            (o) => ((TaskCompletionSource<object>)o).SetResult(null), 
-                            tcs);
+                        TaskUtilities.CompleteOnThreadPool(tcs);
                     }
                     else
                     {
-                        // error is closure captured 
-                        ThreadPool.QueueUserWorkItem(
-                            (o) => ((TaskCompletionSource<object>)o).SetException(_lastWriteError), 
-                            tcs);
+                        TaskUtilities.ErrorOnThreadPool(tcs, _lastWriteError);
                     }
                 }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/TaskUtilities.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/TaskUtilities.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel.Http;
 
 namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 {
@@ -12,5 +15,72 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 #else
         public static Task CompletedTask = Task.FromResult<object>(null);
 #endif
+
+        private static WaitCallback _runAction = (o) =>
+        {
+            try
+            {
+                ((Action)o)();
+            }
+            catch (Exception)
+            {
+                // log with a static logger in some way?
+            }
+        };
+
+        private static WaitCallback _completeTcs = (o) =>
+        {
+            try
+            {
+                ((TaskCompletionSource<object>)o).SetResult(null);
+            }
+            catch (Exception)
+            {
+                // log with a static logger in some way?
+            }
+        };
+
+        private static WaitCallback _abortFrame = (o) =>
+        {
+            try
+            {
+                ((Frame)o).Abort();
+            }
+            catch (Exception)
+            {
+                // log with a static logger in some way?
+            }
+        };
+
+        public static void RunOnThreadPool(Action action)
+        {
+            ThreadPool.QueueUserWorkItem(_runAction, action);
+        }
+
+        public static void CompleteOnThreadPool(TaskCompletionSource<object> tcs)
+        {
+            ThreadPool.QueueUserWorkItem(_completeTcs, tcs);
+        }
+
+        public static void ErrorOnThreadPool(TaskCompletionSource<object> tcs, Exception ex)
+        {
+            // ex is closure captured 
+            ThreadPool.QueueUserWorkItem((o) =>
+            {
+                try
+                {
+                    ((TaskCompletionSource<object>)o).SetException(ex);
+                }
+                catch (Exception)
+                {
+                    // log with a static logger in some way?
+                }
+            }, tcs);
+        }
+
+        public static void AbortOnThreadPool(Frame frame)
+        {
+            ThreadPool.QueueUserWorkItem(_abortFrame, frame);
+        }
     }
 }


### PR DESCRIPTION
Would like to log with logger in the catches but would need to be with a static var to not allocate. Suggestions?

/cc @davidfowl 