### PR TITLE
Faster byte[] copy

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/SocketInputStream.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/SocketInputStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using IllyriadGames.ByteArrayExtensions;
 using Microsoft.AspNet.Server.Kestrel.Http;
 using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 
@@ -76,7 +77,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
         {
             var inputBuffer = _socketInput.IncomingStart(count);
 
-            Buffer.BlockCopy(buffer, offset, inputBuffer.Data.Array, inputBuffer.Data.Offset, count);
+            buffer.VectorizedCopy(offset, inputBuffer.Data.Array, inputBuffer.Data.Offset, count);
 
             _socketInput.IncomingComplete(count, error: null);
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Numerics;
+using IllyriadGames.ByteArrayExtensions;
 
 namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 {
@@ -552,7 +553,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                     actual = count;
                     if (array != null)
                     {
-                        Buffer.BlockCopy(block.Array, index, array, offset, remaining);
+                        block.Array.VectorizedCopy(index, array, offset, remaining);
                     }
                     return new MemoryPoolIterator2(block, index + remaining);
                 }
@@ -561,7 +562,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                     actual = count - remaining + following;
                     if (array != null)
                     {
-                        Buffer.BlockCopy(block.Array, index, array, offset, following);
+                        block.Array.VectorizedCopy(index, array, offset, following);
                     }
                     return new MemoryPoolIterator2(block, index + following);
                 }
@@ -569,7 +570,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                 {
                     if (array != null)
                     {
-                        Buffer.BlockCopy(block.Array, index, array, offset, following);
+                        block.Array.VectorizedCopy(index, array, offset, following);
                     }
                     offset += following;
                     remaining -= following;
@@ -619,7 +620,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 
                 var bytesToCopy = remaining < bytesLeftInBlock ? remaining : bytesLeftInBlock;
 
-                Buffer.BlockCopy(data, bufferIndex, block.Array, blockIndex, bytesToCopy);
+                data.VectorizedCopy(bufferIndex, block.Array, blockIndex, bytesToCopy);
 
                 blockIndex += bytesToCopy;
                 bufferIndex += bytesToCopy;

--- a/src/Microsoft.AspNet.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNet.Server.Kestrel/project.json
@@ -20,7 +20,8 @@
     "Microsoft.AspNet.Internal.libuv-Windows": {
       "version": "1.0.0-*",
       "type": "build"
-    }
+    },
+    "IllyriadGames.ByteArrayExtensions": "1.0.0-beta-10"
   },
   "frameworks": {
     "dnx451": { },


### PR DESCRIPTION
This makes me sad that this is even possible to do (+4% RPS)...

Issue: "Array.Copy & Buffer.BlockCopy x2 to x3 slower < 1kB" https://github.com/dotnet/coreclr/issues/2430

[![Performance Graph](http://aoa.blob.core.windows.net/aspnet/VectorizedCopy888.png)](http://aoa.blob.core.windows.net/aspnet/VectorizedCopy.png)

Until that is fixed, there is this, +4% RPS

Before

> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.31ms   17.04ms 430.36ms   96.48%
    Req/Sec    63.61k    11.37k  121.07k    89.55%
  60603911 requests in 30.04s, 7.45GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 2017281.16
Transfer/sec:    253.95MB

> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.86ms   18.76ms 319.53ms   96.10%
    Req/Sec    65.93k     7.22k  233.05k    91.79%
  61092441 requests in 30.10s, 7.51GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 2029658.31
Transfer/sec:    255.50MB

> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.76ms   18.81ms 338.18ms   96.30%
    Req/Sec    65.90k     6.02k  141.64k    88.76%
  61119465 requests in 30.10s, 7.51GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 2030569.81
Transfer/sec:    255.62MB


After

> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.54ms   16.04ms 421.70ms   97.95%
    Req/Sec    66.30k    13.82k  277.14k    91.29%
  63126220 requests in 30.10s, 7.76GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 2097240.79
Transfer/sec:    264.01MB

> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.39ms   15.65ms 315.77ms   98.11%
    Req/Sec    68.62k     7.74k  234.24k    87.15%
  63593990 requests in 30.10s, 7.82GB read
  Socket errors: connect 35, read 0, write 0, timeout 8
Requests/sec: 2112790.91
Transfer/sec:    265.97MB

> Running 30s test @ http://.../plaintext
  32 threads and 1024 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.25ms   15.05ms 332.33ms   98.25%
    Req/Sec    66.43k    13.67k  283.71k    92.85%
  63515232 requests in 30.10s, 7.81GB read
  Socket errors: connect 35, read 0, write 0, timeout 0
Requests/sec: 2110181.96
Transfer/sec:    265.64MB
