### PR TITLE
Output thread except to console in testing

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -245,6 +245,11 @@ namespace Microsoft.AspNet.Server.Kestrel
             }
             catch (Exception ex)
             {
+#if DEBUG
+                // Output error in debug for Tests, which do not support application lifetime
+                Console.WriteLine(nameof(KestrelThread) + " Exception");
+                Console.WriteLine(ex);
+#endif
                 _closeError = ExceptionDispatchInfo.Capture(ex);
                 // Request shutdown so we can rethrow this exception
                 // in Stop which should be observable.


### PR DESCRIPTION
Without it errors in thrown in libuv loop (in test) either throw `NotImplementedException` from `LifetimeNotImplemented` or worse only show up as `System.Threading.Tasks.TaskCanceledException : A task was canceled.` on the "client" side.

Which doesn't help narrow down causes.