### PR TITLE
Fix typo

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ListenerSecondary.cs
@@ -151,7 +151,7 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
             var ptr = Interlocked.Exchange(ref _ptr, IntPtr.Zero);
             if (ptr != IntPtr.Zero)
             {
-                Marshal.FreeHGlobal(_ptr);
+                Marshal.FreeHGlobal(ptr);
             }
         }
 


### PR DESCRIPTION
Looks like value from wrong variable is passed to Marshal.FreeHGlobal method. So IntPtr.Zero is passed to the method and actual pointer is lost.