### PR TITLE
Bypass LibuvStream if no ConnectionFilter wraps it

### DIFF
--- a/src/Microsoft.AspNet.Server.Kestrel.Https/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNet.Server.Kestrel.Https/Properties/AssemblyInfo.cs
@@ -5,5 +5,6 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Microsoft.AspNet.Server.KestrelTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]

--- a/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNet.Server.KestrelTests/EngineTests.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -13,7 +13,7 @@ using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Features;
 using Microsoft.AspNet.Server.Kestrel;
 using Microsoft.AspNet.Server.Kestrel.Filter;
-using Microsoft.AspNet.Server.Kestrel.Http;
+using Microsoft.AspNet.Server.Kestrel.Infrastructure;
 using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -37,7 +37,7 @@ namespace Microsoft.AspNet.Server.KestrelTests
                     {
                         new TestServiceContext
                         {
-                            ConnectionFilter = new NoOpConnectionFilter()
+                            ConnectionFilter = new PassThroughConnectionFilter()
                         }
                     }
                 };
@@ -1175,6 +1175,15 @@ namespace Microsoft.AspNet.Server.KestrelTests
                 {
                     ApplicationErrorsLogged++;
                 }
+            }
+        }
+
+        private class PassThroughConnectionFilter : IConnectionFilter
+        {
+            public Task OnConnectionAsync(ConnectionFilterContext context)
+            {
+                context.Connection = new LoggingStream(context.Connection, new TestApplicationErrorLogger());
+                return TaskUtilities.CompletedTask;
             }
         }
     }


### PR DESCRIPTION
I haven't come up with a great way to test it, but it makes the stacks way nicer when debugging our SampleApp using port 5000 (which SslStream doesn't wrap).

I know that this might technically fall under "perf", but I think it's nice to avoid all the ConnectionFilter machinery if all the filters decided to not actually wrap the connection. 