### PR TITLE
[Testing] Combined Alloc PRs for testing

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -265,30 +265,17 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             try
             {
-                var terminated = false;
-                while (!terminated && !_requestProcessingStopping)
+                while (!_requestProcessingStopping)
                 {
                     _stringPool.MarkStart();
 
-                    while (!terminated && !_requestProcessingStopping && !TakeStartLine(SocketInput))
+                    if (!await ReadStartLineAsync() ||
+                        !await ReadHeadersAsync()) 
                     {
-                        terminated = SocketInput.RemoteIntakeFin;
-                        if (!terminated)
-                        {
-                            await SocketInput;
-                        }
+                        break;
                     }
 
-                    while (!terminated && !_requestProcessingStopping && !TakeMessageHeaders(SocketInput, _requestHeaders, _stringPool))
-                    {
-                        terminated = SocketInput.RemoteIntakeFin;
-                        if (!terminated)
-                        {
-                            await SocketInput;
-                        }
-                    }
-
-                    if (!terminated && !_requestProcessingStopping)
+                    if (!_requestProcessingStopping)
                     {
                         var messageBody = MessageBody.For(HttpVersion, _requestHeaders, this);
                         _keepAlive = messageBody.RequestKeepAlive;
@@ -341,7 +328,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                             _responseBody.StopAcceptingWrites();
                         }
 
-                        terminated = !_keepAlive;
+                        if (!_keepAlive)
+                        {
+                            break;
+                        }
                     }
 
                     Reset();
@@ -375,6 +365,62 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     Log.LogWarning("Connection shutdown abnormally", ex);
                 }
             }
+        }
+        private Task<bool> ReadStartLineAsync()
+        {
+            if (!_requestProcessingStopping && !TakeStartLine(SocketInput))
+            {
+                if (SocketInput.RemoteIntakeFin)
+                {
+                    return TaskUtilities.CompletedFalseTask;
+                };
+                return ReadStartLineAwaitAsync();
+            }
+            return TaskUtilities.CompletedTrueTask;
+        }
+
+        private async Task<bool> ReadStartLineAwaitAsync()
+        {
+            await SocketInput;
+
+            while (!_requestProcessingStopping && !TakeStartLine(SocketInput))
+            {
+                if (SocketInput.RemoteIntakeFin)
+                {
+                    return false;
+                };
+
+                await SocketInput;
+            }
+            return true;
+        }
+
+        private Task<bool> ReadHeadersAsync()
+        {
+            if (!_requestProcessingStopping && !TakeMessageHeaders(SocketInput, _requestHeaders, _stringPool))
+            {
+                if (SocketInput.RemoteIntakeFin)
+                {
+                    return TaskUtilities.CompletedFalseTask;
+                };
+                return ReadHeadersAwaitAsync();
+            }
+            return TaskUtilities.CompletedTrueTask;
+        }
+
+        private async Task<bool> ReadHeadersAwaitAsync()
+        {
+            await SocketInput;
+
+            while (!_requestProcessingStopping && !TakeMessageHeaders(SocketInput, _requestHeaders, _stringPool))
+            {
+                if (SocketInput.RemoteIntakeFin)
+                {
+                    return false;
+                };
+                await SocketInput;
+            }
+            return true;
         }
 
         public void OnStarting(Func<object, Task> callback, object state)

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -53,8 +53,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         private Task _requestProcessingTask;
         private volatile bool _requestProcessingStopping; // volatile, see: https://msdn.microsoft.com/en-us/library/x13ttww7.aspx
         private volatile bool _requestAborted;
-        private CancellationTokenSource _disconnectCts = new CancellationTokenSource();
-        private CancellationTokenSource _requestAbortCts;
+        private CancellationTokenSource _abortedCts;
+        private CancellationToken? _manuallySetRequestAbortToken;
 
         private FrameRequestStream _requestBody;
         private FrameResponseStream _responseBody;
@@ -137,8 +137,47 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public Stream DuplexStream { get; set; }
 
-        public CancellationToken RequestAborted { get; set; }
+        public CancellationToken RequestAborted
+        {
+            get
+            {
+                // If a request abort token was previously explicitly set, return it.
+                if (_manuallySetRequestAbortToken.HasValue)
+                    return _manuallySetRequestAbortToken.Value;
 
+                // Otherwise, get the abort CTS.  If we have one, which would mean that someone previously
+                // asked for the RequestAborted token, simply return its token.  If we don't,
+                // check to see whether we've already aborted, in which case just return an
+                // already canceled token.  Finally, force a source into existence if we still
+                // don't have one, and return its token.
+                var cts = _abortedCts;
+                return
+                    cts != null ? cts.Token :
+                    _requestAborted ? new CancellationToken(true) :
+                    RequestAbortedSource.Token;
+            }
+            set
+            {
+                // Set an abort token, overriding one we create internally.  This setter and associated
+                // field exist purely to support IHttpRequestLifetimeFeature.set_RequestAborted.
+                _manuallySetRequestAbortToken = value;
+            }
+        }
+
+        private CancellationTokenSource RequestAbortedSource
+        {
+            get
+            {
+                // Get the abort token, lazily-initializing it if necessary.
+                // Make sure it's canceled if an abort request already came in.
+                var cts = LazyInitializer.EnsureInitialized(ref _abortedCts, () => new CancellationTokenSource());
+                if (_requestAborted)
+                {
+                    cts.Cancel();
+                }
+                return cts;
+            }
+        }
         public bool HasResponseStarted
         {
             get { return _responseStarted; }
@@ -190,7 +229,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
             _prepareRequest?.Invoke(this);
 
-            _requestAbortCts?.Dispose();
+            _manuallySetRequestAbortToken = null;
+            _abortedCts = null;
         }
 
         public void ResetResponseHeaders()
@@ -246,12 +286,15 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             {
                 ConnectionControl.End(ProduceEndType.SocketDisconnect);
                 SocketInput.AbortAwaiting();
-
-                _disconnectCts.Cancel();
+                RequestAbortedSource.Cancel();
             }
             catch (Exception ex)
             {
                 Log.LogError("Abort", ex);
+            }
+            finally
+            {
+                _abortedCts = null;
             }
         }
 
@@ -285,8 +328,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                         ResponseBody = _responseBody;
                         DuplexStream = new FrameDuplexStream(RequestBody, ResponseBody);
 
-                        _requestAbortCts = CancellationTokenSource.CreateLinkedTokenSource(_disconnectCts.Token);
-                        RequestAborted = _requestAbortCts.Token;
+                        _abortedCts = null;
+                        _manuallySetRequestAbortToken = null;
 
                         var httpContext = HttpContextFactory.Create(this);
                         try
@@ -345,7 +388,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             {
                 try
                 {
-                    _disconnectCts.Dispose();
+                    _abortedCts = null;
 
                     // If _requestAborted is set, the connection has already been closed.
                     if (!_requestAborted)

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -24,10 +24,10 @@ namespace Microsoft.AspNet.Server.Kestrel
         private Thread _thread;
         private UvLoopHandle _loop;
         private UvAsyncHandle _post;
-        private Queue<Work> _workAdding = new Queue<Work>();
-        private Queue<Work> _workRunning = new Queue<Work>();
-        private Queue<CloseHandle> _closeHandleAdding = new Queue<CloseHandle>();
-        private Queue<CloseHandle> _closeHandleRunning = new Queue<CloseHandle>();
+        private Queue<Work> _workAdding = new Queue<Work>(1024);
+        private Queue<Work> _workRunning = new Queue<Work>(1024);
+        private Queue<CloseHandle> _closeHandleAdding = new Queue<CloseHandle>(256);
+        private Queue<CloseHandle> _closeHandleRunning = new Queue<CloseHandle>(256);
         private object _workSync = new Object();
         private bool _stopImmediate = false;
         private bool _initCompleted = false;

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/StringPool.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/StringPool.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
+{
+    public class StringPool
+    {
+        // x64 int array byte size (28 + length * 4) rounded up to 8 bytes
+        // x86 int array byte size (12 + length * 4) rounded up to 4 bytes
+        // Array of 31 ints is 2 consecutive cache lines on x64; second prefetched
+        private const int _maxCached = 31; 
+        private const int _maxCacheLength = 256;
+
+        private readonly uint[] _hashes = new uint[_maxCached];
+        private readonly int[] _lastUse = new int[_maxCached];
+        private readonly string[] _strings = new string[_maxCached];
+
+        private int _currentUse = 0;
+
+        public void MarkStart()
+        {
+            _currentUse++;
+        }
+
+        public unsafe string GetString(uint hash, char* data, int length)
+        {
+            if (length > _maxCacheLength)
+            {
+                return new string(data, 0, length);
+            }
+
+            int oldestEntry = int.MaxValue;
+            int oldestIndex = 0;
+
+            for (var i = 0; i < _maxCached; i++)
+            {
+                var usage = _lastUse[i];
+                if (oldestEntry > usage)
+                {
+                    oldestEntry = usage;
+                    oldestIndex = i;
+                }
+
+                if (hash == _hashes[i])
+                {
+                    var cachedString = _strings[i];
+                    if (cachedString.Length != length)
+                    {
+#if DEBUG
+                        Console.WriteLine($"{nameof(StringPool)} Collision differing lengths {cachedString.Length} and {length}");
+#endif
+                        continue;
+                    }
+
+                    fixed(char* cs = cachedString)
+                    {
+                        var cached = cs;
+                        var potential = data;
+
+                        var c = 0;
+                        var lengthMinusSpan = length - 3;
+                        for (; c < lengthMinusSpan; c += 4)
+                        {
+                            if(
+                                *(cached) != *(potential) ||
+                                *(cached + 1) != *(potential + 1) ||
+                                *(cached + 2) != *(potential + 2) ||
+                                *(cached + 3) != *(potential + 3)
+                            )
+                            {
+#if DEBUG
+                                Console.WriteLine($"{nameof(StringPool)} Collision same length, differing strings");
+#endif
+                                continue;
+                            }
+                            cached += 4;
+                            potential += 4;
+                        }
+                        for (; c < length; c++)
+                        {
+                            if (*(cached++) != *(potential++))
+                            {
+#if DEBUG
+                                Console.WriteLine($"{nameof(StringPool)} Collision same length, differing strings");
+#endif
+                                continue;
+                            }
+                        }
+                    }
+
+                    _lastUse[i] = _currentUse;
+                    // same string
+                    return cachedString;
+                }
+            }
+
+            var value = new string(data, 0, length);
+#if DEBUG
+            if (_lastUse[oldestIndex] != 0)
+            {
+                Console.WriteLine($"{nameof(StringPool)} Evict: {_strings[oldestIndex]} {_lastUse[oldestIndex]} {_hashes[oldestIndex]}");
+                Console.WriteLine($"{nameof(StringPool)} New: {value} {_currentUse} {hash}");
+            }
+#endif
+            _lastUse[oldestIndex] = _currentUse;
+            _hashes[oldestIndex] = hash;
+            _strings[oldestIndex] = value;
+
+            return value;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/TaskUtilities.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/TaskUtilities.cs
@@ -12,5 +12,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 #else
         public static Task CompletedTask = Task.FromResult<object>(null);
 #endif
+        public static Task<bool> CompletedTrueTask = Task.FromResult(true);
+        public static Task<bool> CompletedFalseTask = Task.FromResult(false);
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     /// </summary>
     public class UvWriteReq : UvRequest
     {
-        private readonly static Libuv.uv_write_cb _uv_write_cb = UvWriteCb;
+        private readonly static Libuv.uv_write_cb _uv_write_cb = (IntPtr ptr, int status) => UvWriteCb(ptr, status);
 
         private IntPtr _bufs;
 
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
         private object _state;
         private const int BUFFER_COUNT = 4;
 
-        private List<GCHandle> _pins = new List<GCHandle>();
+        private List<GCHandle> _pins = new List<GCHandle>(BUFFER_COUNT + 1);
 
         public UvWriteReq(IKestrelTrace logger) : base(logger)
         {

--- a/test/Microsoft.AspNet.Server.KestrelTests/AsciiDecoder.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/AsciiDecoder.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         private void FullByteRangeSupported()
         {
+            var stringPool = new StringPool();
             var byteRange = Enumerable.Range(0, 255).Select(x => (byte)x).ToArray();
 
             var mem = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, null);
@@ -21,7 +22,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
             var begin = mem.GetIterator();
             var end = GetIterator(begin, byteRange.Length);
 
-            var s = begin.GetAsciiString(end);
+            var s = begin.GetAsciiString(end, stringPool);
 
             Assert.Equal(s.Length, byteRange.Length);
 
@@ -37,6 +38,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         private void MultiBlockProducesCorrectResults()
         {
+            var stringPool = new StringPool();
             var byteRange = Enumerable.Range(0, 512 + 64).Select(x => (byte)x).ToArray();
             var expectedByteRange = byteRange
                                     .Concat(byteRange)
@@ -60,7 +62,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
             var begin = mem0.GetIterator();
             var end = GetIterator(begin, expectedByteRange.Length);
 
-            var s = begin.GetAsciiString(end);
+            var s = begin.GetAsciiString(end, stringPool);
 
             Assert.Equal(s.Length, expectedByteRange.Length);
 
@@ -76,6 +78,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         private void HeapAllocationProducesCorrectResults()
         {
+            var stringPool = new StringPool();
             var byteRange = Enumerable.Range(0, 16384 + 64).Select(x => (byte)x).ToArray();
             var expectedByteRange = byteRange.Concat(byteRange).ToArray();
 
@@ -89,7 +92,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
             var begin = mem0.GetIterator();
             var end = GetIterator(begin, expectedByteRange.Length);
 
-            var s = begin.GetAsciiString(end);
+            var s = begin.GetAsciiString(end, stringPool);
 
             Assert.Equal(s.Length, expectedByteRange.Length);
 

--- a/test/Microsoft.AspNet.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/FrameTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [InlineData("Connection:\r\n \r\nCookie \r\n", 1)]
         public void EmptyHeaderValuesCanBeParsed(string rawHeaders, int numHeaders)
         {
+            var stringPool = new StringPool();
             var socketInput = new SocketInput(new MemoryPool2());
             var headerCollection = new FrameRequestHeaders();
 
@@ -56,7 +57,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
             Buffer.BlockCopy(headerArray, 0, inputBuffer.Data.Array, inputBuffer.Data.Offset, headerArray.Length);
             socketInput.IncomingComplete(headerArray.Length, null);
 
-            var success = Frame.TakeMessageHeaders(socketInput, headerCollection);
+            var success = Frame.TakeMessageHeaders(socketInput, headerCollection, stringPool);
 
             Assert.True(success);
             Assert.Equal(numHeaders, headerCollection.Count());


### PR DESCRIPTION
PRs

#424 Improved RequestProcessingAsync legibility 
#411 [Proposal] Request header Stringpool
#408 Remove CreateLinkedTokenSource 
#363 Resuse writes, initalize queues 

Before 7,625,384 bytes used for 4k requests

![kestrel-before](http://aoa.blob.core.windows.net/aspnet/kestrel-before.png)

After 3,817,438 bytes used for 4k requests

![kestrel-after](http://aoa.blob.core.windows.net/aspnet/kestrel-after.png)

Down 3,807,946 bytes (~50% reduction)