### PR TITLE
Amortize stream costs

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -57,6 +57,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         internal FrameRequestStream _requestBody;
         internal FrameResponseStream _responseBody;
+        internal FrameDuplexStream _duplexStream;
 
         protected bool _responseStarted;
         protected bool _keepAlive;
@@ -86,6 +87,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             _localEndPoint = localEndPoint;
             _prepareRequest = prepareRequest;
             _pathBase = context.ServerAddress.PathBase;
+            _requestBody = new FrameRequestStream();
+            _responseBody = new FrameResponseStream(this);
+            _duplexStream = new FrameDuplexStream(_requestBody, _responseBody);
 
             FrameControl = this;
             Reset();

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -87,9 +87,12 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             _localEndPoint = localEndPoint;
             _prepareRequest = prepareRequest;
             _pathBase = context.ServerAddress.PathBase;
-            _requestBody = new FrameRequestStream();
-            _responseBody = new FrameResponseStream(this);
-            _duplexStream = new FrameDuplexStream(_requestBody, _responseBody);
+            if (ReuseStreams)
+            {
+                _requestBody = new FrameRequestStream();
+                _responseBody = new FrameResponseStream(this);
+                _duplexStream = new FrameDuplexStream(_requestBody, _responseBody);
+            }
 
             FrameControl = this;
             Reset();

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameOfT.cs
@@ -91,6 +91,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                                 await FireOnStarting();
                             }
 
+                            _requestBody.PauseAcceptingReads();
+                            _responseBody.PauseAcceptingWrites();
+
                             if (_onCompleted != null)
                             {
                                 await FireOnCompleted();
@@ -101,10 +104,12 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                             // If _requestAbort is set, the connection has already been closed.
                             if (!_requestAborted)
                             {
+                                _responseBody.ResumeAcceptingWrites();
                                 await ProduceEnd();
 
                                 if (_keepAlive)
                                 {
+                                    _requestBody.ResumeAcceptingReads();
                                     // Finish reading the request body in case the app did not.
                                     await messageBody.Consume();
                                 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameOfT.cs
@@ -64,6 +64,15 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     {
                         var messageBody = MessageBody.For(HttpVersion, _requestHeaders, this);
                         _keepAlive = messageBody.RequestKeepAlive;
+
+                        // _duplexStream may be null if flag switched while running
+                        if (!ReuseStreams || _duplexStream == null)
+                        {
+                            _requestBody = new FrameRequestStream();
+                            _responseBody = new FrameResponseStream(this);
+                            _duplexStream = new FrameDuplexStream(_requestBody, _responseBody);
+                        }
+
                         RequestBody = _requestBody.StartAcceptingReads(messageBody);
                         ResponseBody = _responseBody.StartAcceptingWrites();
                         DuplexStream = _duplexStream;

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameOfT.cs
@@ -64,11 +64,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     {
                         var messageBody = MessageBody.For(HttpVersion, _requestHeaders, this);
                         _keepAlive = messageBody.RequestKeepAlive;
-                        _requestBody = new FrameRequestStream(messageBody);
-                        RequestBody = _requestBody;
-                        _responseBody = new FrameResponseStream(this);
-                        ResponseBody = _responseBody;
-                        DuplexStream = new FrameDuplexStream(RequestBody, ResponseBody);
+                        RequestBody = _requestBody.StartAcceptingReads(messageBody);
+                        ResponseBody = _responseBody.StartAcceptingWrites();
+                        DuplexStream = _duplexStream;
 
                         _abortedCts = null;
                         _manuallySetRequestAbortToken = null;

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameRequestStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameRequestStream.cs
@@ -123,6 +123,19 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             return this;
         }
 
+        public void PauseAcceptingReads()
+        {
+            _state = StreamState.Closed;
+        }
+
+        public void ResumeAcceptingReads()
+        {
+            if (_state == StreamState.Closed)
+            {
+                _state = StreamState.Open;
+            }
+        }
+
         public void StopAcceptingReads()
         {
             // Can't use dispose (or close) as can be disposed too early by user code

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameRequestStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameRequestStream.cs
@@ -11,11 +11,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
     public class FrameRequestStream : Stream
     {
         private MessageBody _body;
-        private StreamState _state;
+        private FrameStreamState _state;
 
         public FrameRequestStream()
         {
-            _state = StreamState.Closed;
+            _state = FrameStreamState.Closed;
         }
 
         public override bool CanRead { get { return true; } }
@@ -115,9 +115,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         public Stream StartAcceptingReads(MessageBody body)
         {
             // Only start if not aborted
-            if (_state == StreamState.Closed)
+            if (_state == FrameStreamState.Closed)
             {
-                _state = StreamState.Open;
+                _state = FrameStreamState.Open;
                 _body = body;
             }
             return this;
@@ -125,14 +125,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public void PauseAcceptingReads()
         {
-            _state = StreamState.Closed;
+            _state = FrameStreamState.Closed;
         }
 
         public void ResumeAcceptingReads()
         {
-            if (_state == StreamState.Closed)
+            if (_state == FrameStreamState.Closed)
             {
-                _state = StreamState.Open;
+                _state = FrameStreamState.Open;
             }
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             // Can't use dispose (or close) as can be disposed too early by user code
             // As exampled in EngineTests.ZeroContentLengthNotSetAutomaticallyForCertainStatusCodes
-            _state = StreamState.Closed;
+            _state = FrameStreamState.Closed;
             _body = null;
         }
 
@@ -148,9 +148,9 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             // We don't want to throw an ODE until the app func actually completes.
             // If the request is aborted, we throw an IOException instead.
-            if (_state != StreamState.Closed)
+            if (_state != FrameStreamState.Closed)
             {
-                _state = StreamState.Aborted;
+                _state = FrameStreamState.Aborted;
             }
         }
 
@@ -158,20 +158,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             switch (_state)
             {
-                case StreamState.Open:
+                case FrameStreamState.Open:
                     return;
-                case StreamState.Closed:
+                case FrameStreamState.Closed:
                     throw new ObjectDisposedException(nameof(FrameRequestStream));
-                case StreamState.Aborted:
+                case FrameStreamState.Aborted:
                     throw new IOException("The request has been aborted.");
             }
-        }
-
-        private enum StreamState
-        {
-            Open,
-            Closed,
-            Aborted
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameResponseStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameResponseStream.cs
@@ -89,6 +89,19 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             return this;
         }
 
+        public void PauseAcceptingWrites()
+        {
+            _state = StreamState.Closed;
+        }
+
+        public void ResumeAcceptingWrites()
+        {
+            if (_state == StreamState.Closed)
+            {
+                _state = StreamState.Open;
+            }
+        }
+
         public void StopAcceptingWrites()
         {
             // Can't use dispose (or close) as can be disposed too early by user code

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameStreamState.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameStreamState.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    enum FrameStreamState
+    {
+        Open,
+        Closed,
+        Aborted
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/IKestrelServerInformation.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/IKestrelServerInformation.cs
@@ -11,6 +11,19 @@ namespace Microsoft.AspNet.Server.Kestrel
 
         bool NoDelay { get; set; }
 
+        /// <summary>
+        /// Gets or sets a flag that instructs <seealso cref="KestrelServer"/> whether it is safe to 
+        /// reuse the Request and Response <seealso cref="System.IO.Stream"/> objects
+        /// for another request after the Response's OnCompleted callback has fired. 
+        /// When this is set to true it is not safe to retain references to these streams after this event has fired.
+        /// It is false by default.
+        /// </summary>
+        /// <remarks>
+        /// When this is set to true it is not safe to retain references to these streams after this event has fired.
+        /// It is false by default.
+        /// </remarks>
+        bool ReuseStreams { get; set; }
+
         IConnectionFilter ConnectionFilter { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelServer.cs
@@ -67,7 +67,8 @@ namespace Microsoft.AspNet.Server.Kestrel
                     ThreadPool = new LoggingThreadPool(trace),
                     DateHeaderValueManager = dateHeaderValueManager,
                     ConnectionFilter = information.ConnectionFilter,
-                    NoDelay = information.NoDelay
+                    NoDelay = information.NoDelay,
+                    ReuseStreams = information.ReuseStreams
                 });
 
                 _disposables.Push(engine);

--- a/src/Microsoft.AspNet.Server.Kestrel/KestrelServerInformation.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/KestrelServerInformation.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNet.Server.Kestrel
             Addresses = GetAddresses(configuration);
             ThreadCount = GetThreadCount(configuration);
             NoDelay = GetNoDelay(configuration);
+            ReuseStreams = GetReuseStreams(configuration);
         }
 
         public ICollection<string> Addresses { get; }
@@ -29,6 +30,8 @@ namespace Microsoft.AspNet.Server.Kestrel
         public int ThreadCount { get; set; }
 
         public bool NoDelay { get; set; }
+
+        public bool ReuseStreams { get; set; }
 
         public IConnectionFilter ConnectionFilter { get; set; }
 
@@ -106,6 +109,19 @@ namespace Microsoft.AspNet.Server.Kestrel
             }
 
             return true;
+        }
+
+        private static bool GetReuseStreams(IConfiguration configuration)
+        {
+            var reuseStreamsString = configuration["kestrel.reuseStreams"];
+
+            bool reuseStreams;
+            if (bool.TryParse(reuseStreamsString, out reuseStreams))
+            {
+                return reuseStreams;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/ServiceContext.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/ServiceContext.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNet.Server.Kestrel
             DateHeaderValueManager = context.DateHeaderValueManager;
             ConnectionFilter = context.ConnectionFilter;
             NoDelay = context.NoDelay;
+            ReuseStreams = context.ReuseStreams;
         }
 
         public IApplicationLifetime AppLifetime { get; set; }
@@ -41,5 +42,7 @@ namespace Microsoft.AspNet.Server.Kestrel
         public IConnectionFilter ConnectionFilter { get; set; }
 
         public bool NoDelay { get; set; }
+
+        public bool ReuseStreams { get; set; }
     }
 }

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ReuseStreamsTests.cs
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ReuseStreamsTests.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Hosting;
+using Microsoft.AspNet.Http.Features;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
+{
+    public class ReuseStreamsTests
+    {
+        [Fact]
+        public async Task ReuseStreamsOn()
+        {
+            var streamCount = 0;
+            var loopCount = 20;
+            Stream lastStream = null;
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "server.urls", "http://localhost:8801/" },
+                    { "kestrel.reuseStreams", "true" }
+                })
+                .Build();
+
+            var hostBuilder = new WebHostBuilder(config);
+            hostBuilder.UseServerFactory("Microsoft.AspNet.Server.Kestrel");
+            hostBuilder.UseStartup(app =>
+            {
+                var serverInfo = app.ServerFeatures.Get<IKestrelServerInformation>();
+                app.Run(context =>
+                {
+                    if (context.Request.Body != lastStream)
+                    {
+                        lastStream = context.Request.Body;
+                        streamCount++;
+                    }
+                    return context.Request.Body.CopyToAsync(context.Response.Body);
+                });
+            });            
+
+            using (var app = hostBuilder.Build().Start())
+            {
+                using (var client = new HttpClient())
+                {
+                    for (int i = 0; i < loopCount; i++)
+                    {
+                        var content = $"{i} Hello World {i}";
+                        var request = new HttpRequestMessage()
+                        {
+                            RequestUri = new Uri("http://localhost:8801/"),
+                            Method = HttpMethod.Post,
+                            Content = new StringContent(content)
+                        };
+                        request.Headers.Add("Connection", new string[] { "Keep-Alive" });
+                        var responseMessage = await client.SendAsync(request);
+                        var result = await responseMessage.Content.ReadAsStringAsync();
+                        Assert.Equal(content, result);
+                    }
+                }
+            }
+
+            Assert.True(streamCount < loopCount);
+        }
+
+        [Fact]
+        public async Task ReuseStreamsOff()
+        {
+            var streamCount = 0;
+            var loopCount = 20;
+            Stream lastStream = null;
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "server.urls", "http://localhost:8802/" },
+                    { "kestrel.reuseStreams", "false" }
+                })
+                .Build();
+
+            var hostBuilder = new WebHostBuilder(config);
+            hostBuilder.UseServerFactory("Microsoft.AspNet.Server.Kestrel");
+            hostBuilder.UseStartup(app =>
+            {
+                var serverInfo = app.ServerFeatures.Get<IKestrelServerInformation>();
+                app.Run(context =>
+                {
+                    if (context.Request.Body != lastStream)
+                    {
+                        lastStream = context.Request.Body;
+                        streamCount++;
+                    }
+                    return context.Request.Body.CopyToAsync(context.Response.Body);
+                });
+            });
+
+            using (var app = hostBuilder.Build().Start())
+            {
+                using (var client = new HttpClient())
+                {
+                    for (int i = 0; i < loopCount; i++)
+                    {
+                        var content = $"{i} Hello World {i}";
+                        var request = new HttpRequestMessage()
+                        {
+                            RequestUri = new Uri("http://localhost:8802/"),
+                            Method = HttpMethod.Post,
+                            Content = new StringContent(content)
+                        };
+                        request.Headers.Add("Connection", new string[] { "Keep-Alive" });
+                        var responseMessage = await client.SendAsync(request);
+                        var result = await responseMessage.Content.ReadAsStringAsync();
+                        Assert.Equal(content, result);
+                    }
+                }
+            }
+
+            Assert.Equal(loopCount, streamCount);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Server.KestrelTests/KestrelServerInformationTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/KestrelServerInformationTests.cs
@@ -85,6 +85,31 @@ namespace Microsoft.AspNet.Server.KestrelTests
             Assert.False(information.NoDelay);
         }
 
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("false", false)]
+        [InlineData("False", false)]
+        [InlineData("true", true)]
+        [InlineData("True", true)]
+        [InlineData("Foo", false)]
+        [InlineData("FooBar", false)]
+        public void SetReuseStreamsUsingConfiguration(string input, bool expected)
+        {
+            var values = new Dictionary<string, string>
+            {
+                { "kestrel.reuseStreams", input }
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(values)
+                .Build();
+
+            var information = new KestrelServerInformation(configuration);
+
+            Assert.Equal(expected, information.ReuseStreams);
+        }
+
         private static int Clamp(int value, int min, int max)
         {
             return value < min ? min : value > max ? max : value;

--- a/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MessageBodyTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             var input = new TestInput();
             var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
-            var stream = new FrameRequestStream(body);
+            var stream = new FrameRequestStream().StartAcceptingReads(body);
 
             input.Add("Hello", true);
 
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             var input = new TestInput();
             var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
-            var stream = new FrameRequestStream(body);
+            var stream = new FrameRequestStream().StartAcceptingReads(body);
 
             input.Add("Hello", true);
 
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
         {
             var input = new TestInput();
             var body = MessageBody.For("HTTP/1.0", new Dictionary<string, StringValues>(), input.FrameContext);
-            var stream = new FrameRequestStream(body);
+            var stream = new FrameRequestStream().StartAcceptingReads(body);
 
             // Input needs to be greater than 4032 bytes to allocate a block not backed by a slab.
             var largeInput = new string('a', 8192);


### PR DESCRIPTION
Reuse streams over connection lifetime.

Reduction in 12,000 objects per 4k requests; and 640000 bytes

Also resolves #471 "Can Middleware modify Response In OnCompleted callback" /cc @cesarbs 