### PR TITLE
Reduced locks; return all blocks on threadpool

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketInput.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNet.Server.Kestrel.Http
@@ -60,19 +59,17 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         public IncomingBuffer IncomingStart(int minimumSize)
         {
-            lock (_sync)
+
+            if (_tail != null && minimumSize <= _tail.Data.Offset + _tail.Data.Count - _tail.End)
             {
-                if (_tail != null && minimumSize <= _tail.Data.Offset + _tail.Data.Count - _tail.End)
+                _pinned = _tail;
+                var data = new ArraySegment<byte>(_pinned.Data.Array, _pinned.End, _pinned.Data.Offset + _pinned.Data.Count - _pinned.End);
+                var dataPtr = _pinned.Pin() + _pinned.End;
+                return new IncomingBuffer
                 {
-                    _pinned = _tail;
-                    var data = new ArraySegment<byte>(_pinned.Data.Array, _pinned.End, _pinned.Data.Offset + _pinned.Data.Count - _pinned.End);
-                    var dataPtr = _pinned.Pin() + _pinned.End;
-                    return new IncomingBuffer
-                    {
-                        Data = data,
-                        DataPtr = dataPtr,
-                    };
-                }
+                    Data = data,
+                    DataPtr = dataPtr,
+                };
             }
 
             _pinned = _memory.Lease(minimumSize);
@@ -87,14 +84,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             Action awaitableState;
 
-            lock (_sync)
+            // Unpin may called without an earlier Pin 
+            if (_pinned != null)
             {
-                // Unpin may called without an earlier Pin 
-                if (_pinned != null)
-                {
-                    _pinned.Unpin();
+                _pinned.Unpin();
 
-                    _pinned.End += count;
+                _pinned.End += count;
+                lock (_sync)
+                {
                     if (_head == null)
                     {
                         _head = _tail = _pinned;
@@ -109,23 +106,23 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                         _tail = _pinned;
                     }
                 }
-                _pinned = null;
-
-                if (count == 0)
-                {
-                    RemoteIntakeFin = true;
-                }
-                if (error != null)
-                {
-                    _awaitableError = error;
-                }
-
-                awaitableState = Interlocked.Exchange(
-                    ref _awaitableState,
-                    _awaitableIsCompleted);
-
-                _manualResetEvent.Set();
             }
+            _pinned = null;
+
+            if (count == 0)
+            {
+                RemoteIntakeFin = true;
+            }
+            if (error != null)
+            {
+                _awaitableError = error;
+            }
+
+            awaitableState = Interlocked.Exchange(
+                ref _awaitableState,
+                _awaitableIsCompleted);
+
+            _manualResetEvent.Set();
 
             if (awaitableState != _awaitableIsCompleted &&
                 awaitableState != _awaitableIsNotCompleted)
@@ -148,34 +145,43 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         {
             MemoryPoolBlock2 returnStart = null;
             MemoryPoolBlock2 returnEnd = null;
-            lock (_sync)
+            if (!consumed.IsDefault)
             {
-                if (!consumed.IsDefault)
+                lock (_sync)
                 {
                     returnStart = _head;
                     returnEnd = consumed.Block;
                     _head = consumed.Block;
                     _head.Start = consumed.Index;
                 }
-                if (!examined.IsDefault &&
-                    examined.IsEnd &&
-                    RemoteIntakeFin == false &&
-                    _awaitableError == null)
-                {
-                    _manualResetEvent.Reset();
-
-                    var awaitableState = Interlocked.CompareExchange(
-                        ref _awaitableState,
-                        _awaitableIsNotCompleted,
-                        _awaitableIsCompleted);
-                }
             }
-            while (returnStart != returnEnd)
+            if (!examined.IsDefault &&
+                examined.IsEnd &&
+                RemoteIntakeFin == false &&
+                _awaitableError == null)
             {
-                var returnBlock = returnStart;
-                returnStart = returnStart.Next;
-                returnBlock.Pool?.Return(returnBlock);
+                _manualResetEvent.Reset();
+
+                var awaitableState = Interlocked.CompareExchange(
+                    ref _awaitableState,
+                    _awaitableIsNotCompleted,
+                    _awaitableIsCompleted);
             }
+
+            if  (returnStart == returnEnd)
+            {
+                return;
+            }
+
+            // detach returned block chain from active block
+            var block = returnStart;
+            while (block.Next != returnEnd)
+            {
+                block = block.Next;
+            }
+            block.Next = null;
+
+            _threadPool.ReturnBlockChain(returnStart);
         }
 
         public void AbortAwaiting()

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/IThreadPool.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/IThreadPool.cs
@@ -11,5 +11,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         void Complete(TaskCompletionSource<object> tcs);
         void Error(TaskCompletionSource<object> tcs, Exception ex);
         void Run(Action action);
+        void ReturnBlockChain(MemoryPoolBlock2 startBlock);
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/LoggingThreadPool.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/LoggingThreadPool.cs
@@ -9,10 +9,12 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 {
     public class LoggingThreadPool : IThreadPool
     {
-        private readonly IKestrelTrace _log;
+        private readonly static WaitCallback _returnBlocks = (state) => ReturnBlocks((MemoryPoolBlock2)state);
 
+        private readonly IKestrelTrace _log;
         private readonly WaitCallback _runAction;
         private readonly WaitCallback _completeTcs;
+
 
         public LoggingThreadPool(IKestrelTrace log)
         {
@@ -68,6 +70,25 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                     _log.ApplicationError(e);
                 }
             }, tcs);
+        }
+
+        public void ReturnBlockChain(MemoryPoolBlock2 startBlock)
+        {
+            if (startBlock != null)
+            {
+                ThreadPool.QueueUserWorkItem(_returnBlocks, startBlock);
+            }
+        }
+
+        private static void ReturnBlocks(MemoryPoolBlock2 block)
+        {
+            while (block != null)
+            {
+                var returningBlock = block;
+                block = returningBlock.Next;
+
+                returningBlock.Pool?.Return(returningBlock);
+            }
         }
     }
 }


### PR DESCRIPTION
+2.2% RPS

Before
> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.33ms   17.59ms 405.46ms   96.27%
    Req/Sec    64.45k    12.84k  285.58k    95.19%
  61601385 requests in 30.10s, 7.57GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 2046559.00
Transfer/sec:    257.63MB

After
> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.75ms   14.52ms 317.89ms   95.90%
    Req/Sec    65.88k    13.12k  296.29k    95.27%
  62983504 requests in 30.10s, 7.74GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 2092477.44
Transfer/sec:    263.41MB
