### PR TITLE
StreamSocketOutput WriteAsync as async (SSL)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Filter/StreamSocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Filter/StreamSocketOutput.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Filter
             var beginChunkBytes = ChunkWriter.BeginChunkBytes(buffer.Count);
 
             await _outputStream.WriteAsync(beginChunkBytes.Array, beginChunkBytes.Offset, beginChunkBytes.Count, cancellationToken);
-            await _outputStream.WriteAsync(buffer.Array ?? _nullBuffer, buffer.Offset, buffer.Count, cancellationToken);
+            await _outputStream.WriteAsync(buffer.Array, buffer.Offset, buffer.Count, cancellationToken);
             await _outputStream.WriteAsync(_endChunkBytes, 0, _endChunkBytes.Length, cancellationToken);
         }
 


### PR DESCRIPTION
This prevents https from being async

Blocked by https://github.com/dotnet/corefx/issues/5488 / https://github.com/dotnet/corefx/issues/5077

Blockers
- [x] https://github.com/dotnet/corefx/pull/5534
- [x] https://github.com/dotnet/coreclr/pull/2724
- [x] https://github.com/dotnet/corefx/pull/5541
- [x] dotnet/corefx#7800
- [x] dotnet/corefx#7819

Resolves #569

Works on coreclr, ifdef'd for full framework