### PR TITLE
One-time leased blocks should not be tracked on Return

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamSocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Filter/StreamSocketOutput.cs
@@ -51,11 +51,11 @@ namespace Microsoft.AspNet.Server.Kestrel.Filter
 
                 var returnBlock = block;
                 block = block.Next;
-                returnBlock.Pool?.Return(returnBlock);
+                returnBlock.Pool.Return(returnBlock);
             }
 
             _outputStream.Write(end.Block.Array, end.Block.Data.Offset, end.Index - end.Block.Data.Offset);
-            end.Block.Pool?.Return(end.Block);
+            end.Block.Pool.Return(end.Block);
         }
     }
 }

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/SocketOutput.cs
@@ -241,7 +241,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                 var returningBlock = block;
                 block = returningBlock.Next;
 
-                returningBlock.Pool?.Return(returningBlock);
+                returningBlock.Pool.Return(returningBlock);
             }
         }
 
@@ -341,13 +341,13 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     var returnBlock = block;
                     block = block.Next;
 
-                    returnBlock.Pool?.Return(returnBlock);
+                    returnBlock.Pool.Return(returnBlock);
                 }
 
                 // Only return the _tail if we aren't between ProducingStart/Complete calls
                 if (_lastStart.IsDefault)
                 {
-                    _tail.Pool?.Return(_tail);
+                    _tail.Pool.Return(_tail);
                 }
 
                 _head = null;
@@ -559,7 +559,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
                     block = block.Next;
 
                     returnBlock.Unpin();
-                    returnBlock.Pool?.Return(returnBlock);
+                    returnBlock.Pool.Return(returnBlock);
                 }
             }
 

--- a/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Infrastructure/MemoryPoolIterator2.cs
@@ -695,7 +695,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         public void CopyFrom(byte[] data, int offset, int count)
         {
             Debug.Assert(_block != null);
-            Debug.Assert(_block.Pool != null);
             Debug.Assert(_block.Next == null);
             Debug.Assert(_block.End == _index);
 
@@ -738,7 +737,6 @@ namespace Microsoft.AspNet.Server.Kestrel.Infrastructure
         public unsafe void CopyFromAscii(string data)
         {
             Debug.Assert(_block != null);
-            Debug.Assert(_block.Pool != null);
             Debug.Assert(_block.Next == null);
             Debug.Assert(_block.End == _index);
 


### PR DESCRIPTION
Is there any reason too?