### PR TITLE
MemoryPoolIterator2.Seek performance

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/Frame.cs
@@ -40,11 +40,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
         private static readonly byte[] _bytesDate = Encoding.ASCII.GetBytes("Date: ");
         private static readonly byte[] _bytesEndHeaders = Encoding.ASCII.GetBytes("\r\n\r\n");
 
-        private static readonly Vector<byte> _vectorCRs = new Vector<byte>((byte)'\r');
-        private static readonly Vector<byte> _vectorColons = new Vector<byte>((byte)':');
-        private static readonly Vector<byte> _vectorSpaces = new Vector<byte>((byte)' ');
-        private static readonly Vector<byte> _vectorQuestionMarks = new Vector<byte>((byte)'?');
-        private static readonly Vector<byte> _vectorPercentages = new Vector<byte>((byte)'%');
+        private static Vector<byte> _vectorCRs = new Vector<byte>((byte)'\r');
+        private static Vector<byte> _vectorColons = new Vector<byte>((byte)':');
+        private static Vector<byte> _vectorSpaces = new Vector<byte>((byte)' ');
+        private static Vector<byte> _vectorQuestionMarks = new Vector<byte>((byte)'?');
+        private static Vector<byte> _vectorPercentages = new Vector<byte>((byte)'%');
 
         private readonly object _onStartingSync = new Object();
         private readonly object _onCompletedSync = new Object();
@@ -711,7 +711,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             try
             {
                 var begin = scan;
-                if (scan.Seek(_vectorSpaces) == -1)
+                if (scan.Seek(ref _vectorSpaces) == -1)
                 {
                     return false;
                 }
@@ -726,11 +726,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 begin = scan;
 
                 var needDecode = false;
-                var chFound = scan.Seek(_vectorSpaces, _vectorQuestionMarks, _vectorPercentages);
+                var chFound = scan.Seek(ref _vectorSpaces, ref _vectorQuestionMarks, ref _vectorPercentages);
                 if (chFound == '%')
                 {
                     needDecode = true;
-                    chFound = scan.Seek(_vectorSpaces, _vectorQuestionMarks);
+                    chFound = scan.Seek(ref _vectorSpaces, ref _vectorQuestionMarks);
                 }
 
                 var pathBegin = begin;
@@ -740,7 +740,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 if (chFound == '?')
                 {
                     begin = scan;
-                    if (scan.Seek(_vectorSpaces) != ' ')
+                    if (scan.Seek(ref _vectorSpaces) != ' ')
                     {
                         return false;
                     }
@@ -749,7 +749,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
                 scan.Take();
                 begin = scan;
-                if (scan.Seek(_vectorCRs) == -1)
+                if (scan.Seek(ref _vectorCRs) == -1)
                 {
                     return false;
                 }
@@ -843,7 +843,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 while (!scan.IsEnd)
                 {
                     var beginName = scan;
-                    scan.Seek(_vectorColons, _vectorCRs);
+                    scan.Seek(ref _vectorColons, ref _vectorCRs);
                     var endName = scan;
 
                     chFirst = scan.Take();
@@ -894,7 +894,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     var wrapping = false;
                     while (!scan.IsEnd)
                     {
-                        if (scan.Seek(_vectorCRs) == -1)
+                        if (scan.Seek(ref _vectorCRs) == -1)
                         {
                             // no "\r" in sight, burn used bytes and go back to await more data
                             return false;

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2.cs
@@ -9,6 +9,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
 {
     public struct MemoryPoolIterator2
     {
+        private readonly static int _vectorSpan = Vector<byte>.Count;
+
         private MemoryPoolBlock2 _block;
         private int _index;
 
@@ -168,113 +170,141 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
             }
         }
 
-        public int Seek(Vector<byte> byte0Vector)
+        public unsafe int Seek(ref Vector<byte> byte0Vector)
         {
             if (IsDefault)
             {
                 return -1;
             }
 
+            var following = _block.End - _index;
             var block = _block;
             var index = _index;
-            var array = block.Array;
+            byte[] array;
+            var byte0 = byte0Vector[0];
+
             while (true)
             {
-                while (block.End == index)
+                while (following == 0)
                 {
-                    if (block.Next == null)
+                    var newBlock = block.Next;
+                    if (newBlock == null)
                     {
                         _block = block;
                         _index = index;
                         return -1;
                     }
-                    block = block.Next;
-                    index = block.Start;
-                    array = block.Array;
+                    index = newBlock.Start;
+                    following = newBlock.End - index;
+                    block = newBlock;
                 }
-                while (block.End != index)
+                array = block.Array;
+                while (following > 0)
                 {
-                    var following = block.End - index;
-                    if (following >= Vector<byte>.Count)
+#if !DEBUG // Need unit tests to test Vector path
+                    // Check will be Jitted away https://github.com/dotnet/coreclr/issues/1079
+                    if (Vector.IsHardwareAccelerated)
                     {
-                        var data = new Vector<byte>(array, index);
-                        var byte0Equals = Vector.Equals(data, byte0Vector);
+#endif
+                    if (following >= _vectorSpan)
+                    {
+                        var byte0Equals = Vector.Equals(new Vector<byte>(array, index), byte0Vector);
 
                         if (byte0Equals.Equals(Vector<byte>.Zero))
                         {
-                            index += Vector<byte>.Count;
+                            following -= _vectorSpan;
+                            index += _vectorSpan;
                             continue;
                         }
 
                         _block = block;
-                        _index = index + FindFirstEqualByte(byte0Equals);
-                        return byte0Vector[0];
+                        _index = index + FindFirstEqualByte(ref byte0Equals);
+                        return byte0;
                     }
-
-                    var byte0 = byte0Vector[0];
-
-                    while (following > 0)
+#if !DEBUG // Need unit tests to test Vector path
+                    }
+#endif
+                    fixed (byte* pArray = array)
                     {
-                        if (block.Array[index] == byte0)
+                        var pCurrent = pArray + index;
+                        var pEnd = pArray + index + following;
+                        do
                         {
-                            _block = block;
-                            _index = index;
-                            return byte0;
-                        }
-                        following--;
-                        index++;
+                            if (*pCurrent == byte0)
+                            {
+                                _block = block;
+                                _index = index;
+                                return byte0;
+                            }
+                            pCurrent++;
+                            index++;
+                        } while (pCurrent < pEnd);
                     }
+                    following = 0;
+                    break;
                 }
             }
         }
 
-        public int Seek(Vector<byte> byte0Vector, Vector<byte> byte1Vector)
+        public unsafe int Seek(ref Vector<byte> byte0Vector, ref Vector<byte> byte1Vector)
         {
             if (IsDefault)
             {
                 return -1;
             }
 
+            var following = _block.End - _index;
             var block = _block;
             var index = _index;
-            var array = block.Array;
+            byte[] array;
+            int byte0Index = int.MaxValue;
+            int byte1Index = int.MaxValue;
+            var byte0 = byte0Vector[0];
+            var byte1 = byte1Vector[0];
+
             while (true)
             {
-                while (block.End == index)
+                while (following == 0)
                 {
-                    if (block.Next == null)
+                    var newBlock = block.Next;
+                    if (newBlock == null)
                     {
                         _block = block;
                         _index = index;
                         return -1;
                     }
-                    block = block.Next;
-                    index = block.Start;
-                    array = block.Array;
+                    index = newBlock.Start;
+                    following = newBlock.End - index;
+                    block = newBlock;
                 }
-                while (block.End != index)
+                array = block.Array;
+                while (following > 0)
                 {
-                    var following = block.End - index;
-                    if (following >= Vector<byte>.Count)
+
+#if !DEBUG // Need unit tests to test Vector path
+                    // Check will be Jitted away https://github.com/dotnet/coreclr/issues/1079
+                    if (Vector.IsHardwareAccelerated)
+                    {
+#endif
+                    if (following >= _vectorSpan)
                     {
                         var data = new Vector<byte>(array, index);
                         var byte0Equals = Vector.Equals(data, byte0Vector);
                         var byte1Equals = Vector.Equals(data, byte1Vector);
-                        int byte0Index = int.MaxValue;
-                        int byte1Index = int.MaxValue;
 
                         if (!byte0Equals.Equals(Vector<byte>.Zero))
                         {
-                            byte0Index = FindFirstEqualByte(byte0Equals);
+                            byte0Index = FindFirstEqualByte(ref byte0Equals);
                         }
                         if (!byte1Equals.Equals(Vector<byte>.Zero))
                         {
-                            byte1Index = FindFirstEqualByte(byte1Equals);
+                            byte1Index = FindFirstEqualByte(ref byte1Equals);
                         }
 
                         if (byte0Index == int.MaxValue && byte1Index == int.MaxValue)
                         {
-                            index += Vector<byte>.Count;
+                            following -= _vectorSpan;
+                            index += _vectorSpan;
                             continue;
                         }
 
@@ -283,105 +313,125 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                         if (byte0Index < byte1Index)
                         {
                             _index = index + byte0Index;
-                            return byte0Vector[0];
+                            return byte0;
                         }
 
                         _index = index + byte1Index;
-                        return byte1Vector[0];
+                        return byte1;
                     }
+#if !DEBUG // Need unit tests to test Vector path
+                    }
+#endif
 
-                    byte byte0 = byte0Vector[0];
-                    byte byte1 = byte1Vector[0];
-
-                    while (following > 0)
+                    fixed (byte* pArray = array)
                     {
-                        var byteIndex = block.Array[index];
-                        if (byteIndex == byte0)
+                        var pCurrent = pArray + index;
+                        var pEnd = pArray + index + following;
+                        do
                         {
-                            _block = block;
-                            _index = index;
-                            return byte0;
-                        }
-                        else if (byteIndex == byte1)
-                        {
-                            _block = block;
-                            _index = index;
-                            return byte1;
-                        }
-                        following--;
-                        index++;
+                            if (*pCurrent == byte0)
+                            {
+                                _block = block;
+                                _index = index;
+                                return byte0;
+                            }
+                            if (*pCurrent == byte1)
+                            {
+                                _block = block;
+                                _index = index;
+                                return byte1;
+                            }
+                            pCurrent++;
+                            index++;
+                        } while (pCurrent != pEnd);
                     }
+                    following = 0;
+                    break;
                 }
             }
         }
 
-        public int Seek(Vector<byte> byte0Vector, Vector<byte> byte1Vector, Vector<byte> byte2Vector)
+        public unsafe int Seek(ref Vector<byte> byte0Vector, ref Vector<byte> byte1Vector, ref Vector<byte> byte2Vector)
         {
             if (IsDefault)
             {
                 return -1;
             }
 
+            var following = _block.End - _index;
             var block = _block;
             var index = _index;
-            var array = block.Array;
+            byte[] array;
+            int byte0Index = int.MaxValue;
+            int byte1Index = int.MaxValue;
+            int byte2Index = int.MaxValue;
+            var byte0 = byte0Vector[0];
+            var byte1 = byte1Vector[0];
+            var byte2 = byte2Vector[0];
+
             while (true)
             {
-                while (block.End == index)
+                while (following == 0)
                 {
-                    if (block.Next == null)
+                    var newBlock = block.Next;
+                    if (newBlock == null)
                     {
                         _block = block;
                         _index = index;
                         return -1;
                     }
-                    block = block.Next;
-                    index = block.Start;
-                    array = block.Array;
+                    index = newBlock.Start;
+                    following = newBlock.End - index;
+                    block = newBlock;
                 }
-                while (block.End != index)
+                array = block.Array;
+                while (following > 0)
                 {
-                    var following = block.End - index;
-                    if (following >= Vector<byte>.Count)
+#if !DEBUG // Need unit tests to test Vector path
+                    // Check will be Jitted away https://github.com/dotnet/coreclr/issues/1079
+                    if (Vector.IsHardwareAccelerated)
+                    {
+#endif
+                    if (following >= _vectorSpan)
                     {
                         var data = new Vector<byte>(array, index);
                         var byte0Equals = Vector.Equals(data, byte0Vector);
                         var byte1Equals = Vector.Equals(data, byte1Vector);
                         var byte2Equals = Vector.Equals(data, byte2Vector);
-                        int byte0Index = int.MaxValue;
-                        int byte1Index = int.MaxValue;
-                        int byte2Index = int.MaxValue;
 
                         if (!byte0Equals.Equals(Vector<byte>.Zero))
                         {
-                            byte0Index = FindFirstEqualByte(byte0Equals);
+                            byte0Index = FindFirstEqualByte(ref byte0Equals);
                         }
                         if (!byte1Equals.Equals(Vector<byte>.Zero))
                         {
-                            byte1Index = FindFirstEqualByte(byte1Equals);
+                            byte1Index = FindFirstEqualByte(ref byte1Equals);
                         }
                         if (!byte2Equals.Equals(Vector<byte>.Zero))
                         {
-                            byte2Index = FindFirstEqualByte(byte2Equals);
+                            byte2Index = FindFirstEqualByte(ref byte2Equals);
                         }
 
                         if (byte0Index == int.MaxValue && byte1Index == int.MaxValue && byte2Index == int.MaxValue)
                         {
-                            index += Vector<byte>.Count;
+                            following -= _vectorSpan;
+                            index += _vectorSpan;
                             continue;
                         }
+
+                        _block = block;
 
                         int toReturn, toMove;
                         if (byte0Index < byte1Index)
                         {
                             if (byte0Index < byte2Index)
                             {
-                                toReturn = byte0Vector[0];
+                                toReturn = byte0;
                                 toMove = byte0Index;
                             }
                             else
                             {
-                                toReturn = byte2Vector[0];
+                                toReturn = byte2;
                                 toMove = byte2Index;
                             }
                         }
@@ -389,54 +439,57 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                         {
                             if (byte1Index < byte2Index)
                             {
-                                toReturn = byte1Vector[0];
+                                toReturn = byte1;
                                 toMove = byte1Index;
                             }
                             else
                             {
-                                toReturn = byte2Vector[0];
+                                toReturn = byte2;
                                 toMove = byte2Index;
                             }
                         }
 
-                        _block = block;
                         _index = index + toMove;
                         return toReturn;
                     }
-
-                    var byte0 = byte0Vector[0];
-                    var byte1 = byte1Vector[0];
-                    var byte2 = byte2Vector[0];
-
-                    while (following > 0)
-                    {
-                        var byteIndex = block.Array[index];
-                        if (byteIndex == byte0)
-                        {
-                            _block = block;
-                            _index = index;
-                            return byte0;
-                        }
-                        else if (byteIndex == byte1)
-                        {
-                            _block = block;
-                            _index = index;
-                            return byte1;
-                        }
-                        else if (byteIndex == byte2)
-                        {
-                            _block = block;
-                            _index = index;
-                            return byte2;
-                        }
-                        following--;
-                        index++;
+#if !DEBUG // Need unit tests to test Vector path
                     }
+#endif
+                    fixed (byte* pArray = array)
+                    {
+                        var pCurrent = pArray + index;
+                        var pEnd = pArray + index + following;
+                        do
+                        {
+                            if (*pCurrent == byte0)
+                            {
+                                _block = block;
+                                _index = index;
+                                return byte0;
+                            }
+                            if (*pCurrent == byte1)
+                            {
+                                _block = block;
+                                _index = index;
+                                return byte1;
+                            }
+                            if (*pCurrent == byte2)
+                            {
+                                _block = block;
+                                _index = index;
+                                return byte2;
+                            }
+                            pCurrent++;
+                            index++;
+                        } while (pCurrent != pEnd);
+                    }
+                    following = 0;
+                    break;
                 }
             }
         }
 
-        private static int FindFirstEqualByte(Vector<byte> byteEquals)
+        private static int FindFirstEqualByte(ref Vector<byte> byteEquals)
         {
             // Quasi-tree search
             var vector64 = Vector.AsVectorInt64(byteEquals);
@@ -451,15 +504,14 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
                 if (vector32[shift] != 0)
                 {
                     if (byteEquals[offset] != 0) return offset;
-                    if (byteEquals[++offset] != 0) return offset;
-                    if (byteEquals[++offset] != 0) return offset;
-                    return ++offset;
+                    if (byteEquals[offset + 1] != 0) return offset + 1;
+                    if (byteEquals[offset + 2] != 0) return offset + 2;
+                    return offset + 3;
                 }
-                offset += 4;
-                if (byteEquals[offset] != 0) return offset;
-                if (byteEquals[++offset] != 0) return offset;
-                if (byteEquals[++offset] != 0) return offset;
-                return ++offset;
+                if (byteEquals[offset + 4] != 0) return offset + 4;
+                if (byteEquals[offset + 5] != 0) return offset + 5;
+                if (byteEquals[offset + 6] != 0) return offset + 6;
+                return offset + 7;
             }
             throw new InvalidOperationException();
         }

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2Extensions.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2Extensions.cs
@@ -26,18 +26,18 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         public const string Http10Version = "HTTP/1.0";
         public const string Http11Version = "HTTP/1.1";
 
-        private static long _httpConnectMethodLong = GetAsciiStringAsLong("CONNECT\0");
-        private static long _httpDeleteMethodLong = GetAsciiStringAsLong("DELETE\0\0");
-        private static long _httpGetMethodLong = GetAsciiStringAsLong("GET\0\0\0\0\0");
-        private static long _httpHeadMethodLong = GetAsciiStringAsLong("HEAD\0\0\0\0");
-        private static long _httpPatchMethodLong = GetAsciiStringAsLong("PATCH\0\0\0");
-        private static long _httpPostMethodLong = GetAsciiStringAsLong("POST\0\0\0\0");
-        private static long _httpPutMethodLong = GetAsciiStringAsLong("PUT\0\0\0\0\0");
-        private static long _httpOptionsMethodLong = GetAsciiStringAsLong("OPTIONS\0");
-        private static long _httpTraceMethodLong = GetAsciiStringAsLong("TRACE\0\0\0");
+        private readonly static long _httpConnectMethodLong = GetAsciiStringAsLong("CONNECT\0");
+        private readonly static long _httpDeleteMethodLong = GetAsciiStringAsLong("DELETE\0\0");
+        private readonly static long _httpGetMethodLong = GetAsciiStringAsLong("GET\0\0\0\0\0");
+        private readonly static long _httpHeadMethodLong = GetAsciiStringAsLong("HEAD\0\0\0\0");
+        private readonly static long _httpPatchMethodLong = GetAsciiStringAsLong("PATCH\0\0\0");
+        private readonly static long _httpPostMethodLong = GetAsciiStringAsLong("POST\0\0\0\0");
+        private readonly static long _httpPutMethodLong = GetAsciiStringAsLong("PUT\0\0\0\0\0");
+        private readonly static long _httpOptionsMethodLong = GetAsciiStringAsLong("OPTIONS\0");
+        private readonly static long _httpTraceMethodLong = GetAsciiStringAsLong("TRACE\0\0\0");
 
-        private static long _http10VersionLong = GetAsciiStringAsLong("HTTP/1.0");
-        private static long _http11VersionLong = GetAsciiStringAsLong("HTTP/1.1");
+        private readonly static long _http10VersionLong = GetAsciiStringAsLong("HTTP/1.0");
+        private readonly static long _http11VersionLong = GetAsciiStringAsLong("HTTP/1.1");
 
         private const int PerfectHashDivisor = 37;
         private static Tuple<long, string>[] _knownStrings = new Tuple<long, string>[PerfectHashDivisor];

--- a/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolBlock2Tests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolBlock2Tests.cs
@@ -27,27 +27,27 @@ namespace Microsoft.AspNet.Server.KestrelTests
                     var vectorCh = new Vector<byte>(ch);
 
                     var hit = iterator;
-                    hit.Seek(vectorCh);
+                    hit.Seek(ref vectorCh);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorCh, vectorMaxValues);
+                    hit.Seek(ref vectorCh, ref vectorMaxValues);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorMaxValues, vectorCh);
+                    hit.Seek(ref vectorMaxValues, ref vectorCh);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorCh, vectorMaxValues, vectorMaxValues);
+                    hit.Seek(ref vectorCh, ref vectorMaxValues, ref vectorMaxValues);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorMaxValues, vectorCh, vectorMaxValues);
+                    hit.Seek(ref vectorMaxValues, ref vectorCh, ref vectorMaxValues);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorCh, vectorMaxValues, vectorMaxValues);
+                    hit.Seek(ref vectorCh, ref vectorMaxValues, ref vectorMaxValues);
                     Assert.Equal(ch, iterator.GetLength(hit));
                 }
             }
@@ -56,6 +56,9 @@ namespace Microsoft.AspNet.Server.KestrelTests
         [Fact]
         public void SeekWorksAcrossBlocks()
         {
+            Console.WriteLine($"Vector.IsHardwareAccelerated == {Vector.IsHardwareAccelerated}");
+            Console.WriteLine($"Vector<byte>.Count == {Vector<byte>.Count}");
+
             using (var pool = new MemoryPool2())
             {
                 var block1 = pool.Lease(256);
@@ -83,27 +86,27 @@ namespace Microsoft.AspNet.Server.KestrelTests
                     var vectorCh = new Vector<byte>(ch);
 
                     var hit = iterator;
-                    hit.Seek(vectorCh);
+                    hit.Seek(ref vectorCh);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorCh, vectorMaxValues);
+                    hit.Seek(ref vectorCh, ref vectorMaxValues);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorMaxValues, vectorCh);
+                    hit.Seek(ref vectorMaxValues, ref vectorCh);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorCh, vectorMaxValues, vectorMaxValues);
+                    hit.Seek(ref vectorCh, ref vectorMaxValues, ref vectorMaxValues);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorMaxValues, vectorCh, vectorMaxValues);
+                    hit.Seek(ref vectorMaxValues, ref vectorCh, ref vectorMaxValues);
                     Assert.Equal(ch, iterator.GetLength(hit));
 
                     hit = iterator;
-                    hit.Seek(vectorMaxValues, vectorMaxValues, vectorCh);
+                    hit.Seek(ref vectorMaxValues, ref vectorMaxValues, ref vectorCh);
                     Assert.Equal(ch, iterator.GetLength(hit));
                 }
             }

--- a/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolIterator2Tests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MemoryPoolIterator2Tests.cs
@@ -50,18 +50,25 @@ namespace Microsoft.AspNet.Server.KestrelTests
             var begin = block.GetIterator();
             var searchFor = search.ToCharArray();
 
+
             int found = -1;
             if (searchFor.Length == 1)
             {
-                found = begin.Seek(new Vector<byte>((byte)searchFor[0]));
+                var search0 = new Vector<byte>((byte)searchFor[0]);
+                found = begin.Seek(ref search0);
             }
             else if (searchFor.Length == 2)
             {
-                found = begin.Seek(new Vector<byte>((byte)searchFor[0]), new Vector<byte>((byte)searchFor[1]));
+                var search0 = new Vector<byte>((byte)searchFor[0]);
+                var search1 = new Vector<byte>((byte)searchFor[1]);
+                found = begin.Seek(ref search0, ref search1);
             }
             else if (searchFor.Length == 3)
             {
-                found = begin.Seek(new Vector<byte>((byte)searchFor[0]), new Vector<byte>((byte)searchFor[1]), new Vector<byte>((byte)searchFor[2]));
+                var search0 = new Vector<byte>((byte)searchFor[0]);
+                var search1 = new Vector<byte>((byte)searchFor[1]);
+                var search2 = new Vector<byte>((byte)searchFor[2]);
+                found = begin.Seek(ref search0, ref search1, ref search2);
             }
             else
             {
@@ -218,7 +225,8 @@ namespace Microsoft.AspNet.Server.KestrelTests
             block.End += chars.Length;
             var begin = block.GetIterator();
             var end = begin;
-            end.Seek(new Vector<byte>((byte)endChar));
+            var endVector = new Vector<byte>((byte)endChar);
+            end.Seek(ref endVector);
             string knownString;
 
             // Act


### PR DESCRIPTION
Static vectors by ref rather than by copy
Faster path when length < `Vector<byte>.Count`
Skip Vector path when `Vector.IsHardwareAccelerated != true` unless in debug/test (e.g. linux and x86)

Linux hopefully resolved in RC2? https://github.com/dotnet/coreclr/issues/983

Resolves #512
Resolves #515
