### PR TITLE
[Wip] Differentiate write and write2 + simplify

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerPrimary.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
 
         // this message is passed to write2 because it must be non-zero-length, 
         // but it has no other functional significance
-        private readonly ArraySegment<ArraySegment<byte>> _dummyMessage = new ArraySegment<ArraySegment<byte>>(new[] { new ArraySegment<byte>(new byte[] { 1, 2, 3, 4 }) });
+        private readonly ArraySegment<byte> _dummyMessage = new ArraySegment<byte>(new byte[] { 1, 2, 3, 4 });
 
         protected ListenerPrimary(ServiceContext serviceContext) : base(serviceContext)
         {
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             else
             {
                 var dispatchPipe = _dispatchPipes[index];
-                var write = new UvWriteReq(Log);
+                var write = new UvWrite2Req(Log);
                 write.Init(Thread.Loop);
                 write.Write2(
                     dispatchPipe,

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerPrimary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerPrimary.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             else
             {
                 var dispatchPipe = _dispatchPipes[index];
-                var write = new UvWrite2Req(Log);
+                var write = new UvWriteReq2(Log);
                 write.Init(Thread.Loop);
                 write.Write2(
                     dispatchPipe,

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq2.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNet.Server.Kestrel.Networking
+{
+    /// <summary>
+    /// Summary description for UvWriteRequest2
+    /// </summary>
+    public class UvWrite2Req : UvRequest
+    {
+        private readonly static Libuv.uv_write_cb _uv_write2_cb = (IntPtr ptr, int status) => UvWrite2Cb(ptr, status);
+
+        private IntPtr _bufs;
+
+        private Action<UvWrite2Req, int, Exception, object> _callback;
+        private object _state;
+        private const int BUFFER_COUNT = 1;
+
+        private GCHandle _pinUvWrite2Req;
+        private GCHandle _pinBuffer;
+        private bool _bufferIsPinned;
+
+        public UvWrite2Req(IKestrelTrace logger) : base(logger)
+        {
+        }
+
+        public void Init(UvLoopHandle loop)
+        {
+            var requestSize = loop.Libuv.req_size(Libuv.RequestType.WRITE);
+            var bufferSize = Marshal.SizeOf<Libuv.uv_buf_t>() * BUFFER_COUNT;
+            CreateMemory(
+                loop.Libuv,
+                loop.ThreadId,
+                requestSize + bufferSize);
+            _bufs = handle + requestSize;
+        }
+
+        public unsafe void Write2(
+            UvStreamHandle handle,
+            ArraySegment<byte> buf,
+            UvStreamHandle sendHandle,
+            Action<UvWrite2Req, int, Exception, object> callback,
+            object state)
+        {
+            try
+            {
+                // add GCHandle to keeps this SafeHandle alive while request processing
+                _pinUvWrite2Req = GCHandle.Alloc(this, GCHandleType.Normal);
+
+                var pBuffers = (Libuv.uv_buf_t*)_bufs;
+                _pinBuffer = GCHandle.Alloc(buf.Array, GCHandleType.Pinned);
+                _bufferIsPinned = true;
+
+                pBuffers[0] = Libuv.buf_init(
+                    _pinBuffer.AddrOfPinnedObject() + buf.Offset,
+                    buf.Count);
+
+                _callback = callback;
+                _state = state;
+                _uv.write2(this, handle, pBuffers, BUFFER_COUNT, sendHandle, _uv_write2_cb);
+            }
+            catch
+            {
+                _callback = null;
+                _state = null;
+                Unpin(this);
+                throw;
+            }
+        }
+
+        private static void Unpin(UvWrite2Req req)
+        {
+            req._pinUvWrite2Req.Free();
+            if (req._bufferIsPinned)
+            {
+                req._pinBuffer.Free();
+                req._bufferIsPinned = false;
+            }
+        }
+
+        private static void UvWrite2Cb(IntPtr ptr, int status)
+        {
+            var req = FromIntPtr<UvWrite2Req>(ptr);
+            Unpin(req);
+
+            var callback = req._callback;
+            req._callback = null;
+
+            var state = req._state;
+            req._state = null;
+
+            Exception error = null;
+            if (status < 0)
+            {
+                req.Libuv.Check(status, out error);
+            }
+
+            try
+            {
+                callback(req, status, error, state);
+            }
+            catch (Exception ex)
+            {
+                req._log.LogError("UvWrite2Cb", ex);
+                throw;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Networking/UvWriteReq2.cs
@@ -11,13 +11,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
     /// <summary>
     /// Summary description for UvWriteRequest2
     /// </summary>
-    public class UvWrite2Req : UvRequest
+    public class UvWriteReq2 : UvRequest
     {
         private readonly static Libuv.uv_write_cb _uv_write2_cb = (IntPtr ptr, int status) => UvWrite2Cb(ptr, status);
 
         private IntPtr _bufs;
 
-        private Action<UvWrite2Req, int, Exception, object> _callback;
+        private Action<UvWriteReq2, int, Exception, object> _callback;
         private object _state;
         private const int BUFFER_COUNT = 1;
 
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
         private GCHandle _pinBuffer;
         private bool _bufferIsPinned;
 
-        public UvWrite2Req(IKestrelTrace logger) : base(logger)
+        public UvWriteReq2(IKestrelTrace logger) : base(logger)
         {
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             UvStreamHandle handle,
             ArraySegment<byte> buf,
             UvStreamHandle sendHandle,
-            Action<UvWrite2Req, int, Exception, object> callback,
+            Action<UvWriteReq2, int, Exception, object> callback,
             object state)
         {
             try
@@ -73,7 +73,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
             }
         }
 
-        private static void Unpin(UvWrite2Req req)
+        private static void Unpin(UvWriteReq2 req)
         {
             req._pinUvWrite2Req.Free();
             if (req._bufferIsPinned)
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Networking
 
         private static void UvWrite2Cb(IntPtr ptr, int status)
         {
-            var req = FromIntPtr<UvWrite2Req>(ptr);
+            var req = FromIntPtr<UvWriteReq2>(ptr);
             Unpin(req);
 
             var callback = req._callback;

--- a/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
@@ -163,11 +163,11 @@ namespace Microsoft.AspNet.Server.KestrelTests
 
                 serverConnectionPipeAcceptedEvent.WaitOne();
 
-                var writeRequest = new UvWriteReq(new KestrelTrace(new TestKestrelTrace()));
+                var writeRequest = new UvWrite2Req(new KestrelTrace(new TestKestrelTrace()));
                 writeRequest.Init(loop);
                 writeRequest.Write2(
                     serverConnectionPipe,
-                    new ArraySegment<ArraySegment<byte>>(new ArraySegment<byte>[] { new ArraySegment<byte>(new byte[] { 1, 2, 3, 4 }) }),
+                    new ArraySegment<byte>(new byte[] { 1, 2, 3, 4 }),
                     serverConnectionTcp,
                     (_3, status2, error2, _4) =>
                     {

--- a/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/MultipleLoopTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
 
                 serverConnectionPipeAcceptedEvent.WaitOne();
 
-                var writeRequest = new UvWrite2Req(new KestrelTrace(new TestKestrelTrace()));
+                var writeRequest = new UvWriteReq2(new KestrelTrace(new TestKestrelTrace()));
                 writeRequest.Init(loop);
                 writeRequest.Write2(
                     serverConnectionPipe,


### PR DESCRIPTION
UvWriteReq only uses pooled blocks
UvWrite2Req only has one buffer
`List<GCHandle>` isn't needed

From #519 