### PR TITLE
Concurrent work queues, less native async_send transitions

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -277,12 +277,17 @@ namespace Microsoft.AspNet.Server.Kestrel
 
         private void OnPost()
         {
-            do
+            DoPostWork();
+            DoPostCloseHandle();
+
+            if (_loopIdle == false)
             {
+                _loopIdle = true;
+                // Run the loops once more to pick up any remaining event that 
+                // might not have triggered uv_async_send due to loop not being idle
                 DoPostWork();
                 DoPostCloseHandle();
-                _loopIdle = _workQueue.IsEmpty && _closeHandleQueue.IsEmpty;
-            } while (!_loopIdle);
+            }
         }
 
         private void DoPostWork()


### PR DESCRIPTION
Process queues till complete
Remove the high contention locks
Reduce the calls to native `async_send` when not required (e.g. loop is currently processing).

From #519