### PR TITLE
Changing the folder of ARM version of libuv to win7-arm

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -84,7 +84,7 @@
     "/": "../../content/thirdpartynotices.txt",
     "runtimes/win7-x64/native/": "runtimes/win7-x64/native/*",
     "runtimes/win7-x86/native/": "runtimes/win7-x86/native/*",
-    "runtimes/win10-arm/native/": "runtimes/win10-arm/native/*",
+    "runtimes/win7-arm/native/": "runtimes/win7-arm/native/*",
     "runtimes/osx/native/": "runtimes/osx/native/*"
   }
 }


### PR DESCRIPTION
Depends on: https://github.com/aspnet/libuv-build/pull/4
Fixes: https://github.com/aspnet/Home/issues/1111