### PR TITLE
Process cascaded work immediately

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -18,6 +18,11 @@ namespace Microsoft.AspNet.Server.Kestrel
     /// </summary>
     public class KestrelThread
     {
+        // maximum times the work queues swapped and are processed in a single pass
+        // as completing a task may immediately have write data to put on the network
+        // otherwise it needs to wait till the next pass of the libuv loop
+        private const int _maxLoops = 8;
+
         private static Action<object, object> _threadCallbackAdapter = (callback, state) => ((Action<KestrelThread>)callback).Invoke((KestrelThread)state);
         private KestrelEngine _engine;
         private readonly IApplicationLifetime _appLifetime;
@@ -249,11 +254,17 @@ namespace Microsoft.AspNet.Server.Kestrel
 
         private void OnPost()
         {
-            DoPostWork();
-            DoPostCloseHandle();
+            var loopsRemaining = _maxLoops;
+            bool wasWork;
+            do
+            {
+                wasWork = DoPostWork();
+                wasWork = DoPostCloseHandle() || wasWork;
+                loopsRemaining--;
+            } while (wasWork && loopsRemaining > 0);
         }
 
-        private void DoPostWork()
+        private bool DoPostWork()
         {
             Queue<Work> queue;
             lock (_workSync)
@@ -262,6 +273,9 @@ namespace Microsoft.AspNet.Server.Kestrel
                 _workAdding = _workRunning;
                 _workRunning = queue;
             }
+
+            bool wasWork = queue.Count > 0;
+
             while (queue.Count != 0)
             {
                 var work = queue.Dequeue();
@@ -286,8 +300,10 @@ namespace Microsoft.AspNet.Server.Kestrel
                     }
                 }
             }
+
+            return wasWork;
         }
-        private void DoPostCloseHandle()
+        private bool DoPostCloseHandle()
         {
             Queue<CloseHandle> queue;
             lock (_workSync)
@@ -296,6 +312,9 @@ namespace Microsoft.AspNet.Server.Kestrel
                 _closeHandleAdding = _closeHandleRunning;
                 _closeHandleRunning = queue;
             }
+
+            bool wasWork = queue.Count > 0;
+
             while (queue.Count != 0)
             {
                 var closeHandle = queue.Dequeue();
@@ -309,6 +328,8 @@ namespace Microsoft.AspNet.Server.Kestrel
                     throw;
                 }
             }
+
+            return wasWork; 
         }
 
         private struct Work


### PR DESCRIPTION
Without waiting for next libuv pass; due to it being added to the `_workAdding` buffer and having to wait to the next pass to move to the `_workRunning` buffer to be submitted; which will currently throttle writes to network and handle close speed.

This is to get the events into the libuv loop as early as possible as it determines its sleep time between loops based on pending work. Otherwise end up with a throttled message pump.

Fix for potential regression in #363 due to bug fix.