### PR TITLE
Empty buffer when null buffer

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamSocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamSocketOutput.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
 {
     public class StreamSocketOutput : ISocketOutput
     {
+        private static readonly byte[] _nullBuffer = new byte[0];
+
         private readonly Stream _outputStream;
         private readonly MemoryPool2 _memory;
         private MemoryPoolBlock2 _producingBlock;
@@ -24,13 +26,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
 
         void ISocketOutput.Write(ArraySegment<byte> buffer, bool immediate)
         {
-            _outputStream.Write(buffer.Array, buffer.Offset, buffer.Count);
+            _outputStream.Write(buffer.Array ?? _nullBuffer, buffer.Offset, buffer.Count);
         }
 
         Task ISocketOutput.WriteAsync(ArraySegment<byte> buffer, bool immediate, CancellationToken cancellationToken)
         {
             // TODO: Use _outputStream.WriteAsync
-            _outputStream.Write(buffer.Array, buffer.Offset, buffer.Count);
+            _outputStream.Write(buffer.Array ?? _nullBuffer, buffer.Offset, buffer.Count);
             return TaskUtilities.CompletedTask;
         }
 

--- a/test/Microsoft.AspNet.Server.KestrelTests/StreamSocketOutputTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/StreamSocketOutputTests.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.AspNet.Server.Kestrel.Filter;
+using Microsoft.AspNet.Server.Kestrel.Http;
+using Xunit;
+
+namespace Microsoft.AspNet.Server.KestrelTests
+{
+    public class StreamSocketOutputTests
+    {
+        [Fact]
+        public void DoesNotThrowForNullBuffers()
+        {
+            // This test was added because SslStream throws if passed null buffers with (count == 0)
+            // Which happens if ProduceEnd is called in Frame without _responseStarted == true
+            // As it calls ProduceStart with write immediate == true
+            // This happens in WebSocket Upgrade over SSL
+
+            ISocketOutput socketOutput = new StreamSocketOutput(new ThrowsOnNullWriteStream(), null);
+
+            // Should not throw
+            socketOutput.Write(default(ArraySegment<byte>), true);
+
+            Assert.True(true);
+        }
+
+        private class ThrowsOnNullWriteStream : Stream
+        {
+            public override bool CanRead
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override bool CanSeek
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override bool CanWrite
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override long Length
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override long Position
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+
+                set
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override void Flush()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                if (buffer == null)
+                {
+                    throw new ArgumentNullException(nameof(buffer));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves  #438

```
dbug: Microsoft.AspNet.Server.Kestrel[1]
      Connection id "1" started.
info: Microsoft.AspNet.Hosting.Internal.HostingEngine[1]
      Request starting HTTP/1.1 GET https://space.ageofascent.com/?&name=test-Ssl
dbug: Microsoft.AspNet.Server.Kestrel[6]
      Connection id "1" received FIN.
info: Microsoft.AspNet.Hosting.Internal.HostingEngine[2]
      Request finished in 340969ms 101
dbug: Microsoft.AspNet.Server.Kestrel[7]
      Connection id "1" sending FIN.
dbug: Microsoft.AspNet.Server.Kestrel[10]
      Connection id "1" disconnected.
dbug: Microsoft.AspNet.Server.Kestrel[8]
      Connection id "1" sent FIN with status "0".
dbug: Microsoft.AspNet.Server.Kestrel[2]
      Connection id "1" stopped.
```
vs the Exception thrown in  #438; Websocket comms then works fine over Ssl; tested for 5mins as shown above `Request finished in 340969ms 101`