### PR TITLE
[Proposal] Reduce contention

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
@@ -170,12 +170,21 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                         _awaitableIsCompleted);
                 }
             }
-            while (returnStart != returnEnd)
+
+            if  (returnStart == returnEnd)
             {
-                var returnBlock = returnStart;
-                returnStart = returnStart.Next;
-                returnBlock.Pool?.Return(returnBlock);
+                return;
             }
+
+            // detach returned block chain from active block
+            var block = returnStart;
+            while (block.Next != returnEnd)
+            {
+                block = block.Next;
+            }
+            block.Next = null;
+
+            _threadPool.ReturnBlockChain(returnStart);
         }
 
         public void AbortAwaiting()

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
@@ -21,8 +21,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         private const int _initialTaskQueues = 64;
         private const int _maxPooledWriteContexts = 32;
 
-        private static WaitCallback _returnBlocks = (state) => ReturnBlocks((MemoryPoolBlock2)state);
-
         private readonly KestrelThread _thread;
         private readonly UvStreamHandle _socket;
         private readonly Connection _connection;
@@ -231,18 +229,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
             if (blockToReturn != null)
             {
-                ThreadPool.QueueUserWorkItem(_returnBlocks, blockToReturn);
-            }
-        }
-
-        private static void ReturnBlocks(MemoryPoolBlock2 block)
-        {
-            while (block != null)
-            {
-                var returningBlock = block;
-                block = returningBlock.Next;
-
-                returningBlock.Pool?.Return(returningBlock);
+                _threadPool.ReturnBlockChain(blockToReturn);
             }
         }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/IThreadPool.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/IThreadPool.cs
@@ -11,5 +11,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         void Complete(TaskCompletionSource<object> tcs);
         void Error(TaskCompletionSource<object> tcs, Exception ex);
         void Run(Action action);
+        void ReturnBlockChain(MemoryPoolBlock2 startBlock);
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/LoggingThreadPool.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/LoggingThreadPool.cs
@@ -74,7 +74,10 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 
         public void ReturnBlockChain(MemoryPoolBlock2 startBlock)
         {
-            ThreadPool.QueueUserWorkItem(_returnBlocks, startBlock);
+            if (startBlock != null)
+            {
+                ThreadPool.QueueUserWorkItem(_returnBlocks, startBlock);
+            }
         }
 
         private static void ReturnBlocks(MemoryPoolBlock2 block)

--- a/test/Microsoft.AspNet.Server.KestrelTests/AsciiDecoder.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/AsciiDecoder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             var byteRange = Enumerable.Range(0, 255).Select(x => (byte)x).ToArray();
 
-            var mem = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, null);
+            var mem = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, -1);
             mem.End = byteRange.Length;
 
             var begin = mem.GetIterator();
@@ -44,10 +44,10 @@ namespace Microsoft.AspNet.Server.KestrelTests
                                     .Concat(byteRange)
                                     .ToArray();
 
-            var mem0 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, null);
-            var mem1 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, null);
-            var mem2 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, null);
-            var mem3 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, null);
+            var mem0 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, -1);
+            var mem1 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, -1);
+            var mem2 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, -1);
+            var mem3 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, -1);
             mem0.End = byteRange.Length;
             mem1.End = byteRange.Length;
             mem2.End = byteRange.Length;
@@ -79,8 +79,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             var byteRange = Enumerable.Range(0, 16384 + 64).Select(x => (byte)x).ToArray();
             var expectedByteRange = byteRange.Concat(byteRange).ToArray();
 
-            var mem0 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, null);
-            var mem1 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, null);
+            var mem0 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, -1);
+            var mem1 = MemoryPoolBlock2.Create(new ArraySegment<byte>(byteRange), IntPtr.Zero, null, -1);
             mem0.End = byteRange.Length;
             mem1.End = byteRange.Length;
 

--- a/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolBlock2Tests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolBlock2Tests.cs
@@ -10,58 +10,54 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void SeekWorks()
         {
-            using (var pool = new MemoryPool2())
+            var pool = new MemoryPool2();
+            var block = pool.Lease(256);
+            foreach (var ch in Enumerable.Range(0, 256).Select(x => (byte)x))
             {
-                var block = pool.Lease(256);
-                foreach (var ch in Enumerable.Range(0, 256).Select(x => (byte)x))
-                {
-                    block.Array[block.End++] = ch;
-                }
-                var iterator = block.GetIterator();
-                foreach (var ch in Enumerable.Range(0, 256).Select(x => (char)x))
-                {
-                    var hit = iterator;
-                    hit.Seek(ch);
-                    Assert.Equal(ch, iterator.GetLength(hit));
+                block.Array[block.End++] = ch;
+            }
+            var iterator = block.GetIterator();
+            foreach (var ch in Enumerable.Range(0, 256).Select(x => (char)x))
+            {
+                var hit = iterator;
+                hit.Seek(ch);
+                Assert.Equal(ch, iterator.GetLength(hit));
 
-                    hit = iterator;
-                    hit.Seek(ch, byte.MaxValue);
-                    Assert.Equal(ch, iterator.GetLength(hit));
+                hit = iterator;
+                hit.Seek(ch, byte.MaxValue);
+                Assert.Equal(ch, iterator.GetLength(hit));
 
-                    hit = iterator;
-                    hit.Seek(byte.MaxValue, ch);
-                    Assert.Equal(ch, iterator.GetLength(hit));
-                }
+                hit = iterator;
+                hit.Seek(byte.MaxValue, ch);
+                Assert.Equal(ch, iterator.GetLength(hit));
             }
         }
 
         [Fact]
         public void GetLengthBetweenIteratorsWorks()
         {
-            using (var pool = new MemoryPool2())
+            var pool = new MemoryPool2();
+            var block = pool.Lease(256);
+            block.End += 256;
+            TestAllLengths(block, 256);
+            pool.Return(block);
+            block = null;
+
+            for (var fragment = 0; fragment < 256; fragment += 4)
             {
-                var block = pool.Lease(256);
-                block.End += 256;
-                TestAllLengths(block, 256);
+                var next = block;
+                block = pool.Lease(4);
+                block.Next = next;
+                block.End += 4;
+            }
+
+            TestAllLengths(block, 256);
+
+            while(block != null)
+            {
+                var next = block.Next;
                 pool.Return(block);
-                block = null;
-
-                for (var fragment = 0; fragment < 256; fragment += 4)
-                {
-                    var next = block;
-                    block = pool.Lease(4);
-                    block.Next = next;
-                    block.End += 4;
-                }
-
-                TestAllLengths(block, 256);
-
-                while(block != null)
-                {
-                    var next = block.Next;
-                    pool.Return(block);
-                    block = next;
-                }
+                block = next;
             }
         }
 
@@ -83,131 +79,123 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void AddDoesNotAdvanceAtEndOfCurrentBlock()
         {
-            using (var pool = new MemoryPool2())
-            {
-                var block1 = pool.Lease(256);
-                var block2 = block1.Next = pool.Lease(256);
+            var pool = new MemoryPool2();
+            var block1 = pool.Lease(256);
+            var block2 = block1.Next = pool.Lease(256);
 
-                block1.End += 100;
-                block2.End += 200;
+            block1.End += 100;
+            block2.End += 200;
 
-                var iter0 = block1.GetIterator();
-                var iter100 = iter0.Add(100);
+            var iter0 = block1.GetIterator();
+            var iter100 = iter0.Add(100);
 
-                var iter200a = iter0.Add(200);
-                var iter200b = iter100.Add(100);
+            var iter200a = iter0.Add(200);
+            var iter200b = iter100.Add(100);
 
-                var iter300a = iter0.Add(300);
-                var iter300b = iter100.Add(200);
-                var iter300c = iter200a.Add(100);
+            var iter300a = iter0.Add(300);
+            var iter300b = iter100.Add(200);
+            var iter300c = iter200a.Add(100);
 
-                var iter300a2 = iter300a.Add(1);
-                var iter300b2 = iter300b.Add(1);
-                var iter300c2 = iter300c.Add(1);
+            var iter300a2 = iter300a.Add(1);
+            var iter300b2 = iter300b.Add(1);
+            var iter300c2 = iter300c.Add(1);
 
-                AssertIterator(iter0, block1, block1.Start);
-                AssertIterator(iter100, block1, block1.End);
-                AssertIterator(iter200a, block2, block2.Start+100);
-                AssertIterator(iter200b, block2, block2.Start + 100);
-                AssertIterator(iter300a, block2, block2.End);
-                AssertIterator(iter300b, block2, block2.End);
-                AssertIterator(iter300c, block2, block2.End);
-                AssertIterator(iter300a2, block2, block2.End);
-                AssertIterator(iter300b2, block2, block2.End);
-                AssertIterator(iter300c2, block2, block2.End);
-            }
+            AssertIterator(iter0, block1, block1.Start);
+            AssertIterator(iter100, block1, block1.End);
+            AssertIterator(iter200a, block2, block2.Start+100);
+            AssertIterator(iter200b, block2, block2.Start + 100);
+            AssertIterator(iter300a, block2, block2.End);
+            AssertIterator(iter300b, block2, block2.End);
+            AssertIterator(iter300c, block2, block2.End);
+            AssertIterator(iter300a2, block2, block2.End);
+            AssertIterator(iter300b2, block2, block2.End);
+            AssertIterator(iter300c2, block2, block2.End);
         }
 
         [Fact]
         public void CopyToCorrectlyTraversesBlocks()
         {
-            using (var pool = new MemoryPool2())
+            var pool = new MemoryPool2();
+            var block1 = pool.Lease(128);
+            var block2 = block1.Next = pool.Lease(128);
+
+            for (int i = 0; i < 128; i++)
             {
-                var block1 = pool.Lease(128);
-                var block2 = block1.Next = pool.Lease(128);
-
-                for (int i = 0; i < 128; i++)
-                {
-                    block1.Array[block1.End++] = (byte)i;
-                }
-                for (int i = 128; i < 256; i++)
-                {
-                    block2.Array[block2.End++] = (byte)i;
-                }
-
-                var beginIterator = block1.GetIterator();
-                
-                var array = new byte[256];
-                int actual;
-                var endIterator = beginIterator.CopyTo(array, 0, 256, out actual);
-
-                Assert.Equal(256, actual);
-
-                for (int i = 0; i < 256; i++)
-                {
-                    Assert.Equal(i, array[i]);
-                }
-
-                endIterator.CopyTo(array, 0, 256, out actual);
-                Assert.Equal(0, actual);
+                block1.Array[block1.End++] = (byte)i;
             }
+            for (int i = 128; i < 256; i++)
+            {
+                block2.Array[block2.End++] = (byte)i;
+            }
+
+            var beginIterator = block1.GetIterator();
+                
+            var array = new byte[256];
+            int actual;
+            var endIterator = beginIterator.CopyTo(array, 0, 256, out actual);
+
+            Assert.Equal(256, actual);
+
+            for (int i = 0; i < 256; i++)
+            {
+                Assert.Equal(i, array[i]);
+            }
+
+            endIterator.CopyTo(array, 0, 256, out actual);
+            Assert.Equal(0, actual);
         }
 
         [Fact]
         public void CopyFromCorrectlyTraversesBlocks()
         {
-            using (var pool = new MemoryPool2())
+            var pool = new MemoryPool2();
+            var block1 = pool.Lease(128);
+            var start = block1.GetIterator();
+            var end = start;
+            var bufferSize = block1.Data.Count * 3;
+            var buffer = new byte[bufferSize];
+
+            for (int i = 0; i < bufferSize; i++)
             {
-                var block1 = pool.Lease(128);
-                var start = block1.GetIterator();
-                var end = start;
-                var bufferSize = block1.Data.Count * 3;
-                var buffer = new byte[bufferSize];
-
-                for (int i = 0; i < bufferSize; i++)
-                {
-                    buffer[i] = (byte)(i % 73);
-                }
-
-                Assert.Null(block1.Next);
-
-                end.CopyFrom(new ArraySegment<byte>(buffer));
-
-                Assert.NotNull(block1.Next);
-
-                for (int i = 0; i < bufferSize; i++)
-                {
-                    Assert.Equal(i % 73, start.Take());
-                }
-
-                Assert.Equal(-1, start.Take());
-                Assert.Equal(start.Block, end.Block);
-                Assert.Equal(start.Index, end.Index);
+                buffer[i] = (byte)(i % 73);
             }
+
+            Assert.Null(block1.Next);
+
+            end.CopyFrom(new ArraySegment<byte>(buffer));
+
+            Assert.NotNull(block1.Next);
+
+            for (int i = 0; i < bufferSize; i++)
+            {
+                Assert.Equal(i % 73, start.Take());
+            }
+
+            Assert.Equal(-1, start.Take());
+            Assert.Equal(start.Block, end.Block);
+            Assert.Equal(start.Index, end.Index);
         }
 
         [Fact]
         public void IsEndCorrectlyTraversesBlocks()
         {
-            using (var pool = new MemoryPool2())
-            {
-                var block1 = pool.Lease(128);
-                var block2 = block1.Next = pool.Lease(128);
-                var block3 = block2.Next = pool.Lease(128);
-                var block4 = block3.Next = pool.Lease(128);
+            var pool = new MemoryPool2();
+            var block1 = pool.Lease(128);
+            var block2 = block1.Next = pool.Lease(128);
+            var block3 = block2.Next = pool.Lease(128);
+            var block4 = block3.Next = pool.Lease(128);
 
-                // There is no data in block2 or block4, so IsEnd should be true after 256 bytes are read.
-                block1.End += 128;
-                block3.End += 128;
+            // There is no data in block2 or block4, so IsEnd should be true after 256 bytes are read.
+            block1.End += 128;
+            block3.End += 128;
 
-                var iterStart = block1.GetIterator();
-                var iterMid = iterStart.Add(128);
-                var iterEnd = iterMid.Add(128);
+            var iterStart = block1.GetIterator();
+            var iterMid = iterStart.Add(128);
+            var iterEnd = iterMid.Add(128);
 
-                Assert.False(iterStart.IsEnd);
-                Assert.False(iterMid.IsEnd);
-                Assert.True(iterEnd.IsEnd);
-            }
+            Assert.False(iterStart.IsEnd);
+            Assert.False(iterMid.IsEnd);
+            Assert.True(iterEnd.IsEnd);
         }
 
         private void AssertIterator(MemoryPoolIterator2 iter, MemoryPoolBlock2 block, int index)

--- a/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolIterator2Tests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolIterator2Tests.cs
@@ -5,18 +5,13 @@ using Xunit;
 
 namespace Microsoft.AspNet.Server.KestrelTests
 {
-    public class MemoryPoolIterator2Tests : IDisposable
+    public class MemoryPoolIterator2Tests
     {
         private readonly MemoryPool2 _pool;
 
         public MemoryPoolIterator2Tests()
         {
             _pool = new MemoryPool2();
-        }
-
-        public void Dispose()
-        {
-            _pool.Dispose();
         }
 
         [Theory]

--- a/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                     new ArraySegment<byte>(new byte[] { 1, 2, 3, 4 }),
                     dataPtr: IntPtr.Zero,
                     pool: null,
-                    slab: null);
+                    slabId: -1);
                 var start = new MemoryPoolIterator2(block, 0);
                 var end = new MemoryPoolIterator2(block, block.Data.Count);
                 writeRequest.Write(

--- a/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/NetworkingTests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                                     new ArraySegment<byte>(new byte[] { 65, 66, 67, 68, 69 }),
                                     dataPtr: IntPtr.Zero,
                                     pool: null,
-                                    slab: null);
+                                    slabId: -1);
                                 var start = new MemoryPoolIterator2(block, 0);
                                 var end = new MemoryPoolIterator2(block, block.Data.Count);
                                 req.Write(

--- a/test/Microsoft.AspNet.Server.KestrelTests/SocketInputTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/SocketInputTests.cs
@@ -18,64 +18,62 @@ namespace Microsoft.AspNet.Server.KestrelTests
             // Arrange
             var trace = new KestrelTrace(new TestKestrelTrace());
             var ltp = new LoggingThreadPool(trace);
-            using (var memory2 = new MemoryPool2())
-            {
-                var socketInput = new SocketInput(memory2, ltp);
+            var memory2 = new MemoryPool2();
+            var socketInput = new SocketInput(memory2, ltp);
 
-                var task0Threw = false;
-                var task1Threw = false;
-                var task2Threw = false;
+            var task0Threw = false;
+            var task1Threw = false;
+            var task2Threw = false;
 
 
-                var task0 = AwaitAsTaskAsync(socketInput);
+            var task0 = AwaitAsTaskAsync(socketInput);
 
-                Assert.False(task0.IsFaulted);
+            Assert.False(task0.IsFaulted);
 
-                var task = task0.ContinueWith(
-                    (t) =>
-                    {
-                        TestConcurrentFaultedTask(t);
-                        task0Threw = true;
-                    },
-                    TaskContinuationOptions.OnlyOnFaulted);
+            var task = task0.ContinueWith(
+                (t) =>
+                {
+                    TestConcurrentFaultedTask(t);
+                    task0Threw = true;
+                },
+                TaskContinuationOptions.OnlyOnFaulted);
 
-                Assert.False(task0.IsFaulted);
+            Assert.False(task0.IsFaulted);
 
-                // Awaiting/continuing two tasks faults both
+            // Awaiting/continuing two tasks faults both
 
-                var task1 = AwaitAsTaskAsync(socketInput);
+            var task1 = AwaitAsTaskAsync(socketInput);
 
-                await task1.ContinueWith(
-                    (t) =>
-                    {
-                        TestConcurrentFaultedTask(t);
-                        task1Threw = true;
-                    },
-                    TaskContinuationOptions.OnlyOnFaulted);
+            await task1.ContinueWith(
+                (t) =>
+                {
+                    TestConcurrentFaultedTask(t);
+                    task1Threw = true;
+                },
+                TaskContinuationOptions.OnlyOnFaulted);
 
-                await task;
+            await task;
 
-                Assert.True(task0.IsFaulted);
-                Assert.True(task1.IsFaulted);
+            Assert.True(task0.IsFaulted);
+            Assert.True(task1.IsFaulted);
 
-                Assert.True(task0Threw);
-                Assert.True(task1Threw);
+            Assert.True(task0Threw);
+            Assert.True(task1Threw);
 
-                // socket stays faulted
+            // socket stays faulted
 
-                var task2 = AwaitAsTaskAsync(socketInput);
+            var task2 = AwaitAsTaskAsync(socketInput);
 
-                await task2.ContinueWith(
-                    (t) =>
-                    {
-                        TestConcurrentFaultedTask(t);
-                        task2Threw = true;
-                    },
-                    TaskContinuationOptions.OnlyOnFaulted);
+            await task2.ContinueWith(
+                (t) =>
+                {
+                    TestConcurrentFaultedTask(t);
+                    task2Threw = true;
+                },
+                TaskContinuationOptions.OnlyOnFaulted);
 
-                Assert.True(task2.IsFaulted);
-                Assert.True(task2Threw);
-            }
+            Assert.True(task2.IsFaulted);
+            Assert.True(task2Threw);
         }
 
         private static void TestConcurrentFaultedTask(Task t)

--- a/test/Microsoft.AspNet.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/SocketOutputTests.cs
@@ -34,8 +34,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             };
 
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
-            using (var memory = new MemoryPool2())
-            {
+            { 
+                var memory = new MemoryPool2();
                 kestrelEngine.Start(count: 1);
 
                 var kestrelThread = kestrelEngine.Threads[0];
@@ -81,8 +81,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             };
 
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
-            using (var memory = new MemoryPool2())
             {
+                var memory = new MemoryPool2();
                 kestrelEngine.Start(count: 1);
 
                 var kestrelThread = kestrelEngine.Threads[0];
@@ -138,8 +138,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             };
 
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
-            using (var memory = new MemoryPool2())
             {
+                var memory = new MemoryPool2();
                 kestrelEngine.Start(count: 1);
 
                 var kestrelThread = kestrelEngine.Threads[0];
@@ -219,8 +219,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             };
 
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
-            using (var memory = new MemoryPool2())
             {
+                var memory = new MemoryPool2();
                 kestrelEngine.Start(count: 1);
 
                 var kestrelThread = kestrelEngine.Threads[0];
@@ -296,8 +296,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             };
 
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
-            using (var memory = new MemoryPool2())
             {
+                var memory = new MemoryPool2();
                 kestrelEngine.Start(count: 1);
 
                 var kestrelThread = kestrelEngine.Threads[0];

--- a/test/Microsoft.AspNet.Server.KestrelTests/UrlPathDecoder.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/UrlPathDecoder.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         private MemoryPoolIterator2 BuildSample(string data)
         {
             var store = data.Select(c => (byte)c).ToArray();
-            var mem = MemoryPoolBlock2.Create(new ArraySegment<byte>(store), IntPtr.Zero, null, null);
+            var mem = MemoryPoolBlock2.Create(new ArraySegment<byte>(store), IntPtr.Zero, null, -1);
             mem.End = store.Length;
 
             return mem.GetIterator();


### PR DESCRIPTION
Seeing "only" a 5% gain on top for this (though that is +70k rps)

Before
```
Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     8.68ms   14.73ms 333.56ms   95.18%
    Req/Sec    47.81k     4.58k  122.10k    90.28%
  44317883 requests in 30.10s, 5.45GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 1472388.96
```
After
```
Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     9.18ms   18.09ms 305.19ms   95.63%
    Req/Sec    48.55k     8.78k  290.43k    91.02%
  46410810 requests in 30.10s, 5.71GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 1541996.54
```
Gets a little exotic with `WeakReference<Thread>` so it can free pinned memory from the `ThreadStatic` MemoryPools as the threadpool scales back down without using finalizers.