### PR TITLE
Make all write operations atomic

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ChunkWriter.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ChunkWriter.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
+
+namespace Microsoft.AspNet.Server.Kestrel.Http
+{
+    public static class ChunkWriter
+    {
+        private static readonly ArraySegment<byte> _endChunkBytes = CreateAsciiByteArraySegment("\r\n");
+        private static readonly byte[] _hex = Encoding.ASCII.GetBytes("0123456789abcdef");
+
+        private static ArraySegment<byte> CreateAsciiByteArraySegment(string text)
+        {
+            var bytes = Encoding.ASCII.GetBytes(text);
+            return new ArraySegment<byte>(bytes);
+        }
+
+        public static ArraySegment<byte> BeginChunkBytes(int dataCount)
+        {
+            var bytes = new byte[10]
+            {
+                _hex[((dataCount >> 0x1c) & 0x0f)],
+                _hex[((dataCount >> 0x18) & 0x0f)],
+                _hex[((dataCount >> 0x14) & 0x0f)],
+                _hex[((dataCount >> 0x10) & 0x0f)],
+                _hex[((dataCount >> 0x0c) & 0x0f)],
+                _hex[((dataCount >> 0x08) & 0x0f)],
+                _hex[((dataCount >> 0x04) & 0x0f)],
+                _hex[((dataCount >> 0x00) & 0x0f)],
+                (byte)'\r',
+                (byte)'\n',
+            };
+
+            // Determine the most-significant non-zero nibble
+            int total, shift;
+            total = (dataCount > 0xffff) ? 0x10 : 0x00;
+            dataCount >>= total;
+            shift = (dataCount > 0x00ff) ? 0x08 : 0x00;
+            dataCount >>= shift;
+            total |= shift;
+            total |= (dataCount > 0x000f) ? 0x04 : 0x00;
+
+            var offset = 7 - (total >> 2);
+            return new ArraySegment<byte>(bytes, offset, 10 - offset);
+        }
+
+        public static int WriteBeginChunkBytes(ref MemoryPoolIterator2 start, int dataCount)
+        {
+            var chunkSegment = BeginChunkBytes(dataCount);
+            start.CopyFrom(chunkSegment);
+            return chunkSegment.Count;
+        }
+
+        public static void WriteEndChunkBytes(ref MemoryPoolIterator2 start)
+        {
+            start.CopyFrom(_endChunkBytes);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.Kestrel/Http/ISocketOutput.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel/Http/ISocketOutput.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNet.Server.Kestrel.Http
     /// </summary>
     public interface ISocketOutput
     {
-        void Write(ArraySegment<byte> buffer, bool immediate = true);
-        Task WriteAsync(ArraySegment<byte> buffer, bool immediate = true, CancellationToken cancellationToken = default(CancellationToken));
+        void Write(ArraySegment<byte> buffer, bool immediate = true, bool chunk = false);
+        Task WriteAsync(ArraySegment<byte> buffer, bool immediate = true, bool chunk = false, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Returns an iterator pointing to the tail of the response buffer. Response data can be appended

--- a/test/Microsoft.AspNet.Server.KestrelTests/ChunkWriterTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/ChunkWriterTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Text;
+using Microsoft.AspNet.Server.Kestrel.Http;
+using Xunit;
+
+namespace Microsoft.AspNet.Server.KestrelTests
+{
+    public class ChunkWriterTests
+    {
+        [Theory]
+        [InlineData(1, "1\r\n")]
+        [InlineData(10, "a\r\n")]
+        [InlineData(0x08, "8\r\n")]
+        [InlineData(0x10, "10\r\n")]
+        [InlineData(0x080, "80\r\n")]
+        [InlineData(0x100, "100\r\n")]
+        [InlineData(0x0800, "800\r\n")]
+        [InlineData(0x1000, "1000\r\n")]
+        [InlineData(0x08000, "8000\r\n")]
+        [InlineData(0x10000, "10000\r\n")]
+        [InlineData(0x080000, "80000\r\n")]
+        [InlineData(0x100000, "100000\r\n")]
+        [InlineData(0x0800000, "800000\r\n")]
+        [InlineData(0x1000000, "1000000\r\n")]
+        [InlineData(0x08000000, "8000000\r\n")]
+        [InlineData(0x10000000, "10000000\r\n")]
+        [InlineData(0x7fffffffL, "7fffffff\r\n")]
+        public void ChunkedPrefixMustBeHexCrLfWithoutLeadingZeros(int dataCount, string expected)
+        {
+            var beginChunkBytes = ChunkWriter.BeginChunkBytes(dataCount);
+
+            Assert.Equal(Encoding.ASCII.GetBytes(expected), beginChunkBytes.ToArray());
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/FrameTests.cs
@@ -14,31 +14,6 @@ namespace Microsoft.AspNet.Server.KestrelTests
     public class FrameTests
     {
         [Theory]
-        [InlineData(1, "1\r\n")]
-        [InlineData(10, "a\r\n")]
-        [InlineData(0x08, "8\r\n")]
-        [InlineData(0x10, "10\r\n")]
-        [InlineData(0x080, "80\r\n")]
-        [InlineData(0x100, "100\r\n")]
-        [InlineData(0x0800, "800\r\n")]
-        [InlineData(0x1000, "1000\r\n")]
-        [InlineData(0x08000, "8000\r\n")]
-        [InlineData(0x10000, "10000\r\n")]
-        [InlineData(0x080000, "80000\r\n")]
-        [InlineData(0x100000, "100000\r\n")]
-        [InlineData(0x0800000, "800000\r\n")]
-        [InlineData(0x1000000, "1000000\r\n")]
-        [InlineData(0x08000000, "8000000\r\n")]
-        [InlineData(0x10000000, "10000000\r\n")]
-        [InlineData(0x7fffffffL, "7fffffff\r\n")]
-        public void ChunkedPrefixMustBeHexCrLfWithoutLeadingZeros(int dataCount, string expected)
-        {
-            var beginChunkBytes = Frame.BeginChunkBytes(dataCount);
-
-            Assert.Equal(Encoding.ASCII.GetBytes(expected), beginChunkBytes.ToArray());
-        }
-        
-        [Theory]
         [InlineData("Cookie: \r\n\r\n", 1)]
         [InlineData("Cookie:\r\n\r\n", 1)]
         [InlineData("Cookie:\r\n value\r\n\r\n", 1)]


### PR DESCRIPTION
This PR ensures that simultaneous calls to `SocketOutput.WriteAsync` won't result in a corrupted write.

This was mainly achieved by moving the `CopyFrom` call inside of `SocketOutput.WriteAsync` inside of the `_contenxtLock`. I also moved chunking down a layer inside of `SocketOutput`, so it could be protected by the same lock.

I tested this change using both the plaintext benchmark and a modified LargeResponseSample that used small chunking, and in both cases the performance was nearly identical <1% to dev.

When I first tried only moving `CopyFrom` inside of the lock, I saw performance degradation of a few percent. I was able to remedy this by using `Monitor.TryEnter` to avoid stalling libuv threads.