### PR TITLE
Use ValueTask

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -20,7 +20,8 @@
     "Microsoft.AspNet.Internal.libuv-Windows": {
       "version": "1.0.0-*",
       "type": "build"
-    }
+    },
+    "System.Threading.Tasks.Extensions": "4.0.0-*"
   },
   "frameworks": {
     "dnx451": { },


### PR DESCRIPTION
For lighter async and sync reads when already completed synchronously 

+2.6% RPS (Variable)

Before
> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.99ms   16.43ms 298.51ms   97.60%
    Req/Sec    65.03k     7.15k  214.14k    85.26%
  60288749 requests in 30.10s, 7.41GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 2002987.40
Transfer/sec:    252.15MB

After 
> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.42ms   19.18ms 640.49ms   96.76%
    Req/Sec    64.64k    11.13k  162.59k    89.40%
  61826961 requests in 30.06s, 7.60GB read
  Socket errors: connect 35, read 0, write 0, timeout 27
Requests/sec: 2056488.77
Transfer/sec:    258.88MB