### PR TITLE
Dispose socket on Accept() error (#328).

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListener.cs
@@ -37,19 +37,19 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         protected override void OnConnection(UvStreamHandle listenSocket, int status)
         {
             var acceptSocket = new UvPipeHandle(Log);
-            acceptSocket.Init(Thread.Loop, false);
 
             try
             {
+                acceptSocket.Init(Thread.Loop, false);
                 listenSocket.Accept(acceptSocket);
+                DispatchConnection(acceptSocket);
             }
             catch (UvException ex)
             {
                 Log.LogError("PipeListener.OnConnection", ex);
+                acceptSocket.Dispose();
                 return;
             }
-
-            DispatchConnection(acceptSocket);
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/PipeListenerPrimary.cs
@@ -37,19 +37,19 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         protected override void OnConnection(UvStreamHandle listenSocket, int status)
         {
             var acceptSocket = new UvPipeHandle(Log);
-            acceptSocket.Init(Thread.Loop, false);
 
             try
             {
+                acceptSocket.Init(Thread.Loop, false);
                 listenSocket.Accept(acceptSocket);
+                DispatchConnection(acceptSocket);
             }
             catch (UvException ex)
             {
                 Log.LogError("ListenerPrimary.OnConnection", ex);
+                acceptSocket.Dispose();
                 return;
             }
-
-            DispatchConnection(acceptSocket);
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListener.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListener.cs
@@ -37,20 +37,21 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         protected override void OnConnection(UvStreamHandle listenSocket, int status)
         {
             var acceptSocket = new UvTcpHandle(Log);
-            acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
-            acceptSocket.NoDelay(NoDelay);
 
             try
             {
+                acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
+                acceptSocket.NoDelay(NoDelay);
                 listenSocket.Accept(acceptSocket);
+                DispatchConnection(acceptSocket);
+
             }
             catch (UvException ex)
             {
                 Log.LogError("TcpListener.OnConnection", ex);
+                acceptSocket.Dispose();
                 return;
             }
-
-            DispatchConnection(acceptSocket);
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/TcpListenerPrimary.cs
@@ -39,20 +39,21 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         protected override void OnConnection(UvStreamHandle listenSocket, int status)
         {
             var acceptSocket = new UvTcpHandle(Log);
-            acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
-            acceptSocket.NoDelay(NoDelay);
 
             try
             {
+                acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
+                acceptSocket.NoDelay(NoDelay);
                 listenSocket.Accept(acceptSocket);
+                DispatchConnection(acceptSocket);
+
             }
             catch (UvException ex)
             {
                 Log.LogError("TcpListenerPrimary.OnConnection", ex);
+                acceptSocket.Dispose();
                 return;
             }
-
-            DispatchConnection(acceptSocket);
         }
     }
 }


### PR DESCRIPTION
We're leaking sockets when there's an error on Accept() on an incoming connection. The socket is only disposed when finalizers are run, which is non-deterministic.

#328 

cc @halter73 @benaadams @migueldeicaza 