### PR TITLE
Don't use named pipes to support multithreading on windows

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Listener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Listener.cs
@@ -13,20 +13,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
     /// </summary>
     public abstract class Listener : ListenerContext, IDisposable
     {
-        protected Listener(ServiceContext serviceContext) 
+        protected Listener(ServiceContext serviceContext, ServerAddress addreess, KestrelThread thread) 
             : base(serviceContext)
         {
+            ServerAddress = addreess;
+            Thread = thread;
         }
 
         protected UvStreamHandle ListenSocket { get; private set; }
 
-        public Task StartAsync(
-            ServerAddress address,
-            KestrelThread thread)
+        public Task StartAsync()
         {
-            ServerAddress = address;
-            Thread = thread;
-
             var tcs = new TaskCompletionSource<int>(this);
 
             Thread.Post(tcs2 =>
@@ -77,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             connection.Start();
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             // Ensure the event loop is still running.
             // If the event loop isn't running and we try to wait on this Post

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/ListenerPrimary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/ListenerPrimary.cs
@@ -24,23 +24,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         // but it has no other functional significance
         private readonly ArraySegment<ArraySegment<byte>> _dummyMessage = new ArraySegment<ArraySegment<byte>>(new[] { new ArraySegment<byte>(new byte[] { 1, 2, 3, 4 }) });
 
-        protected ListenerPrimary(ServiceContext serviceContext) : base(serviceContext)
+        protected ListenerPrimary(ServiceContext serviceContext, ServerAddress address, KestrelThread thread, string pipeName)
+            : base(serviceContext, address, thread)
         {
+            _pipeName = pipeName;
         }
 
         private UvPipeHandle ListenPipe { get; set; }
 
-        public async Task StartAsync(
-            string pipeName,
-            ServerAddress address,
-            KestrelThread thread)
+        public async Task StartPrimaryAsync()
         {
-            _pipeName = pipeName;
+            await StartAsync().ConfigureAwait(false);
 
-            await StartAsync(address, thread).ConfigureAwait(false);
-
-            await Thread.PostAsync(_this => _this.PostCallback(), 
-                                    this).ConfigureAwait(false);
+            await Thread.PostAsync(state => ((ListenerPrimary)state).PostCallback(), 
+                                   this).ConfigureAwait(false);
         }
 
         private void PostCallback()

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/PipeListener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/PipeListener.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Networking;
 using Microsoft.Extensions.Logging;
@@ -13,7 +12,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
     /// </summary>
     public class PipeListener : Listener
     {
-        public PipeListener(ServiceContext serviceContext) : base(serviceContext)
+        public PipeListener(ServiceContext serviceContext, ServerAddress address, KestrelThread thread)
+            : base(serviceContext, address, thread)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/PipeListenerPrimary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/PipeListenerPrimary.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Networking;
 using Microsoft.Extensions.Logging;
@@ -13,7 +12,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
     /// </summary>
     public class PipeListenerPrimary : ListenerPrimary
     {
-        public PipeListenerPrimary(ServiceContext serviceContext) : base(serviceContext)
+        public PipeListenerPrimary(ServiceContext serviceContext, ServerAddress address, KestrelThread thread, string pipeName)
+            : base(serviceContext, address, thread, pipeName)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/PipeListenerSecondary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/PipeListenerSecondary.cs
@@ -10,7 +10,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
     /// </summary>
     public class PipeListenerSecondary : ListenerSecondary
     {
-        public PipeListenerSecondary(ServiceContext serviceContext) : base(serviceContext)
+        public PipeListenerSecondary(ServiceContext serviceContext, ServerAddress address, KestrelThread thread, string pipeName)
+            : base(serviceContext, address, thread, pipeName)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListener.cs
@@ -12,7 +12,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
     /// </summary>
     public class TcpListener : Listener
     {
-        public TcpListener(ServiceContext serviceContext) : base(serviceContext)
+        public TcpListener(ServiceContext serviceContext, ServerAddress address, KestrelThread thread)
+            : base(serviceContext, address, thread)
         {
         }
 
@@ -44,7 +45,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 acceptSocket.NoDelay(NoDelay);
                 listenSocket.Accept(acceptSocket);
                 DispatchConnection(acceptSocket);
-
             }
             catch (UvException ex)
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerMultithreaded.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerMultithreaded.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Networking;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Http
+{
+    /// <summary>
+    /// A Windows-only implementation of <see cref="TcpListener"/> that disptaches connection processing
+    /// to multiple threads/libuv loops.
+    /// </summary>
+    public class TcpListenerMultithreaded : TcpListener
+    {
+        private ListenerContext[] _secondaryListeners;
+        private int _dispatchIndex;
+
+        public TcpListenerMultithreaded(ServiceContext serviceContext, ServerAddress address, List<KestrelThread> threads)
+            : base(serviceContext, address, threads[0])
+        {
+            _secondaryListeners = new ListenerContext[threads.Count - 1];
+
+            for (int i = 1; i < threads.Count; i++)
+            {
+                var secondaryContext = new ListenerContext(serviceContext);
+                secondaryContext.Thread = threads[i];
+                secondaryContext.ServerAddress = address;
+                _secondaryListeners[i - 1] = secondaryContext;
+            }
+        }
+
+        /// <summary>
+        /// Handles an incoming connection does round-robin dispatching to various kestrel threads
+        /// </summary>
+        /// <param name="listenSocket">Socket being used to listen on</param>
+        /// <param name="status">Connection status</param>
+        protected override void OnConnection(UvStreamHandle listenSocket, int status)
+        {
+            _dispatchIndex = (_dispatchIndex + 1) % _secondaryListeners.Length;
+            var secondaryThread = _secondaryListeners[_dispatchIndex].Thread;
+
+            try
+            {
+                // Block the primary thread until the client thread accepts the connection
+                // to avoid potential race conditions.
+                secondaryThread.PostAsync(state =>
+                {
+                    var listener = (TcpListenerMultithreaded)state;
+                    listener.DispatchConnectionToContext();
+                }, this).Wait();
+            }
+            catch (UvException ex)
+            {
+                Log.LogError("TcpListenerMultithreaded.OnConnection", ex);
+                return;
+            }
+        }
+
+        private void DispatchConnectionToContext()
+        {
+            var secondaryContext = _secondaryListeners[_dispatchIndex];
+            var acceptSocket = new UvTcpHandle(Log);
+
+            try
+            {
+                acceptSocket.Init(secondaryContext.Thread.Loop);
+                acceptSocket.NoDelay(NoDelay);
+                ListenSocket.Accept(acceptSocket, crossThread: true);
+            }
+            catch (UvException ex)
+            {
+                Log.LogError("DispatchConnectionToContext.DispatchConnectionToContext", ex);
+            }
+
+            var connection = new Connection(secondaryContext, acceptSocket);
+            connection.Start();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            var disposeTasks = new List<Task>();
+
+            foreach (var listener in _secondaryListeners)
+            {
+                // Ensure the event loop is still running.
+                // If the event loop isn't running and we try to wait on this Post
+                // to complete, then KestrelEngine will never be disposed and
+                // the exception that stopped the event loop will never be surfaced.
+                if (listener.Thread.FatalError == null)
+                {
+                    var disposeTask = listener.Thread.PostAsync(state =>
+                    {
+                        var context = (ListenerContext)state;
+                        var writeReqPool = context.WriteReqPool;
+                        while (writeReqPool.Count > 0)
+                        {
+                            writeReqPool.Dequeue().Dispose();
+                        }
+                    }, listener);
+
+                    disposeTasks.Add(disposeTask);
+                }
+            }
+
+            Task.WhenAll(disposeTasks).Wait();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerPrimary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerPrimary.cs
@@ -14,7 +14,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
     /// </summary>
     public class TcpListenerPrimary : ListenerPrimary
     {
-        public TcpListenerPrimary(ServiceContext serviceContext) : base(serviceContext)
+        public TcpListenerPrimary(ServiceContext serviceContext, ServerAddress address, KestrelThread thread, string pipeName)
+            : base(serviceContext, address, thread, pipeName)
         {
         }
 
@@ -46,7 +47,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 acceptSocket.NoDelay(NoDelay);
                 listenSocket.Accept(acceptSocket);
                 DispatchConnection(acceptSocket);
-
             }
             catch (UvException ex)
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerSecondary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerSecondary.cs
@@ -10,7 +10,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
     /// </summary>
     public class TcpListenerSecondary : ListenerSecondary
     {
-        public TcpListenerSecondary(ServiceContext serviceContext) : base(serviceContext)
+        public TcpListenerSecondary(ServiceContext serviceContext, ServerAddress address, KestrelThread thread, string pipeName)
+            : base(serviceContext, address, thread, pipeName)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Networking/Libuv.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Networking/Libuv.cs
@@ -257,9 +257,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Networking
         }
 
         protected Func<UvStreamHandle, UvStreamHandle, int> _uv_accept;
-        public void accept(UvStreamHandle server, UvStreamHandle client)
+        public void accept(UvStreamHandle server, UvStreamHandle client, bool crossThread)
         {
-            server.Validate();
+            server.Validate(closed: false, crossThread: crossThread);
             client.Validate();
             Check(_uv_accept(server, client));
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Networking/UvMemory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Networking/UvMemory.cs
@@ -75,11 +75,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Networking
             return handle;
         }
 
-        public void Validate(bool closed = false)
+        public void Validate(bool closed = false, bool crossThread = false)
         {
             Debug.Assert(closed || !IsClosed, "Handle is closed");
             Debug.Assert(!IsInvalid, "Handle is invalid");
-            Debug.Assert(_threadId == Thread.CurrentThread.ManagedThreadId, "ThreadId is incorrect");
+            Debug.Assert(crossThread || _threadId == Thread.CurrentThread.ManagedThreadId, "ThreadId is incorrect");
         }
 
         unsafe public static THandle FromIntPtr<THandle>(IntPtr handle)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Networking/UvStreamHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Networking/UvStreamHandle.cs
@@ -66,9 +66,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Networking
             }
         }
 
-        public void Accept(UvStreamHandle handle)
+        public void Accept(UvStreamHandle handle, bool crossThread = false)
         {
-            _uv.accept(this, handle);
+            _uv.accept(this, handle, crossThread);
         }
 
         public void ReadStart(


### PR DESCRIPTION
- Fixes multithreading support on Azure Web Apps
- Allows secondary threads to use IOCPs

#582