### PR TITLE
Use pooled memory for Stream CopyToAsync

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/FilteredStreamAdapter.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/FilteredStreamAdapter.cs
@@ -28,7 +28,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
             _filteredStream = filteredStream;
             _socketInputStream = new SocketInputStream(SocketInput);
 
-            _filteredStream.CopyToAsync(_socketInputStream).ContinueWith((task, state) =>
+            // Don't use 81920 byte buffer
+            _filteredStream.CopyToAsync(_socketInputStream, 4096).ContinueWith((task, state) =>
             {
                 ((FilteredStreamAdapter)state).OnStreamClose(task);
             }, this);

--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamExtensions.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+
+namespace Microsoft.AspNet.Server.Kestrel.Filter
+{
+    public static class StreamExtensions
+    {
+        public static async Task<MemoryPoolBlock2> CopyToAsync(this Stream source, Stream destination, MemoryPoolBlock2 block)
+        {
+            int bytesRead;
+            while ((bytesRead = await source.ReadAsync(block.Array, block.Data.Offset, block.Data.Count)) != 0)
+            {
+                await destination.WriteAsync(block.Array, block.Data.Offset, bytesRead);
+            }
+
+            return block;
+        }
+    }
+}


### PR DESCRIPTION
Default buffer size Is crazy large (82kB); and as is used for lifetime of connection; per connection - likely ends up in Gen2

(Ref https://github.com/dotnet/coreclr/issues/2223)