### PR TITLE
Use pre-encoded headers if possible

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/FrameHeaders.Generated.cs
@@ -7825,381 +7825,741 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             
                 if (((_bits & 1L) != 0)) 
-                { 
-                    foreach(var value in _CacheControl)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_CacheControl.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 0, 17);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _CacheControl)
                         {
-                            output.CopyFrom(_headerBytes, 0, 17);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 0, 17);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 2L) != 0)) 
-                { 
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
                     if (_rawConnection != null) 
                     {
                         output.CopyFrom(_rawConnection, 0, _rawConnection.Length);
                     } else 
-                    foreach(var value in _Connection)
+                    if (_Connection.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 17, 14);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Connection)
                         {
-                            output.CopyFrom(_headerBytes, 17, 14);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 17, 14);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 4L) != 0)) 
-                { 
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
                     if (_rawDate != null) 
                     {
                         output.CopyFrom(_rawDate, 0, _rawDate.Length);
                     } else 
-                    foreach(var value in _Date)
+                    if (_Date.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 31, 8);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Date)
                         {
-                            output.CopyFrom(_headerBytes, 31, 8);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 31, 8);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 8L) != 0)) 
-                { 
-                    foreach(var value in _KeepAlive)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_KeepAlive.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 39, 14);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _KeepAlive)
                         {
-                            output.CopyFrom(_headerBytes, 39, 14);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 39, 14);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 16L) != 0)) 
-                { 
-                    foreach(var value in _Pragma)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Pragma.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 53, 10);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Pragma)
                         {
-                            output.CopyFrom(_headerBytes, 53, 10);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 53, 10);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 32L) != 0)) 
-                { 
-                    foreach(var value in _Trailer)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Trailer.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 63, 11);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Trailer)
                         {
-                            output.CopyFrom(_headerBytes, 63, 11);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 63, 11);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 64L) != 0)) 
-                { 
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
                     if (_rawTransferEncoding != null) 
                     {
                         output.CopyFrom(_rawTransferEncoding, 0, _rawTransferEncoding.Length);
                     } else 
-                    foreach(var value in _TransferEncoding)
+                    if (_TransferEncoding.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 74, 21);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _TransferEncoding)
                         {
-                            output.CopyFrom(_headerBytes, 74, 21);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 74, 21);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 128L) != 0)) 
-                { 
-                    foreach(var value in _Upgrade)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Upgrade.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 95, 11);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Upgrade)
                         {
-                            output.CopyFrom(_headerBytes, 95, 11);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 95, 11);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 256L) != 0)) 
-                { 
-                    foreach(var value in _Via)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Via.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 106, 7);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Via)
                         {
-                            output.CopyFrom(_headerBytes, 106, 7);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 106, 7);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 512L) != 0)) 
-                { 
-                    foreach(var value in _Warning)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Warning.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 113, 11);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Warning)
                         {
-                            output.CopyFrom(_headerBytes, 113, 11);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 113, 11);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 1024L) != 0)) 
-                { 
-                    foreach(var value in _Allow)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Allow.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 124, 9);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Allow)
                         {
-                            output.CopyFrom(_headerBytes, 124, 9);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 124, 9);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 2048L) != 0)) 
-                { 
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
                     if (_rawContentLength != null) 
                     {
                         output.CopyFrom(_rawContentLength, 0, _rawContentLength.Length);
                     } else 
-                    foreach(var value in _ContentLength)
+                    if (_ContentLength.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 133, 18);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _ContentLength)
                         {
-                            output.CopyFrom(_headerBytes, 133, 18);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 133, 18);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 4096L) != 0)) 
-                { 
-                    foreach(var value in _ContentType)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_ContentType.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 151, 16);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _ContentType)
                         {
-                            output.CopyFrom(_headerBytes, 151, 16);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 151, 16);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 8192L) != 0)) 
-                { 
-                    foreach(var value in _ContentEncoding)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_ContentEncoding.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 167, 20);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _ContentEncoding)
                         {
-                            output.CopyFrom(_headerBytes, 167, 20);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 167, 20);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 16384L) != 0)) 
-                { 
-                    foreach(var value in _ContentLanguage)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_ContentLanguage.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 187, 20);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _ContentLanguage)
                         {
-                            output.CopyFrom(_headerBytes, 187, 20);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 187, 20);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 32768L) != 0)) 
-                { 
-                    foreach(var value in _ContentLocation)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_ContentLocation.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 207, 20);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _ContentLocation)
                         {
-                            output.CopyFrom(_headerBytes, 207, 20);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 207, 20);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 65536L) != 0)) 
-                { 
-                    foreach(var value in _ContentMD5)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_ContentMD5.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 227, 15);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _ContentMD5)
                         {
-                            output.CopyFrom(_headerBytes, 227, 15);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 227, 15);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 131072L) != 0)) 
-                { 
-                    foreach(var value in _ContentRange)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_ContentRange.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 242, 17);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _ContentRange)
                         {
-                            output.CopyFrom(_headerBytes, 242, 17);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 242, 17);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 262144L) != 0)) 
-                { 
-                    foreach(var value in _Expires)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Expires.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 259, 11);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Expires)
                         {
-                            output.CopyFrom(_headerBytes, 259, 11);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 259, 11);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 524288L) != 0)) 
-                { 
-                    foreach(var value in _LastModified)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_LastModified.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 270, 17);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _LastModified)
                         {
-                            output.CopyFrom(_headerBytes, 270, 17);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 270, 17);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 1048576L) != 0)) 
-                { 
-                    foreach(var value in _AcceptRanges)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_AcceptRanges.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 287, 17);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _AcceptRanges)
                         {
-                            output.CopyFrom(_headerBytes, 287, 17);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 287, 17);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 2097152L) != 0)) 
-                { 
-                    foreach(var value in _Age)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Age.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 304, 7);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Age)
                         {
-                            output.CopyFrom(_headerBytes, 304, 7);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 304, 7);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 4194304L) != 0)) 
-                { 
-                    foreach(var value in _ETag)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_ETag.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 311, 8);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _ETag)
                         {
-                            output.CopyFrom(_headerBytes, 311, 8);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 311, 8);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 8388608L) != 0)) 
-                { 
-                    foreach(var value in _Location)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Location.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 319, 12);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Location)
                         {
-                            output.CopyFrom(_headerBytes, 319, 12);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 319, 12);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 16777216L) != 0)) 
-                { 
-                    foreach(var value in _ProxyAutheticate)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_ProxyAutheticate.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 331, 21);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _ProxyAutheticate)
                         {
-                            output.CopyFrom(_headerBytes, 331, 21);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 331, 21);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 33554432L) != 0)) 
-                { 
-                    foreach(var value in _RetryAfter)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_RetryAfter.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 352, 15);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _RetryAfter)
                         {
-                            output.CopyFrom(_headerBytes, 352, 15);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 352, 15);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 67108864L) != 0)) 
-                { 
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
                     if (_rawServer != null) 
                     {
                         output.CopyFrom(_rawServer, 0, _rawServer.Length);
                     } else 
-                    foreach(var value in _Server)
+                    if (_Server.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 367, 10);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Server)
                         {
-                            output.CopyFrom(_headerBytes, 367, 10);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 367, 10);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 134217728L) != 0)) 
-                { 
-                    foreach(var value in _SetCookie)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_SetCookie.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 377, 14);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _SetCookie)
                         {
-                            output.CopyFrom(_headerBytes, 377, 14);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 377, 14);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 268435456L) != 0)) 
-                { 
-                    foreach(var value in _Vary)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_Vary.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 391, 8);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _Vary)
                         {
-                            output.CopyFrom(_headerBytes, 391, 8);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 391, 8);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }
             
                 if (((_bits & 536870912L) != 0)) 
-                { 
-                    foreach(var value in _WWWAuthenticate)
+                {
+                    byte[] bytes;
+                    Encoding encoding;
+                    
+                    if (_WWWAuthenticate.TryGetPreEncoded(out bytes, out encoding) &&
+                        ((encoding == _asciiEncoding || encoding.WebName == _asciiWebName)))
                     {
-                        if (value != null)
+                        output.CopyFrom(_headerBytes, 399, 20);
+                        output.CopyFrom(bytes);
+                    }
+                    else
+                    {
+                        foreach(var value in _WWWAuthenticate)
                         {
-                            output.CopyFrom(_headerBytes, 399, 20);
-                            output.CopyFromAscii(value);
+                            if (value != null)
+                            {
+                                output.CopyFrom(_headerBytes, 399, 20);
+                                output.CopyFromAscii(value);
+                            }
                         }
                     }
                 }

--- a/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNet.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Hosting;
@@ -139,6 +140,50 @@ namespace Microsoft.AspNet.Server.Kestrel.FunctionalTests
                 dataset.Add("Location", new string[] { null, "" }, "");
 
                 return dataset;
+            }
+        }
+
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on mono.")]
+        public async Task PreEncodedHeaders()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "server.urls", "http://localhost:8794/" }
+                })
+                .Build();
+            var knownHeaderName = "Location";
+            var encodedKnownHeader = StringValues.CreatePreEncoded("somewhere", Encoding.ASCII);
+            var unknownHeaderName = "foo";
+            var encodedUnknownHeader = StringValues.CreatePreEncoded("bar", Encoding.ASCII);
+
+            var hostBuilder = new WebHostBuilder(config);
+            hostBuilder.UseServerFactory("Microsoft.AspNet.Server.Kestrel");
+            hostBuilder.UseStartup(app =>
+            {
+                app.Run(async context =>
+                {
+                    context.Response.Headers[knownHeaderName] = encodedKnownHeader;
+                    context.Response.Headers[unknownHeaderName] = encodedUnknownHeader;
+
+                    await context.Response.WriteAsync("");
+                });
+            });
+
+            using (var app = hostBuilder.Build().Start())
+            {
+                using (var client = new HttpClient())
+                {
+                    var response = await client.GetAsync("http://localhost:8794/");
+                    response.EnsureSuccessStatusCode();
+                    var headers = response.Headers;
+
+                    Assert.True(headers.Contains(knownHeaderName));
+                    Assert.Equal(headers.GetValues(knownHeaderName).Single(), encodedKnownHeader);
+                    Assert.True(headers.Contains(unknownHeaderName));
+                    Assert.Equal(headers.GetValues(unknownHeaderName).Single(), encodedUnknownHeader);
+                }
             }
         }
     }


### PR DESCRIPTION
Kestrel update after pre-encoded bytes are added to `StringValues` in https://github.com/aspnet/Common/pull/68