### PR TITLE
Micro optimizations

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel.Https/ClientCertificateMode.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel.Https/ClientCertificateMode.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNet.Server.Kestrel.Https
 {
-    public enum ClientCertificateMode
+    public enum ClientCertificateMode : byte
     {
         NoCertificate,
         AllowCertificate,

--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/LibuvStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/LibuvStream.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Server.Kestrel.Http;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Filter
 {
@@ -68,30 +69,21 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            ArraySegment<byte> segment;
-            if (buffer != null)
+            if (buffer?.Length > 0)
             {
-                segment = new ArraySegment<byte>(buffer, offset, count);
+                _output.Write(new ArraySegment<byte>(buffer, offset, count));
             }
-            else
-            {
-                segment = default(ArraySegment<byte>);
-            }
-            _output.Write(segment);
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token)
         {
-            ArraySegment<byte> segment;
-            if (buffer != null)
+            if (buffer?.Length > 0)
             {
-                segment = new ArraySegment<byte>(buffer, offset, count);
+                var segment = new ArraySegment<byte>(buffer, offset, count);
+                return _output.WriteAsync(segment, cancellationToken: token);
             }
-            else
-            {
-                segment = default(ArraySegment<byte>);
-            }
-            return _output.WriteAsync(segment, cancellationToken: token);
+
+            return TaskUtilities.CompletedTask;
         }
 
         public override void Flush()

--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/SocketInputStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/SocketInputStream.cs
@@ -74,11 +74,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            var inputBuffer = _socketInput.IncomingStart(count);
+            if (buffer?.Length > 0)
+            {
+                var inputBuffer = _socketInput.IncomingStart(count);
 
-            Buffer.BlockCopy(buffer, offset, inputBuffer.Data.Array, inputBuffer.Data.Offset, count);
+                Buffer.BlockCopy(buffer, offset, inputBuffer.Data.Array, inputBuffer.Data.Offset, count);
 
-            _socketInput.IncomingComplete(count, error: null);
+                _socketInput.IncomingComplete(count, error: null);
+            }
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token)

--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamSocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamSocketOutput.cs
@@ -24,13 +24,20 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
 
         void ISocketOutput.Write(ArraySegment<byte> buffer, bool immediate)
         {
-            _outputStream.Write(buffer.Array, buffer.Offset, buffer.Count);
+            if (buffer.Count > 0)
+            {
+                _outputStream.Write(buffer.Array, buffer.Offset, buffer.Count);
+            }
         }
 
         Task ISocketOutput.WriteAsync(ArraySegment<byte> buffer, bool immediate, CancellationToken cancellationToken)
         {
-            // TODO: Use _outputStream.WriteAsync
-            _outputStream.Write(buffer.Array, buffer.Offset, buffer.Count);
+            if (buffer.Count > 0)
+            {
+                // TODO: Use _outputStream.WriteAsync
+                _outputStream.Write(buffer.Array, buffer.Offset, buffer.Count);
+            }
+
             return TaskUtilities.CompletedTask;
         }
 
@@ -45,7 +52,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
             var block = _producingBlock;
             while (block != end.Block)
             {
-                _outputStream.Write(block.Data.Array, block.Data.Offset, block.Data.Count);
+                if (block.Data.Count > 0)
+                {
+                    _outputStream.Write(block.Data.Array, block.Data.Offset, block.Data.Count);
+                }
 
                 var returnBlock = block;
                 block = block.Next;

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Connection.cs
@@ -238,7 +238,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             }
         }
 
-        private enum ConnectionState
+        private enum ConnectionState : byte
         {
             Open,
             Shutdown,

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -900,11 +900,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             Log.ApplicationError(ex);
         }
 
-        private enum HttpVersionType
+        private enum HttpVersionType : byte
         {
-            Unknown = -1,
-            Http1_0 = 0,
-            Http1_1 = 1
+            Unknown,
+            Http1_0,
+            Http1_1
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -685,7 +685,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
             if (immediate)
             {
-                return SocketOutput.WriteAsync(default(ArraySegment<byte>), immediate: true);
+                return SocketOutput.WriteAsync(_emptyData, immediate: true);
             }
             else
             {

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameDuplexStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameDuplexStream.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
@@ -160,7 +161,12 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return _responseStream.WriteAsync(buffer, offset, count, cancellationToken);
+            if (buffer?.Length > 0)
+            {
+                return _responseStream.WriteAsync(buffer, offset, count, cancellationToken);
+            }
+
+            return TaskUtilities.CompletedTask;
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -185,7 +191,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            _responseStream.Write(buffer, offset, count);
+            if (buffer?.Length > 0)
+            {
+                _responseStream.Write(buffer, offset, count);
+            }
         }
 
         public override void WriteByte(byte value)

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/MessageBody.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/MessageBody.cs
@@ -356,7 +356,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 }
             }
 
-            private enum Mode
+            private enum Mode : byte
             {
                 ChunkPrefix,
                 ChunkData,

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ProduceEndType.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ProduceEndType.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
 {
-    public enum ProduceEndType
+    public enum ProduceEndType : byte
     {
         SocketShutdownSend,
         SocketDisconnect,

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         private const int _initialTaskQueues = 64;
 
         private static WaitCallback _returnBlocks = (state) => ReturnBlocks((MemoryPoolBlock2)state);
+        private static readonly ArraySegment<byte> _emptyData = new ArraySegment<byte>(new byte[0]);
 
         private readonly KestrelThread _thread;
         private readonly UvStreamHandle _socket;
@@ -144,13 +145,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             switch (endType)
             {
                 case ProduceEndType.SocketShutdownSend:
-                    WriteAsync(default(ArraySegment<byte>),
+                    WriteAsync(_emptyData,
                         immediate: true,
                         socketShutdownSend: true,
                         socketDisconnect: false);
                     break;
                 case ProduceEndType.SocketDisconnect:
-                    WriteAsync(default(ArraySegment<byte>),
+                    WriteAsync(_emptyData,
                         immediate: true,
                         socketShutdownSend: false,
                         socketDisconnect: true);

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/Libuv.cs
@@ -441,9 +441,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
         }
 
-        public enum HandleType
+        public enum HandleType : byte
         {
-            Unknown = 0,
+            Unknown,
             ASYNC,
             CHECK,
             FS_EVENT,
@@ -462,9 +462,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             SIGNAL,
         }
 
-        public enum RequestType
+        public enum RequestType : byte
         {
-            Unknown = 0,
+            Unknown,
             REQ,
             CONNECT,
             WRITE,

--- a/tools/Microsoft.StandardsPolice/StandardsPoliceCompileModule.cs
+++ b/tools/Microsoft.StandardsPolice/StandardsPoliceCompileModule.cs
@@ -277,7 +277,7 @@ namespace Microsoft.StandardsPolice
         {
         }
 
-        private enum ClassZone
+        private enum ClassZone : byte
         {
             Ignored,
             BeforeStart,


### PR DESCRIPTION
I was playing around with Kestrel a little bit and decided to take a look at the code. I couldn't build in VS 2015 (Not using Update 1 RC), but could build via the command line. Please give me feedback on anything I could change or update. It's a learning experience playing with libuv :)

* Enums use byte instead of int. This will need to be benchmarked, ints may preform better on some cpus.
* Fixed an issue where a new buffer was being created when it didn't need to be.
* Don't write to streams or do extra work (allocations) if we don't need to be.