### PR TITLE
Reduce lifetime of header values

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Connection.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             }
 
             // Don't initialize _frame until SocketInput and SocketOutput are set to their final values.
-            if (ConnectionFilter == null)
+            if (ServerInformation.ConnectionFilter == null)
             {
                 SocketInput = _rawSocketInput;
                 SocketOutput = _rawSocketOutput;
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 
                 try
                 {
-                    ConnectionFilter.OnConnectionAsync(_filterContext).ContinueWith((task, state) =>
+                    ServerInformation.ConnectionFilter.OnConnectionAsync(_filterContext).ContinueWith((task, state) =>
                     {
                         var connection = (Connection)state;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
@@ -656,8 +656,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             byte[] statusBytes,
             bool appCompleted)
         {
-            var end = SocketOutput.ProducingStart();
             var responseHeaders = _frameHeaders.ResponseHeaders;
+            responseHeaders.SetReadOnly();
+
+            var end = SocketOutput.ProducingStart();
             if (_keepAlive)
             {
                 foreach (var connectionValue in responseHeaders.HeaderConnection)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
@@ -266,20 +266,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         {
             if (_frameHeaders != null)
             {
-                RequestHeaders = null;
-                ResponseHeaders = null;
                 var frameHeaders = _frameHeaders;
                 _frameHeaders = null;
+
+                RequestHeaders = null;
+                ResponseHeaders = null;
                 HttpComponentFactory.DisposeHeaders(frameHeaders, poolingPermitted);
             }
 
             if (_frameStreams != null)
             {
+                var frameStreams = _frameStreams;
+                _frameStreams = null;
+
                 RequestBody = null;
                 ResponseBody = null;
                 DuplexStream = null;
-                var frameStreams = _frameStreams;
-                _frameStreams = null;
                 HttpComponentFactory.DisposeStreams(frameStreams, poolingPermitted);
             }
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
@@ -45,6 +45,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         private readonly object _onStartingSync = new Object();
         private readonly object _onCompletedSync = new Object();
 
+        protected bool _poolingPermitted = true;
         private Headers _frameHeaders;
         private Streams _frameStreams;
 
@@ -279,7 +280,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 DuplexStream = null;
                 var frameStreams = _frameStreams;
                 _frameStreams = null;
-                HttpComponentFactory.DisposeStreams(frameStreams, poolingPermitted: (poolingPermitted && ReuseStreams));
+                HttpComponentFactory.DisposeStreams(frameStreams, poolingPermitted);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameHeaders.Generated.cs
@@ -3737,6 +3737,51 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         }
         protected override void ClearFast()
         {
+            if (((_bits & 1L) != 0)) _CacheControl = default(StringValues);
+            if (((_bits & 2L) != 0)) _Connection = default(StringValues);
+            if (((_bits & 4L) != 0)) _Date = default(StringValues);
+            if (((_bits & 8L) != 0)) _KeepAlive = default(StringValues);
+            if (((_bits & 16L) != 0)) _Pragma = default(StringValues);
+            if (((_bits & 32L) != 0)) _Trailer = default(StringValues);
+            if (((_bits & 64L) != 0)) _TransferEncoding = default(StringValues);
+            if (((_bits & 128L) != 0)) _Upgrade = default(StringValues);
+            if (((_bits & 256L) != 0)) _Via = default(StringValues);
+            if (((_bits & 512L) != 0)) _Warning = default(StringValues);
+            if (((_bits & 1024L) != 0)) _Allow = default(StringValues);
+            if (((_bits & 2048L) != 0)) _ContentLength = default(StringValues);
+            if (((_bits & 4096L) != 0)) _ContentType = default(StringValues);
+            if (((_bits & 8192L) != 0)) _ContentEncoding = default(StringValues);
+            if (((_bits & 16384L) != 0)) _ContentLanguage = default(StringValues);
+            if (((_bits & 32768L) != 0)) _ContentLocation = default(StringValues);
+            if (((_bits & 65536L) != 0)) _ContentMD5 = default(StringValues);
+            if (((_bits & 131072L) != 0)) _ContentRange = default(StringValues);
+            if (((_bits & 262144L) != 0)) _Expires = default(StringValues);
+            if (((_bits & 524288L) != 0)) _LastModified = default(StringValues);
+            if (((_bits & 1048576L) != 0)) _Accept = default(StringValues);
+            if (((_bits & 2097152L) != 0)) _AcceptCharset = default(StringValues);
+            if (((_bits & 4194304L) != 0)) _AcceptEncoding = default(StringValues);
+            if (((_bits & 8388608L) != 0)) _AcceptLanguage = default(StringValues);
+            if (((_bits & 16777216L) != 0)) _Authorization = default(StringValues);
+            if (((_bits & 33554432L) != 0)) _Cookie = default(StringValues);
+            if (((_bits & 67108864L) != 0)) _Expect = default(StringValues);
+            if (((_bits & 134217728L) != 0)) _From = default(StringValues);
+            if (((_bits & 268435456L) != 0)) _Host = default(StringValues);
+            if (((_bits & 536870912L) != 0)) _IfMatch = default(StringValues);
+            if (((_bits & 1073741824L) != 0)) _IfModifiedSince = default(StringValues);
+            if (((_bits & 2147483648L) != 0)) _IfNoneMatch = default(StringValues);
+            if (((_bits & 4294967296L) != 0)) _IfRange = default(StringValues);
+            if (((_bits & 8589934592L) != 0)) _IfUnmodifiedSince = default(StringValues);
+            if (((_bits & 17179869184L) != 0)) _MaxForwards = default(StringValues);
+            if (((_bits & 34359738368L) != 0)) _ProxyAuthorization = default(StringValues);
+            if (((_bits & 68719476736L) != 0)) _Referer = default(StringValues);
+            if (((_bits & 137438953472L) != 0)) _Range = default(StringValues);
+            if (((_bits & 274877906944L) != 0)) _TE = default(StringValues);
+            if (((_bits & 549755813888L) != 0)) _Translate = default(StringValues);
+            if (((_bits & 1099511627776L) != 0)) _UserAgent = default(StringValues);
+            if (((_bits & 2199023255552L) != 0)) _Origin = default(StringValues);
+            if (((_bits & 4398046511104L) != 0)) _AccessControlRequestMethod = default(StringValues);
+            if (((_bits & 8796093022208L) != 0)) _AccessControlRequestHeaders = default(StringValues);
+
             _bits = 0;
             MaybeUnknown?.Clear();
         }
@@ -8618,6 +8663,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         }
         protected override void ClearFast()
         {
+
             _bits = 0;
             MaybeUnknown?.Clear();
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameHeaders.Generated.cs
@@ -782,7 +782,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -794,7 +794,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -806,7 +806,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -818,7 +818,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -830,7 +830,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -846,7 +846,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -858,7 +858,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -870,7 +870,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -886,7 +886,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -898,7 +898,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -910,7 +910,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -926,7 +926,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -938,7 +938,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -950,7 +950,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -962,7 +962,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -974,7 +974,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -990,7 +990,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1002,7 +1002,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1014,7 +1014,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1026,7 +1026,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1038,7 +1038,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1054,7 +1054,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1066,7 +1066,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1082,7 +1082,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1098,7 +1098,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1110,7 +1110,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1126,7 +1126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1138,7 +1138,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1154,7 +1154,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1166,7 +1166,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1182,7 +1182,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1194,7 +1194,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1206,7 +1206,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1222,7 +1222,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1238,7 +1238,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1250,7 +1250,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1266,7 +1266,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1278,7 +1278,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1294,7 +1294,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -1306,7 +1306,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1322,7 +1322,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1338,7 +1338,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1354,7 +1354,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1370,7 +1370,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -1378,7 +1378,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 }
             if (MaybeUnknown == null) 
             {
-                throw new System.Collections.Generic.KeyNotFoundException();
+                ThrowKeyNotFoundException();
             }
             return MaybeUnknown[key];
         }
@@ -2481,7 +2481,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 1L;
                             _CacheControl = value;
@@ -2492,7 +2492,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 131072L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 131072L;
                             _ContentRange = value;
@@ -2503,7 +2503,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 524288L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 524288L;
                             _LastModified = value;
@@ -2514,7 +2514,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16777216L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 16777216L;
                             _Authorization = value;
@@ -2525,7 +2525,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2147483648L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 2147483648L;
                             _IfNoneMatch = value;
@@ -2540,7 +2540,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 2L;
                             _Connection = value;
@@ -2551,7 +2551,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 8L;
                             _KeepAlive = value;
@@ -2562,7 +2562,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1099511627776L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 1099511627776L;
                             _UserAgent = value;
@@ -2577,7 +2577,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 4L;
                             _Date = value;
@@ -2588,7 +2588,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 134217728L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 134217728L;
                             _From = value;
@@ -2599,7 +2599,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 268435456L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 268435456L;
                             _Host = value;
@@ -2614,7 +2614,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 16L;
                             _Pragma = value;
@@ -2625,7 +2625,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1048576L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 1048576L;
                             _Accept = value;
@@ -2636,7 +2636,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 33554432L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 33554432L;
                             _Cookie = value;
@@ -2647,7 +2647,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 67108864L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 67108864L;
                             _Expect = value;
@@ -2658,7 +2658,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2199023255552L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 2199023255552L;
                             _Origin = value;
@@ -2673,7 +2673,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 32L;
                             _Trailer = value;
@@ -2684,7 +2684,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 128L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 128L;
                             _Upgrade = value;
@@ -2695,7 +2695,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 512L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 512L;
                             _Warning = value;
@@ -2706,7 +2706,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 262144L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 262144L;
                             _Expires = value;
@@ -2717,7 +2717,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 68719476736L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 68719476736L;
                             _Referer = value;
@@ -2732,7 +2732,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 64L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 64L;
                             _TransferEncoding = value;
@@ -2743,7 +2743,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1073741824L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 1073741824L;
                             _IfModifiedSince = value;
@@ -2758,7 +2758,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 256L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 256L;
                             _Via = value;
@@ -2773,7 +2773,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1024L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 1024L;
                             _Allow = value;
@@ -2784,7 +2784,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 137438953472L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 137438953472L;
                             _Range = value;
@@ -2799,7 +2799,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2048L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 2048L;
                             _ContentLength = value;
@@ -2810,7 +2810,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2097152L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 2097152L;
                             _AcceptCharset = value;
@@ -2825,7 +2825,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4096L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 4096L;
                             _ContentType = value;
@@ -2836,7 +2836,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 17179869184L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 17179869184L;
                             _MaxForwards = value;
@@ -2851,7 +2851,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8192L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 8192L;
                             _ContentEncoding = value;
@@ -2862,7 +2862,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16384L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 16384L;
                             _ContentLanguage = value;
@@ -2873,7 +2873,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32768L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 32768L;
                             _ContentLocation = value;
@@ -2888,7 +2888,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 65536L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 65536L;
                             _ContentMD5 = value;
@@ -2903,7 +2903,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4194304L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 4194304L;
                             _AcceptEncoding = value;
@@ -2914,7 +2914,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8388608L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 8388608L;
                             _AcceptLanguage = value;
@@ -2929,7 +2929,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 536870912L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 536870912L;
                             _IfMatch = value;
@@ -2940,7 +2940,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4294967296L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 4294967296L;
                             _IfRange = value;
@@ -2955,7 +2955,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8589934592L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 8589934592L;
                             _IfUnmodifiedSince = value;
@@ -2966,7 +2966,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 34359738368L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 34359738368L;
                             _ProxyAuthorization = value;
@@ -2981,7 +2981,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 274877906944L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 274877906944L;
                             _TE = value;
@@ -2996,7 +2996,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 549755813888L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 549755813888L;
                             _Translate = value;
@@ -3011,7 +3011,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4398046511104L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 4398046511104L;
                             _AccessControlRequestMethod = value;
@@ -3026,7 +3026,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8796093022208L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 8796093022208L;
                             _AccessControlRequestHeaders = value;
@@ -3790,14 +3790,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         {
             if (arrayIndex < 0)
             {
-                throw new ArgumentException();
+                ThrowArgumentException();
             }
             
                 if (((_bits & 1L) != 0)) 
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Cache-Control", _CacheControl);
@@ -3808,7 +3808,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Connection", _Connection);
@@ -3819,7 +3819,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Date", _Date);
@@ -3830,7 +3830,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Keep-Alive", _KeepAlive);
@@ -3841,7 +3841,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Pragma", _Pragma);
@@ -3852,7 +3852,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Trailer", _Trailer);
@@ -3863,7 +3863,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Transfer-Encoding", _TransferEncoding);
@@ -3874,7 +3874,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Upgrade", _Upgrade);
@@ -3885,7 +3885,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Via", _Via);
@@ -3896,7 +3896,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Warning", _Warning);
@@ -3907,7 +3907,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Allow", _Allow);
@@ -3918,7 +3918,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Length", _ContentLength);
@@ -3929,7 +3929,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Type", _ContentType);
@@ -3940,7 +3940,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Encoding", _ContentEncoding);
@@ -3951,7 +3951,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Language", _ContentLanguage);
@@ -3962,7 +3962,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Location", _ContentLocation);
@@ -3973,7 +3973,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-MD5", _ContentMD5);
@@ -3984,7 +3984,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Range", _ContentRange);
@@ -3995,7 +3995,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Expires", _Expires);
@@ -4006,7 +4006,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Last-Modified", _LastModified);
@@ -4017,7 +4017,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept", _Accept);
@@ -4028,7 +4028,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Charset", _AcceptCharset);
@@ -4039,7 +4039,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Encoding", _AcceptEncoding);
@@ -4050,7 +4050,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Language", _AcceptLanguage);
@@ -4061,7 +4061,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Authorization", _Authorization);
@@ -4072,7 +4072,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Cookie", _Cookie);
@@ -4083,7 +4083,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Expect", _Expect);
@@ -4094,7 +4094,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("From", _From);
@@ -4105,7 +4105,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Host", _Host);
@@ -4116,7 +4116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Match", _IfMatch);
@@ -4127,7 +4127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Modified-Since", _IfModifiedSince);
@@ -4138,7 +4138,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("If-None-Match", _IfNoneMatch);
@@ -4149,7 +4149,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Range", _IfRange);
@@ -4160,7 +4160,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Unmodified-Since", _IfUnmodifiedSince);
@@ -4171,7 +4171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Max-Forwards", _MaxForwards);
@@ -4182,7 +4182,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Proxy-Authorization", _ProxyAuthorization);
@@ -4193,7 +4193,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Referer", _Referer);
@@ -4204,7 +4204,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Range", _Range);
@@ -4215,7 +4215,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("TE", _TE);
@@ -4226,7 +4226,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Translate", _Translate);
@@ -4237,7 +4237,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("User-Agent", _UserAgent);
@@ -4248,7 +4248,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Origin", _Origin);
@@ -4259,7 +4259,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Request-Method", _AccessControlRequestMethod);
@@ -4270,7 +4270,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Request-Headers", _AccessControlRequestHeaders);
@@ -4279,6 +4279,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
             ((ICollection<KeyValuePair<string, StringValues>>)MaybeUnknown)?.CopyTo(array, arrayIndex);
         }
+        
         
         public unsafe void Append(byte[] keyBytes, int keyOffset, int keyLength, string value)
         {
@@ -6177,7 +6178,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6189,7 +6190,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6201,7 +6202,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6213,7 +6214,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6229,7 +6230,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6241,7 +6242,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6253,7 +6254,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6269,7 +6270,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6281,7 +6282,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6293,7 +6294,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6309,7 +6310,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6321,7 +6322,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6337,7 +6338,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6349,7 +6350,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6361,7 +6362,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6373,7 +6374,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6389,7 +6390,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6401,7 +6402,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6417,7 +6418,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6429,7 +6430,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6445,7 +6446,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6461,7 +6462,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6477,7 +6478,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6493,7 +6494,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6505,7 +6506,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6517,7 +6518,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6529,7 +6530,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6545,7 +6546,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6557,7 +6558,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6573,7 +6574,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6589,7 +6590,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6605,7 +6606,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     
@@ -6617,7 +6618,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6633,7 +6634,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6649,7 +6650,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6665,7 +6666,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }
                             else
                             {
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }
                         }
                     }
@@ -6673,7 +6674,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 }
             if (MaybeUnknown == null) 
             {
-                throw new System.Collections.Generic.KeyNotFoundException();
+                ThrowKeyNotFoundException();
             }
             return MaybeUnknown[key];
         }
@@ -7605,7 +7606,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 1L;
                             _CacheControl = value;
@@ -7616,7 +7617,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 131072L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 131072L;
                             _ContentRange = value;
@@ -7627,7 +7628,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 524288L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 524288L;
                             _LastModified = value;
@@ -7638,7 +7639,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1048576L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 1048576L;
                             _AcceptRanges = value;
@@ -7653,7 +7654,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 2L;
                             _Connection = value;
@@ -7665,7 +7666,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 8L;
                             _KeepAlive = value;
@@ -7676,7 +7677,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 134217728L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 134217728L;
                             _SetCookie = value;
@@ -7691,7 +7692,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 4L;
                             _Date = value;
@@ -7703,7 +7704,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4194304L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 4194304L;
                             _ETag = value;
@@ -7714,7 +7715,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 268435456L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 268435456L;
                             _Vary = value;
@@ -7729,7 +7730,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 16L;
                             _Pragma = value;
@@ -7740,7 +7741,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 67108864L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 67108864L;
                             _Server = value;
@@ -7756,7 +7757,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 32L;
                             _Trailer = value;
@@ -7767,7 +7768,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 128L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 128L;
                             _Upgrade = value;
@@ -7778,7 +7779,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 512L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 512L;
                             _Warning = value;
@@ -7789,7 +7790,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 262144L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 262144L;
                             _Expires = value;
@@ -7804,7 +7805,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 64L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 64L;
                             _TransferEncoding = value;
@@ -7816,7 +7817,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16777216L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 16777216L;
                             _ProxyAutheticate = value;
@@ -7831,7 +7832,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 256L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 256L;
                             _Via = value;
@@ -7842,7 +7843,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2097152L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 2097152L;
                             _Age = value;
@@ -7857,7 +7858,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1024L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 1024L;
                             _Allow = value;
@@ -7872,7 +7873,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2048L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 2048L;
                             _ContentLength = value;
@@ -7888,7 +7889,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4096L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 4096L;
                             _ContentType = value;
@@ -7903,7 +7904,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8192L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 8192L;
                             _ContentEncoding = value;
@@ -7914,7 +7915,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16384L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 16384L;
                             _ContentLanguage = value;
@@ -7925,7 +7926,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32768L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 32768L;
                             _ContentLocation = value;
@@ -7936,7 +7937,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 536870912L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 536870912L;
                             _WWWAuthenticate = value;
@@ -7951,7 +7952,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 65536L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 65536L;
                             _ContentMD5 = value;
@@ -7962,7 +7963,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 33554432L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 33554432L;
                             _RetryAfter = value;
@@ -7977,7 +7978,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8388608L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 8388608L;
                             _Location = value;
@@ -7992,7 +7993,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1073741824L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 1073741824L;
                             _AccessControlAllowCredentials = value;
@@ -8007,7 +8008,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2147483648L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 2147483648L;
                             _AccessControlAllowHeaders = value;
@@ -8018,7 +8019,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4294967296L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 4294967296L;
                             _AccessControlAllowMethods = value;
@@ -8033,7 +8034,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8589934592L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 8589934592L;
                             _AccessControlAllowOrigin = value;
@@ -8048,7 +8049,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 17179869184L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 17179869184L;
                             _AccessControlExposeHeaders = value;
@@ -8063,7 +8064,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 34359738368L) != 0))
                             {
-                                throw new ArgumentException("An item with the same key has already been added.");
+                                ThrowDuplicateKeyException();
                             }
                             _bits |= 34359738368L;
                             _AccessControlMaxAge = value;
@@ -8672,14 +8673,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         {
             if (arrayIndex < 0)
             {
-                throw new ArgumentException();
+                ThrowArgumentException();
             }
             
                 if (((_bits & 1L) != 0)) 
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Cache-Control", _CacheControl);
@@ -8690,7 +8691,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Connection", _Connection);
@@ -8701,7 +8702,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Date", _Date);
@@ -8712,7 +8713,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Keep-Alive", _KeepAlive);
@@ -8723,7 +8724,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Pragma", _Pragma);
@@ -8734,7 +8735,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Trailer", _Trailer);
@@ -8745,7 +8746,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Transfer-Encoding", _TransferEncoding);
@@ -8756,7 +8757,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Upgrade", _Upgrade);
@@ -8767,7 +8768,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Via", _Via);
@@ -8778,7 +8779,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Warning", _Warning);
@@ -8789,7 +8790,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Allow", _Allow);
@@ -8800,7 +8801,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Length", _ContentLength);
@@ -8811,7 +8812,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Type", _ContentType);
@@ -8822,7 +8823,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Encoding", _ContentEncoding);
@@ -8833,7 +8834,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Language", _ContentLanguage);
@@ -8844,7 +8845,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Location", _ContentLocation);
@@ -8855,7 +8856,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-MD5", _ContentMD5);
@@ -8866,7 +8867,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Range", _ContentRange);
@@ -8877,7 +8878,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Expires", _Expires);
@@ -8888,7 +8889,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Last-Modified", _LastModified);
@@ -8899,7 +8900,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Ranges", _AcceptRanges);
@@ -8910,7 +8911,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Age", _Age);
@@ -8921,7 +8922,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("ETag", _ETag);
@@ -8932,7 +8933,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Location", _Location);
@@ -8943,7 +8944,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Proxy-Autheticate", _ProxyAutheticate);
@@ -8954,7 +8955,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Retry-After", _RetryAfter);
@@ -8965,7 +8966,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Server", _Server);
@@ -8976,7 +8977,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Set-Cookie", _SetCookie);
@@ -8987,7 +8988,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Vary", _Vary);
@@ -8998,7 +8999,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("WWW-Authenticate", _WWWAuthenticate);
@@ -9009,7 +9010,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Credentials", _AccessControlAllowCredentials);
@@ -9020,7 +9021,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Headers", _AccessControlAllowHeaders);
@@ -9031,7 +9032,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Methods", _AccessControlAllowMethods);
@@ -9042,7 +9043,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Origin", _AccessControlAllowOrigin);
@@ -9053,7 +9054,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Expose-Headers", _AccessControlExposeHeaders);
@@ -9064,7 +9065,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 {
                     if (arrayIndex == array.Length)
                     {
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Max-Age", _AccessControlMaxAge);
@@ -9535,603 +9536,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 }
             
         }
-        public unsafe void Append(byte[] keyBytes, int keyOffset, int keyLength, string value)
-        {
-            fixed (byte* ptr = &keyBytes[keyOffset]) 
-            { 
-                var pUB = ptr; 
-                var pUL = (ulong*)pUB; 
-                var pUI = (uint*)pUB; 
-                var pUS = (ushort*)pUB;
-                switch (keyLength)
-                {
-                    case 13:
-                        {
-                            if ((((pUL[0] & 16131893727263186911uL) == 5711458528024281411uL) && ((pUI[2] & 3755991007u) == 1330795598u) && ((pUB[12] & 223u) == 76u))) 
-                            {
-                                if (((_bits & 1L) != 0))
-                                {
-                                    _CacheControl = AppendValue(_CacheControl, value);
-                                }
-                                else
-                                {
-                                    _bits |= 1L;
-                                    _CacheControl = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 18437701552104792031uL) == 3266321689424580419uL) && ((pUI[2] & 3755991007u) == 1196310866u) && ((pUB[12] & 223u) == 69u))) 
-                            {
-                                if (((_bits & 131072L) != 0))
-                                {
-                                    _ContentRange = AppendValue(_ContentRange, value);
-                                }
-                                else
-                                {
-                                    _bits |= 131072L;
-                                    _ContentRange = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 16131858680330051551uL) == 4922237774822850892uL) && ((pUI[2] & 3755991007u) == 1162430025u) && ((pUB[12] & 223u) == 68u))) 
-                            {
-                                if (((_bits & 524288L) != 0))
-                                {
-                                    _LastModified = AppendValue(_LastModified, value);
-                                }
-                                else
-                                {
-                                    _bits |= 524288L;
-                                    _LastModified = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 16140865742145839071uL) == 5921481788798223169uL) && ((pUI[2] & 3755991007u) == 1162300993u) && ((pUB[12] & 223u) == 83u))) 
-                            {
-                                if (((_bits & 1048576L) != 0))
-                                {
-                                    _AcceptRanges = AppendValue(_AcceptRanges, value);
-                                }
-                                else
-                                {
-                                    _bits |= 1048576L;
-                                    _AcceptRanges = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 10:
-                        {
-                            if ((((pUL[0] & 16131858542891098079uL) == 5283922227757993795uL) && ((pUS[4] & 57311u) == 20047u))) 
-                            {
-                                if (((_bits & 2L) != 0))
-                                {
-                                    _Connection = AppendValue(_Connection, value);
-                                }
-                                else
-                                {
-                                    _bits |= 2L;
-                                    _Connection = new StringValues(value);
-                                    _rawConnection = null;
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 16131858680330051551uL) == 5281668125874799947uL) && ((pUS[4] & 57311u) == 17750u))) 
-                            {
-                                if (((_bits & 8L) != 0))
-                                {
-                                    _KeepAlive = AppendValue(_KeepAlive, value);
-                                }
-                                else
-                                {
-                                    _bits |= 8L;
-                                    _KeepAlive = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 16131858543427968991uL) == 5426643225946637651uL) && ((pUS[4] & 57311u) == 17737u))) 
-                            {
-                                if (((_bits & 134217728L) != 0))
-                                {
-                                    _SetCookie = AppendValue(_SetCookie, value);
-                                }
-                                else
-                                {
-                                    _bits |= 134217728L;
-                                    _SetCookie = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 4:
-                        {
-                            if ((((pUI[0] & 3755991007u) == 1163149636u))) 
-                            {
-                                if (((_bits & 4L) != 0))
-                                {
-                                    _Date = AppendValue(_Date, value);
-                                }
-                                else
-                                {
-                                    _bits |= 4L;
-                                    _Date = new StringValues(value);
-                                    _rawDate = null;
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUI[0] & 3755991007u) == 1195463749u))) 
-                            {
-                                if (((_bits & 4194304L) != 0))
-                                {
-                                    _ETag = AppendValue(_ETag, value);
-                                }
-                                else
-                                {
-                                    _bits |= 4194304L;
-                                    _ETag = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUI[0] & 3755991007u) == 1498562902u))) 
-                            {
-                                if (((_bits & 268435456L) != 0))
-                                {
-                                    _Vary = AppendValue(_Vary, value);
-                                }
-                                else
-                                {
-                                    _bits |= 268435456L;
-                                    _Vary = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 6:
-                        {
-                            if ((((pUI[0] & 3755991007u) == 1195463248u) && ((pUS[2] & 57311u) == 16717u))) 
-                            {
-                                if (((_bits & 16L) != 0))
-                                {
-                                    _Pragma = AppendValue(_Pragma, value);
-                                }
-                                else
-                                {
-                                    _bits |= 16L;
-                                    _Pragma = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUI[0] & 3755991007u) == 1448232275u) && ((pUS[2] & 57311u) == 21061u))) 
-                            {
-                                if (((_bits & 67108864L) != 0))
-                                {
-                                    _Server = AppendValue(_Server, value);
-                                }
-                                else
-                                {
-                                    _bits |= 67108864L;
-                                    _Server = new StringValues(value);
-                                    _rawServer = null;
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 7:
-                        {
-                            if ((((pUI[0] & 3755991007u) == 1229017684u) && ((pUS[2] & 57311u) == 17740u) && ((pUB[6] & 223u) == 82u))) 
-                            {
-                                if (((_bits & 32L) != 0))
-                                {
-                                    _Trailer = AppendValue(_Trailer, value);
-                                }
-                                else
-                                {
-                                    _bits |= 32L;
-                                    _Trailer = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUI[0] & 3755991007u) == 1380405333u) && ((pUS[2] & 57311u) == 17473u) && ((pUB[6] & 223u) == 69u))) 
-                            {
-                                if (((_bits & 128L) != 0))
-                                {
-                                    _Upgrade = AppendValue(_Upgrade, value);
-                                }
-                                else
-                                {
-                                    _bits |= 128L;
-                                    _Upgrade = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUI[0] & 3755991007u) == 1314013527u) && ((pUS[2] & 57311u) == 20041u) && ((pUB[6] & 223u) == 71u))) 
-                            {
-                                if (((_bits & 512L) != 0))
-                                {
-                                    _Warning = AppendValue(_Warning, value);
-                                }
-                                else
-                                {
-                                    _bits |= 512L;
-                                    _Warning = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUI[0] & 3755991007u) == 1230002245u) && ((pUS[2] & 57311u) == 17746u) && ((pUB[6] & 223u) == 83u))) 
-                            {
-                                if (((_bits & 262144L) != 0))
-                                {
-                                    _Expires = AppendValue(_Expires, value);
-                                }
-                                else
-                                {
-                                    _bits |= 262144L;
-                                    _Expires = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 17:
-                        {
-                            if ((((pUL[0] & 16131858542891098079uL) == 5928221808112259668uL) && ((pUL[1] & 16131858542891098111uL) == 5641115115480565037uL) && ((pUB[16] & 223u) == 71u))) 
-                            {
-                                if (((_bits & 64L) != 0))
-                                {
-                                    _TransferEncoding = AppendValue(_TransferEncoding, value);
-                                }
-                                else
-                                {
-                                    _bits |= 64L;
-                                    _TransferEncoding = new StringValues(value);
-                                    _rawTransferEncoding = null;
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 16131893727263186911uL) == 6143241228466999888uL) && ((pUL[1] & 16131858542891098079uL) == 6071207754897639508uL) && ((pUB[16] & 223u) == 69u))) 
-                            {
-                                if (((_bits & 16777216L) != 0))
-                                {
-                                    _ProxyAutheticate = AppendValue(_ProxyAutheticate, value);
-                                }
-                                else
-                                {
-                                    _bits |= 16777216L;
-                                    _ProxyAutheticate = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 3:
-                        {
-                            if ((((pUS[0] & 57311u) == 18774u) && ((pUB[2] & 223u) == 65u))) 
-                            {
-                                if (((_bits & 256L) != 0))
-                                {
-                                    _Via = AppendValue(_Via, value);
-                                }
-                                else
-                                {
-                                    _bits |= 256L;
-                                    _Via = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUS[0] & 57311u) == 18241u) && ((pUB[2] & 223u) == 69u))) 
-                            {
-                                if (((_bits & 2097152L) != 0))
-                                {
-                                    _Age = AppendValue(_Age, value);
-                                }
-                                else
-                                {
-                                    _bits |= 2097152L;
-                                    _Age = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 5:
-                        {
-                            if ((((pUI[0] & 3755991007u) == 1330400321u) && ((pUB[4] & 223u) == 87u))) 
-                            {
-                                if (((_bits & 1024L) != 0))
-                                {
-                                    _Allow = AppendValue(_Allow, value);
-                                }
-                                else
-                                {
-                                    _bits |= 1024L;
-                                    _Allow = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 14:
-                        {
-                            if ((((pUL[0] & 18437701552104792031uL) == 3266321689424580419uL) && ((pUI[2] & 3755991007u) == 1196311884u) && ((pUS[6] & 57311u) == 18516u))) 
-                            {
-                                if (((_bits & 2048L) != 0))
-                                {
-                                    _ContentLength = AppendValue(_ContentLength, value);
-                                }
-                                else
-                                {
-                                    _bits |= 2048L;
-                                    _ContentLength = new StringValues(value);
-                                    _rawContentLength = null;
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 12:
-                        {
-                            if ((((pUL[0] & 18437701552104792031uL) == 3266321689424580419uL) && ((pUI[2] & 3755991007u) == 1162893652u))) 
-                            {
-                                if (((_bits & 4096L) != 0))
-                                {
-                                    _ContentType = AppendValue(_ContentType, value);
-                                }
-                                else
-                                {
-                                    _bits |= 4096L;
-                                    _ContentType = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 16:
-                        {
-                            if ((((pUL[0] & 18437701552104792031uL) == 3266321689424580419uL) && ((pUL[1] & 16131858542891098079uL) == 5138124782612729413uL))) 
-                            {
-                                if (((_bits & 8192L) != 0))
-                                {
-                                    _ContentEncoding = AppendValue(_ContentEncoding, value);
-                                }
-                                else
-                                {
-                                    _bits |= 8192L;
-                                    _ContentEncoding = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 18437701552104792031uL) == 3266321689424580419uL) && ((pUL[1] & 16131858542891098079uL) == 4992030546487820620uL))) 
-                            {
-                                if (((_bits & 16384L) != 0))
-                                {
-                                    _ContentLanguage = AppendValue(_ContentLanguage, value);
-                                }
-                                else
-                                {
-                                    _bits |= 16384L;
-                                    _ContentLanguage = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 18437701552104792031uL) == 3266321689424580419uL) && ((pUL[1] & 16131858542891098079uL) == 5642809484339531596uL))) 
-                            {
-                                if (((_bits & 32768L) != 0))
-                                {
-                                    _ContentLocation = AppendValue(_ContentLocation, value);
-                                }
-                                else
-                                {
-                                    _bits |= 32768L;
-                                    _ContentLocation = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 16131858543427968991uL) == 5211884407196440407uL) && ((pUL[1] & 16131858542891098079uL) == 4995689643909598789uL))) 
-                            {
-                                if (((_bits & 536870912L) != 0))
-                                {
-                                    _WWWAuthenticate = AppendValue(_WWWAuthenticate, value);
-                                }
-                                else
-                                {
-                                    _bits |= 536870912L;
-                                    _WWWAuthenticate = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 11:
-                        {
-                            if ((((pUL[0] & 18437701552104792031uL) == 3266321689424580419uL) && ((pUS[4] & 57311u) == 17485u) && ((pUB[10] & 255u) == 53u))) 
-                            {
-                                if (((_bits & 65536L) != 0))
-                                {
-                                    _ContentMD5 = AppendValue(_ContentMD5, value);
-                                }
-                                else
-                                {
-                                    _bits |= 65536L;
-                                    _ContentMD5 = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 16131893727263186911uL) == 5062377317797741906uL) && ((pUS[4] & 57311u) == 17748u) && ((pUB[10] & 223u) == 82u))) 
-                            {
-                                if (((_bits & 33554432L) != 0))
-                                {
-                                    _RetryAfter = AppendValue(_RetryAfter, value);
-                                }
-                                else
-                                {
-                                    _bits |= 33554432L;
-                                    _RetryAfter = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 8:
-                        {
-                            if ((((pUL[0] & 16131858542891098079uL) == 5642809484339531596uL))) 
-                            {
-                                if (((_bits & 8388608L) != 0))
-                                {
-                                    _Location = AppendValue(_Location, value);
-                                }
-                                else
-                                {
-                                    _bits |= 8388608L;
-                                    _Location = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 32:
-                        {
-                            if ((((pUL[0] & 16140865742145839071uL) == 4840616791602578241uL) && ((pUL[1] & 16140865742145839071uL) == 4696493889984679503uL) && ((pUL[2] & 16131858680330051551uL) == 4995128798724705356uL) && ((pUL[3] & 16131858542891098079uL) == 6002244186580862276uL))) 
-                            {
-                                if (((_bits & 1073741824L) != 0))
-                                {
-                                    _AccessControlAllowCredentials = AppendValue(_AccessControlAllowCredentials, value);
-                                }
-                                else
-                                {
-                                    _bits |= 1073741824L;
-                                    _AccessControlAllowCredentials = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 28:
-                        {
-                            if ((((pUL[0] & 16140865742145839071uL) == 4840616791602578241uL) && ((pUL[1] & 16140865742145839071uL) == 4696493889984679503uL) && ((pUL[2] & 16131858680330051551uL) == 4703244745433893964uL) && ((pUI[6] & 3755991007u) == 1397900612u))) 
-                            {
-                                if (((_bits & 2147483648L) != 0))
-                                {
-                                    _AccessControlAllowHeaders = AppendValue(_AccessControlAllowHeaders, value);
-                                }
-                                else
-                                {
-                                    _bits |= 2147483648L;
-                                    _AccessControlAllowHeaders = new StringValues(value);
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 16140865742145839071uL) == 4840616791602578241uL) && ((pUL[1] & 16140865742145839071uL) == 4696493889984679503uL) && ((pUL[2] & 16131858680330051551uL) == 6072344529712663628uL) && ((pUI[6] & 3755991007u) == 1396985672u))) 
-                            {
-                                if (((_bits & 4294967296L) != 0))
-                                {
-                                    _AccessControlAllowMethods = AppendValue(_AccessControlAllowMethods, value);
-                                }
-                                else
-                                {
-                                    _bits |= 4294967296L;
-                                    _AccessControlAllowMethods = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 27:
-                        {
-                            if ((((pUL[0] & 16140865742145839071uL) == 4840616791602578241uL) && ((pUL[1] & 16140865742145839071uL) == 4696493889984679503uL) && ((pUL[2] & 16131858680330051551uL) == 5283372369015950412uL) && ((pUS[12] & 57311u) == 18759u) && ((pUB[26] & 223u) == 78u))) 
-                            {
-                                if (((_bits & 8589934592L) != 0))
-                                {
-                                    _AccessControlAllowOrigin = AppendValue(_AccessControlAllowOrigin, value);
-                                }
-                                else
-                                {
-                                    _bits |= 8589934592L;
-                                    _AccessControlAllowOrigin = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 29:
-                        {
-                            if ((((pUL[0] & 16140865742145839071uL) == 4840616791602578241uL) && ((pUL[1] & 16140865742145839071uL) == 4984724266136391247uL) && ((pUL[2] & 16131893727263186911uL) == 4992289962713895000uL) && ((pUI[6] & 3755991007u) == 1380271169u) && ((pUB[28] & 223u) == 83u))) 
-                            {
-                                if (((_bits & 17179869184L) != 0))
-                                {
-                                    _AccessControlExposeHeaders = AppendValue(_AccessControlExposeHeaders, value);
-                                }
-                                else
-                                {
-                                    _bits |= 17179869184L;
-                                    _AccessControlExposeHeaders = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 22:
-                        {
-                            if ((((pUL[0] & 16140865742145839071uL) == 4840616791602578241uL) && ((pUL[1] & 16140865742145839071uL) == 5561185018439814735uL) && ((pUI[4] & 3758088159u) == 1093490753u) && ((pUS[10] & 57311u) == 17735u))) 
-                            {
-                                if (((_bits & 34359738368L) != 0))
-                                {
-                                    _AccessControlMaxAge = AppendValue(_AccessControlMaxAge, value);
-                                }
-                                else
-                                {
-                                    _bits |= 34359738368L;
-                                    _AccessControlMaxAge = new StringValues(value);
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                }
-            }
-            var key = System.Text.Encoding.ASCII.GetString(keyBytes, keyOffset, keyLength);
-            StringValues existing;
-            Unknown.TryGetValue(key, out existing);
-            Unknown[key] = AppendValue(existing, value);
-        }
+        
         public partial struct Enumerator
         {
             public bool MoveNext()

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameHeaders.Generated.cs
@@ -12,52 +12,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
     {
         
         private long _bits = 0;
-        
-        private StringValues _CacheControl;
-        private StringValues _Connection;
-        private StringValues _Date;
-        private StringValues _KeepAlive;
-        private StringValues _Pragma;
-        private StringValues _Trailer;
-        private StringValues _TransferEncoding;
-        private StringValues _Upgrade;
-        private StringValues _Via;
-        private StringValues _Warning;
-        private StringValues _Allow;
-        private StringValues _ContentLength;
-        private StringValues _ContentType;
-        private StringValues _ContentEncoding;
-        private StringValues _ContentLanguage;
-        private StringValues _ContentLocation;
-        private StringValues _ContentMD5;
-        private StringValues _ContentRange;
-        private StringValues _Expires;
-        private StringValues _LastModified;
-        private StringValues _Accept;
-        private StringValues _AcceptCharset;
-        private StringValues _AcceptEncoding;
-        private StringValues _AcceptLanguage;
-        private StringValues _Authorization;
-        private StringValues _Cookie;
-        private StringValues _Expect;
-        private StringValues _From;
-        private StringValues _Host;
-        private StringValues _IfMatch;
-        private StringValues _IfModifiedSince;
-        private StringValues _IfNoneMatch;
-        private StringValues _IfRange;
-        private StringValues _IfUnmodifiedSince;
-        private StringValues _MaxForwards;
-        private StringValues _ProxyAuthorization;
-        private StringValues _Referer;
-        private StringValues _Range;
-        private StringValues _TE;
-        private StringValues _Translate;
-        private StringValues _UserAgent;
-        private StringValues _Origin;
-        private StringValues _AccessControlRequestMethod;
-        private StringValues _AccessControlRequestHeaders;
-        
+        private HeaderReferences _headers;
         
         public StringValues HeaderCacheControl
         {
@@ -65,14 +20,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 1L) != 0))
                 {
-                    return _CacheControl;
+                    return _headers._CacheControl;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 1L;
-                _CacheControl = value; 
+                _headers._CacheControl = value; 
             }
         }
         public StringValues HeaderConnection
@@ -81,14 +36,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 2L) != 0))
                 {
-                    return _Connection;
+                    return _headers._Connection;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 2L;
-                _Connection = value; 
+                _headers._Connection = value; 
             }
         }
         public StringValues HeaderDate
@@ -97,14 +52,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 4L) != 0))
                 {
-                    return _Date;
+                    return _headers._Date;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 4L;
-                _Date = value; 
+                _headers._Date = value; 
             }
         }
         public StringValues HeaderKeepAlive
@@ -113,14 +68,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 8L) != 0))
                 {
-                    return _KeepAlive;
+                    return _headers._KeepAlive;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 8L;
-                _KeepAlive = value; 
+                _headers._KeepAlive = value; 
             }
         }
         public StringValues HeaderPragma
@@ -129,14 +84,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 16L) != 0))
                 {
-                    return _Pragma;
+                    return _headers._Pragma;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 16L;
-                _Pragma = value; 
+                _headers._Pragma = value; 
             }
         }
         public StringValues HeaderTrailer
@@ -145,14 +100,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 32L) != 0))
                 {
-                    return _Trailer;
+                    return _headers._Trailer;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 32L;
-                _Trailer = value; 
+                _headers._Trailer = value; 
             }
         }
         public StringValues HeaderTransferEncoding
@@ -161,14 +116,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 64L) != 0))
                 {
-                    return _TransferEncoding;
+                    return _headers._TransferEncoding;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 64L;
-                _TransferEncoding = value; 
+                _headers._TransferEncoding = value; 
             }
         }
         public StringValues HeaderUpgrade
@@ -177,14 +132,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 128L) != 0))
                 {
-                    return _Upgrade;
+                    return _headers._Upgrade;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 128L;
-                _Upgrade = value; 
+                _headers._Upgrade = value; 
             }
         }
         public StringValues HeaderVia
@@ -193,14 +148,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 256L) != 0))
                 {
-                    return _Via;
+                    return _headers._Via;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 256L;
-                _Via = value; 
+                _headers._Via = value; 
             }
         }
         public StringValues HeaderWarning
@@ -209,14 +164,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 512L) != 0))
                 {
-                    return _Warning;
+                    return _headers._Warning;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 512L;
-                _Warning = value; 
+                _headers._Warning = value; 
             }
         }
         public StringValues HeaderAllow
@@ -225,14 +180,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 1024L) != 0))
                 {
-                    return _Allow;
+                    return _headers._Allow;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 1024L;
-                _Allow = value; 
+                _headers._Allow = value; 
             }
         }
         public StringValues HeaderContentLength
@@ -241,14 +196,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 2048L) != 0))
                 {
-                    return _ContentLength;
+                    return _headers._ContentLength;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 2048L;
-                _ContentLength = value; 
+                _headers._ContentLength = value; 
             }
         }
         public StringValues HeaderContentType
@@ -257,14 +212,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 4096L) != 0))
                 {
-                    return _ContentType;
+                    return _headers._ContentType;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 4096L;
-                _ContentType = value; 
+                _headers._ContentType = value; 
             }
         }
         public StringValues HeaderContentEncoding
@@ -273,14 +228,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 8192L) != 0))
                 {
-                    return _ContentEncoding;
+                    return _headers._ContentEncoding;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 8192L;
-                _ContentEncoding = value; 
+                _headers._ContentEncoding = value; 
             }
         }
         public StringValues HeaderContentLanguage
@@ -289,14 +244,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 16384L) != 0))
                 {
-                    return _ContentLanguage;
+                    return _headers._ContentLanguage;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 16384L;
-                _ContentLanguage = value; 
+                _headers._ContentLanguage = value; 
             }
         }
         public StringValues HeaderContentLocation
@@ -305,14 +260,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 32768L) != 0))
                 {
-                    return _ContentLocation;
+                    return _headers._ContentLocation;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 32768L;
-                _ContentLocation = value; 
+                _headers._ContentLocation = value; 
             }
         }
         public StringValues HeaderContentMD5
@@ -321,14 +276,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 65536L) != 0))
                 {
-                    return _ContentMD5;
+                    return _headers._ContentMD5;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 65536L;
-                _ContentMD5 = value; 
+                _headers._ContentMD5 = value; 
             }
         }
         public StringValues HeaderContentRange
@@ -337,14 +292,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 131072L) != 0))
                 {
-                    return _ContentRange;
+                    return _headers._ContentRange;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 131072L;
-                _ContentRange = value; 
+                _headers._ContentRange = value; 
             }
         }
         public StringValues HeaderExpires
@@ -353,14 +308,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 262144L) != 0))
                 {
-                    return _Expires;
+                    return _headers._Expires;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 262144L;
-                _Expires = value; 
+                _headers._Expires = value; 
             }
         }
         public StringValues HeaderLastModified
@@ -369,14 +324,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 524288L) != 0))
                 {
-                    return _LastModified;
+                    return _headers._LastModified;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 524288L;
-                _LastModified = value; 
+                _headers._LastModified = value; 
             }
         }
         public StringValues HeaderAccept
@@ -385,14 +340,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 1048576L) != 0))
                 {
-                    return _Accept;
+                    return _headers._Accept;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 1048576L;
-                _Accept = value; 
+                _headers._Accept = value; 
             }
         }
         public StringValues HeaderAcceptCharset
@@ -401,14 +356,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 2097152L) != 0))
                 {
-                    return _AcceptCharset;
+                    return _headers._AcceptCharset;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 2097152L;
-                _AcceptCharset = value; 
+                _headers._AcceptCharset = value; 
             }
         }
         public StringValues HeaderAcceptEncoding
@@ -417,14 +372,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 4194304L) != 0))
                 {
-                    return _AcceptEncoding;
+                    return _headers._AcceptEncoding;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 4194304L;
-                _AcceptEncoding = value; 
+                _headers._AcceptEncoding = value; 
             }
         }
         public StringValues HeaderAcceptLanguage
@@ -433,14 +388,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 8388608L) != 0))
                 {
-                    return _AcceptLanguage;
+                    return _headers._AcceptLanguage;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 8388608L;
-                _AcceptLanguage = value; 
+                _headers._AcceptLanguage = value; 
             }
         }
         public StringValues HeaderAuthorization
@@ -449,14 +404,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 16777216L) != 0))
                 {
-                    return _Authorization;
+                    return _headers._Authorization;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 16777216L;
-                _Authorization = value; 
+                _headers._Authorization = value; 
             }
         }
         public StringValues HeaderCookie
@@ -465,14 +420,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 33554432L) != 0))
                 {
-                    return _Cookie;
+                    return _headers._Cookie;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 33554432L;
-                _Cookie = value; 
+                _headers._Cookie = value; 
             }
         }
         public StringValues HeaderExpect
@@ -481,14 +436,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 67108864L) != 0))
                 {
-                    return _Expect;
+                    return _headers._Expect;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 67108864L;
-                _Expect = value; 
+                _headers._Expect = value; 
             }
         }
         public StringValues HeaderFrom
@@ -497,14 +452,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 134217728L) != 0))
                 {
-                    return _From;
+                    return _headers._From;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 134217728L;
-                _From = value; 
+                _headers._From = value; 
             }
         }
         public StringValues HeaderHost
@@ -513,14 +468,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 268435456L) != 0))
                 {
-                    return _Host;
+                    return _headers._Host;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 268435456L;
-                _Host = value; 
+                _headers._Host = value; 
             }
         }
         public StringValues HeaderIfMatch
@@ -529,14 +484,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 536870912L) != 0))
                 {
-                    return _IfMatch;
+                    return _headers._IfMatch;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 536870912L;
-                _IfMatch = value; 
+                _headers._IfMatch = value; 
             }
         }
         public StringValues HeaderIfModifiedSince
@@ -545,14 +500,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 1073741824L) != 0))
                 {
-                    return _IfModifiedSince;
+                    return _headers._IfModifiedSince;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 1073741824L;
-                _IfModifiedSince = value; 
+                _headers._IfModifiedSince = value; 
             }
         }
         public StringValues HeaderIfNoneMatch
@@ -561,14 +516,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 2147483648L) != 0))
                 {
-                    return _IfNoneMatch;
+                    return _headers._IfNoneMatch;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 2147483648L;
-                _IfNoneMatch = value; 
+                _headers._IfNoneMatch = value; 
             }
         }
         public StringValues HeaderIfRange
@@ -577,14 +532,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 4294967296L) != 0))
                 {
-                    return _IfRange;
+                    return _headers._IfRange;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 4294967296L;
-                _IfRange = value; 
+                _headers._IfRange = value; 
             }
         }
         public StringValues HeaderIfUnmodifiedSince
@@ -593,14 +548,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 8589934592L) != 0))
                 {
-                    return _IfUnmodifiedSince;
+                    return _headers._IfUnmodifiedSince;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 8589934592L;
-                _IfUnmodifiedSince = value; 
+                _headers._IfUnmodifiedSince = value; 
             }
         }
         public StringValues HeaderMaxForwards
@@ -609,14 +564,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 17179869184L) != 0))
                 {
-                    return _MaxForwards;
+                    return _headers._MaxForwards;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 17179869184L;
-                _MaxForwards = value; 
+                _headers._MaxForwards = value; 
             }
         }
         public StringValues HeaderProxyAuthorization
@@ -625,14 +580,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 34359738368L) != 0))
                 {
-                    return _ProxyAuthorization;
+                    return _headers._ProxyAuthorization;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 34359738368L;
-                _ProxyAuthorization = value; 
+                _headers._ProxyAuthorization = value; 
             }
         }
         public StringValues HeaderReferer
@@ -641,14 +596,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 68719476736L) != 0))
                 {
-                    return _Referer;
+                    return _headers._Referer;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 68719476736L;
-                _Referer = value; 
+                _headers._Referer = value; 
             }
         }
         public StringValues HeaderRange
@@ -657,14 +612,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 137438953472L) != 0))
                 {
-                    return _Range;
+                    return _headers._Range;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 137438953472L;
-                _Range = value; 
+                _headers._Range = value; 
             }
         }
         public StringValues HeaderTE
@@ -673,14 +628,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 274877906944L) != 0))
                 {
-                    return _TE;
+                    return _headers._TE;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 274877906944L;
-                _TE = value; 
+                _headers._TE = value; 
             }
         }
         public StringValues HeaderTranslate
@@ -689,14 +644,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 549755813888L) != 0))
                 {
-                    return _Translate;
+                    return _headers._Translate;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 549755813888L;
-                _Translate = value; 
+                _headers._Translate = value; 
             }
         }
         public StringValues HeaderUserAgent
@@ -705,14 +660,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 1099511627776L) != 0))
                 {
-                    return _UserAgent;
+                    return _headers._UserAgent;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 1099511627776L;
-                _UserAgent = value; 
+                _headers._UserAgent = value; 
             }
         }
         public StringValues HeaderOrigin
@@ -721,14 +676,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 2199023255552L) != 0))
                 {
-                    return _Origin;
+                    return _headers._Origin;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 2199023255552L;
-                _Origin = value; 
+                _headers._Origin = value; 
             }
         }
         public StringValues HeaderAccessControlRequestMethod
@@ -737,14 +692,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 4398046511104L) != 0))
                 {
-                    return _AccessControlRequestMethod;
+                    return _headers._AccessControlRequestMethod;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 4398046511104L;
-                _AccessControlRequestMethod = value; 
+                _headers._AccessControlRequestMethod = value; 
             }
         }
         public StringValues HeaderAccessControlRequestHeaders
@@ -753,14 +708,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 8796093022208L) != 0))
                 {
-                    return _AccessControlRequestHeaders;
+                    return _headers._AccessControlRequestHeaders;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 8796093022208L;
-                _AccessControlRequestHeaders = value; 
+                _headers._AccessControlRequestHeaders = value; 
             }
         }
         
@@ -778,7 +733,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1L) != 0))
                             {
-                                return _CacheControl;
+                                return _headers._CacheControl;
                             }
                             else
                             {
@@ -790,7 +745,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 131072L) != 0))
                             {
-                                return _ContentRange;
+                                return _headers._ContentRange;
                             }
                             else
                             {
@@ -802,7 +757,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 524288L) != 0))
                             {
-                                return _LastModified;
+                                return _headers._LastModified;
                             }
                             else
                             {
@@ -814,7 +769,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16777216L) != 0))
                             {
-                                return _Authorization;
+                                return _headers._Authorization;
                             }
                             else
                             {
@@ -826,7 +781,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2147483648L) != 0))
                             {
-                                return _IfNoneMatch;
+                                return _headers._IfNoneMatch;
                             }
                             else
                             {
@@ -842,7 +797,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2L) != 0))
                             {
-                                return _Connection;
+                                return _headers._Connection;
                             }
                             else
                             {
@@ -854,7 +809,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8L) != 0))
                             {
-                                return _KeepAlive;
+                                return _headers._KeepAlive;
                             }
                             else
                             {
@@ -866,7 +821,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1099511627776L) != 0))
                             {
-                                return _UserAgent;
+                                return _headers._UserAgent;
                             }
                             else
                             {
@@ -882,7 +837,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4L) != 0))
                             {
-                                return _Date;
+                                return _headers._Date;
                             }
                             else
                             {
@@ -894,7 +849,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 134217728L) != 0))
                             {
-                                return _From;
+                                return _headers._From;
                             }
                             else
                             {
@@ -906,7 +861,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 268435456L) != 0))
                             {
-                                return _Host;
+                                return _headers._Host;
                             }
                             else
                             {
@@ -922,7 +877,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16L) != 0))
                             {
-                                return _Pragma;
+                                return _headers._Pragma;
                             }
                             else
                             {
@@ -934,7 +889,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1048576L) != 0))
                             {
-                                return _Accept;
+                                return _headers._Accept;
                             }
                             else
                             {
@@ -946,7 +901,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 33554432L) != 0))
                             {
-                                return _Cookie;
+                                return _headers._Cookie;
                             }
                             else
                             {
@@ -958,7 +913,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 67108864L) != 0))
                             {
-                                return _Expect;
+                                return _headers._Expect;
                             }
                             else
                             {
@@ -970,7 +925,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2199023255552L) != 0))
                             {
-                                return _Origin;
+                                return _headers._Origin;
                             }
                             else
                             {
@@ -986,7 +941,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32L) != 0))
                             {
-                                return _Trailer;
+                                return _headers._Trailer;
                             }
                             else
                             {
@@ -998,7 +953,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 128L) != 0))
                             {
-                                return _Upgrade;
+                                return _headers._Upgrade;
                             }
                             else
                             {
@@ -1010,7 +965,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 512L) != 0))
                             {
-                                return _Warning;
+                                return _headers._Warning;
                             }
                             else
                             {
@@ -1022,7 +977,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 262144L) != 0))
                             {
-                                return _Expires;
+                                return _headers._Expires;
                             }
                             else
                             {
@@ -1034,7 +989,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 68719476736L) != 0))
                             {
-                                return _Referer;
+                                return _headers._Referer;
                             }
                             else
                             {
@@ -1050,7 +1005,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 64L) != 0))
                             {
-                                return _TransferEncoding;
+                                return _headers._TransferEncoding;
                             }
                             else
                             {
@@ -1062,7 +1017,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1073741824L) != 0))
                             {
-                                return _IfModifiedSince;
+                                return _headers._IfModifiedSince;
                             }
                             else
                             {
@@ -1078,7 +1033,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 256L) != 0))
                             {
-                                return _Via;
+                                return _headers._Via;
                             }
                             else
                             {
@@ -1094,7 +1049,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1024L) != 0))
                             {
-                                return _Allow;
+                                return _headers._Allow;
                             }
                             else
                             {
@@ -1106,7 +1061,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 137438953472L) != 0))
                             {
-                                return _Range;
+                                return _headers._Range;
                             }
                             else
                             {
@@ -1122,7 +1077,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2048L) != 0))
                             {
-                                return _ContentLength;
+                                return _headers._ContentLength;
                             }
                             else
                             {
@@ -1134,7 +1089,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2097152L) != 0))
                             {
-                                return _AcceptCharset;
+                                return _headers._AcceptCharset;
                             }
                             else
                             {
@@ -1150,7 +1105,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4096L) != 0))
                             {
-                                return _ContentType;
+                                return _headers._ContentType;
                             }
                             else
                             {
@@ -1162,7 +1117,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 17179869184L) != 0))
                             {
-                                return _MaxForwards;
+                                return _headers._MaxForwards;
                             }
                             else
                             {
@@ -1178,7 +1133,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8192L) != 0))
                             {
-                                return _ContentEncoding;
+                                return _headers._ContentEncoding;
                             }
                             else
                             {
@@ -1190,7 +1145,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16384L) != 0))
                             {
-                                return _ContentLanguage;
+                                return _headers._ContentLanguage;
                             }
                             else
                             {
@@ -1202,7 +1157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32768L) != 0))
                             {
-                                return _ContentLocation;
+                                return _headers._ContentLocation;
                             }
                             else
                             {
@@ -1218,7 +1173,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 65536L) != 0))
                             {
-                                return _ContentMD5;
+                                return _headers._ContentMD5;
                             }
                             else
                             {
@@ -1234,7 +1189,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4194304L) != 0))
                             {
-                                return _AcceptEncoding;
+                                return _headers._AcceptEncoding;
                             }
                             else
                             {
@@ -1246,7 +1201,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8388608L) != 0))
                             {
-                                return _AcceptLanguage;
+                                return _headers._AcceptLanguage;
                             }
                             else
                             {
@@ -1262,7 +1217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 536870912L) != 0))
                             {
-                                return _IfMatch;
+                                return _headers._IfMatch;
                             }
                             else
                             {
@@ -1274,7 +1229,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4294967296L) != 0))
                             {
-                                return _IfRange;
+                                return _headers._IfRange;
                             }
                             else
                             {
@@ -1290,7 +1245,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8589934592L) != 0))
                             {
-                                return _IfUnmodifiedSince;
+                                return _headers._IfUnmodifiedSince;
                             }
                             else
                             {
@@ -1302,7 +1257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 34359738368L) != 0))
                             {
-                                return _ProxyAuthorization;
+                                return _headers._ProxyAuthorization;
                             }
                             else
                             {
@@ -1318,7 +1273,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 274877906944L) != 0))
                             {
-                                return _TE;
+                                return _headers._TE;
                             }
                             else
                             {
@@ -1334,7 +1289,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 549755813888L) != 0))
                             {
-                                return _Translate;
+                                return _headers._Translate;
                             }
                             else
                             {
@@ -1350,7 +1305,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4398046511104L) != 0))
                             {
-                                return _AccessControlRequestMethod;
+                                return _headers._AccessControlRequestMethod;
                             }
                             else
                             {
@@ -1366,7 +1321,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8796093022208L) != 0))
                             {
-                                return _AccessControlRequestHeaders;
+                                return _headers._AccessControlRequestHeaders;
                             }
                             else
                             {
@@ -1392,7 +1347,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1L) != 0))
                             {
-                                value = _CacheControl;
+                                value = _headers._CacheControl;
                                 return true;
                             }
                             else
@@ -1406,7 +1361,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 131072L) != 0))
                             {
-                                value = _ContentRange;
+                                value = _headers._ContentRange;
                                 return true;
                             }
                             else
@@ -1420,7 +1375,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 524288L) != 0))
                             {
-                                value = _LastModified;
+                                value = _headers._LastModified;
                                 return true;
                             }
                             else
@@ -1434,7 +1389,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16777216L) != 0))
                             {
-                                value = _Authorization;
+                                value = _headers._Authorization;
                                 return true;
                             }
                             else
@@ -1448,7 +1403,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2147483648L) != 0))
                             {
-                                value = _IfNoneMatch;
+                                value = _headers._IfNoneMatch;
                                 return true;
                             }
                             else
@@ -1466,7 +1421,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2L) != 0))
                             {
-                                value = _Connection;
+                                value = _headers._Connection;
                                 return true;
                             }
                             else
@@ -1480,7 +1435,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8L) != 0))
                             {
-                                value = _KeepAlive;
+                                value = _headers._KeepAlive;
                                 return true;
                             }
                             else
@@ -1494,7 +1449,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1099511627776L) != 0))
                             {
-                                value = _UserAgent;
+                                value = _headers._UserAgent;
                                 return true;
                             }
                             else
@@ -1512,7 +1467,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4L) != 0))
                             {
-                                value = _Date;
+                                value = _headers._Date;
                                 return true;
                             }
                             else
@@ -1526,7 +1481,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 134217728L) != 0))
                             {
-                                value = _From;
+                                value = _headers._From;
                                 return true;
                             }
                             else
@@ -1540,7 +1495,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 268435456L) != 0))
                             {
-                                value = _Host;
+                                value = _headers._Host;
                                 return true;
                             }
                             else
@@ -1558,7 +1513,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16L) != 0))
                             {
-                                value = _Pragma;
+                                value = _headers._Pragma;
                                 return true;
                             }
                             else
@@ -1572,7 +1527,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1048576L) != 0))
                             {
-                                value = _Accept;
+                                value = _headers._Accept;
                                 return true;
                             }
                             else
@@ -1586,7 +1541,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 33554432L) != 0))
                             {
-                                value = _Cookie;
+                                value = _headers._Cookie;
                                 return true;
                             }
                             else
@@ -1600,7 +1555,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 67108864L) != 0))
                             {
-                                value = _Expect;
+                                value = _headers._Expect;
                                 return true;
                             }
                             else
@@ -1614,7 +1569,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2199023255552L) != 0))
                             {
-                                value = _Origin;
+                                value = _headers._Origin;
                                 return true;
                             }
                             else
@@ -1632,7 +1587,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32L) != 0))
                             {
-                                value = _Trailer;
+                                value = _headers._Trailer;
                                 return true;
                             }
                             else
@@ -1646,7 +1601,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 128L) != 0))
                             {
-                                value = _Upgrade;
+                                value = _headers._Upgrade;
                                 return true;
                             }
                             else
@@ -1660,7 +1615,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 512L) != 0))
                             {
-                                value = _Warning;
+                                value = _headers._Warning;
                                 return true;
                             }
                             else
@@ -1674,7 +1629,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 262144L) != 0))
                             {
-                                value = _Expires;
+                                value = _headers._Expires;
                                 return true;
                             }
                             else
@@ -1688,7 +1643,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 68719476736L) != 0))
                             {
-                                value = _Referer;
+                                value = _headers._Referer;
                                 return true;
                             }
                             else
@@ -1706,7 +1661,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 64L) != 0))
                             {
-                                value = _TransferEncoding;
+                                value = _headers._TransferEncoding;
                                 return true;
                             }
                             else
@@ -1720,7 +1675,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1073741824L) != 0))
                             {
-                                value = _IfModifiedSince;
+                                value = _headers._IfModifiedSince;
                                 return true;
                             }
                             else
@@ -1738,7 +1693,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 256L) != 0))
                             {
-                                value = _Via;
+                                value = _headers._Via;
                                 return true;
                             }
                             else
@@ -1756,7 +1711,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1024L) != 0))
                             {
-                                value = _Allow;
+                                value = _headers._Allow;
                                 return true;
                             }
                             else
@@ -1770,7 +1725,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 137438953472L) != 0))
                             {
-                                value = _Range;
+                                value = _headers._Range;
                                 return true;
                             }
                             else
@@ -1788,7 +1743,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2048L) != 0))
                             {
-                                value = _ContentLength;
+                                value = _headers._ContentLength;
                                 return true;
                             }
                             else
@@ -1802,7 +1757,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2097152L) != 0))
                             {
-                                value = _AcceptCharset;
+                                value = _headers._AcceptCharset;
                                 return true;
                             }
                             else
@@ -1820,7 +1775,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4096L) != 0))
                             {
-                                value = _ContentType;
+                                value = _headers._ContentType;
                                 return true;
                             }
                             else
@@ -1834,7 +1789,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 17179869184L) != 0))
                             {
-                                value = _MaxForwards;
+                                value = _headers._MaxForwards;
                                 return true;
                             }
                             else
@@ -1852,7 +1807,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8192L) != 0))
                             {
-                                value = _ContentEncoding;
+                                value = _headers._ContentEncoding;
                                 return true;
                             }
                             else
@@ -1866,7 +1821,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16384L) != 0))
                             {
-                                value = _ContentLanguage;
+                                value = _headers._ContentLanguage;
                                 return true;
                             }
                             else
@@ -1880,7 +1835,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32768L) != 0))
                             {
-                                value = _ContentLocation;
+                                value = _headers._ContentLocation;
                                 return true;
                             }
                             else
@@ -1898,7 +1853,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 65536L) != 0))
                             {
-                                value = _ContentMD5;
+                                value = _headers._ContentMD5;
                                 return true;
                             }
                             else
@@ -1916,7 +1871,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4194304L) != 0))
                             {
-                                value = _AcceptEncoding;
+                                value = _headers._AcceptEncoding;
                                 return true;
                             }
                             else
@@ -1930,7 +1885,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8388608L) != 0))
                             {
-                                value = _AcceptLanguage;
+                                value = _headers._AcceptLanguage;
                                 return true;
                             }
                             else
@@ -1948,7 +1903,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 536870912L) != 0))
                             {
-                                value = _IfMatch;
+                                value = _headers._IfMatch;
                                 return true;
                             }
                             else
@@ -1962,7 +1917,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4294967296L) != 0))
                             {
-                                value = _IfRange;
+                                value = _headers._IfRange;
                                 return true;
                             }
                             else
@@ -1980,7 +1935,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8589934592L) != 0))
                             {
-                                value = _IfUnmodifiedSince;
+                                value = _headers._IfUnmodifiedSince;
                                 return true;
                             }
                             else
@@ -1994,7 +1949,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 34359738368L) != 0))
                             {
-                                value = _ProxyAuthorization;
+                                value = _headers._ProxyAuthorization;
                                 return true;
                             }
                             else
@@ -2012,7 +1967,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 274877906944L) != 0))
                             {
-                                value = _TE;
+                                value = _headers._TE;
                                 return true;
                             }
                             else
@@ -2030,7 +1985,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 549755813888L) != 0))
                             {
-                                value = _Translate;
+                                value = _headers._Translate;
                                 return true;
                             }
                             else
@@ -2048,7 +2003,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4398046511104L) != 0))
                             {
-                                value = _AccessControlRequestMethod;
+                                value = _headers._AccessControlRequestMethod;
                                 return true;
                             }
                             else
@@ -2066,7 +2021,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8796093022208L) != 0))
                             {
-                                value = _AccessControlRequestHeaders;
+                                value = _headers._AccessControlRequestHeaders;
                                 return true;
                             }
                             else
@@ -2090,35 +2045,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Cache-Control".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 1L;
-                            _CacheControl = value;
+                            _headers._CacheControl = value;
                             return;
                         }
                     
                         if ("Content-Range".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 131072L;
-                            _ContentRange = value;
+                            _headers._ContentRange = value;
                             return;
                         }
                     
                         if ("Last-Modified".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 524288L;
-                            _LastModified = value;
+                            _headers._LastModified = value;
                             return;
                         }
                     
                         if ("Authorization".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 16777216L;
-                            _Authorization = value;
+                            _headers._Authorization = value;
                             return;
                         }
                     
                         if ("If-None-Match".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 2147483648L;
-                            _IfNoneMatch = value;
+                            _headers._IfNoneMatch = value;
                             return;
                         }
                     }
@@ -2129,21 +2084,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Connection".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 2L;
-                            _Connection = value;
+                            _headers._Connection = value;
                             return;
                         }
                     
                         if ("Keep-Alive".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 8L;
-                            _KeepAlive = value;
+                            _headers._KeepAlive = value;
                             return;
                         }
                     
                         if ("User-Agent".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 1099511627776L;
-                            _UserAgent = value;
+                            _headers._UserAgent = value;
                             return;
                         }
                     }
@@ -2154,21 +2109,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Date".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 4L;
-                            _Date = value;
+                            _headers._Date = value;
                             return;
                         }
                     
                         if ("From".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 134217728L;
-                            _From = value;
+                            _headers._From = value;
                             return;
                         }
                     
                         if ("Host".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 268435456L;
-                            _Host = value;
+                            _headers._Host = value;
                             return;
                         }
                     }
@@ -2179,35 +2134,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Pragma".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 16L;
-                            _Pragma = value;
+                            _headers._Pragma = value;
                             return;
                         }
                     
                         if ("Accept".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 1048576L;
-                            _Accept = value;
+                            _headers._Accept = value;
                             return;
                         }
                     
                         if ("Cookie".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 33554432L;
-                            _Cookie = value;
+                            _headers._Cookie = value;
                             return;
                         }
                     
                         if ("Expect".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 67108864L;
-                            _Expect = value;
+                            _headers._Expect = value;
                             return;
                         }
                     
                         if ("Origin".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 2199023255552L;
-                            _Origin = value;
+                            _headers._Origin = value;
                             return;
                         }
                     }
@@ -2218,35 +2173,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Trailer".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 32L;
-                            _Trailer = value;
+                            _headers._Trailer = value;
                             return;
                         }
                     
                         if ("Upgrade".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 128L;
-                            _Upgrade = value;
+                            _headers._Upgrade = value;
                             return;
                         }
                     
                         if ("Warning".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 512L;
-                            _Warning = value;
+                            _headers._Warning = value;
                             return;
                         }
                     
                         if ("Expires".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 262144L;
-                            _Expires = value;
+                            _headers._Expires = value;
                             return;
                         }
                     
                         if ("Referer".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 68719476736L;
-                            _Referer = value;
+                            _headers._Referer = value;
                             return;
                         }
                     }
@@ -2257,14 +2212,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Transfer-Encoding".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 64L;
-                            _TransferEncoding = value;
+                            _headers._TransferEncoding = value;
                             return;
                         }
                     
                         if ("If-Modified-Since".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 1073741824L;
-                            _IfModifiedSince = value;
+                            _headers._IfModifiedSince = value;
                             return;
                         }
                     }
@@ -2275,7 +2230,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Via".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 256L;
-                            _Via = value;
+                            _headers._Via = value;
                             return;
                         }
                     }
@@ -2286,14 +2241,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Allow".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 1024L;
-                            _Allow = value;
+                            _headers._Allow = value;
                             return;
                         }
                     
                         if ("Range".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 137438953472L;
-                            _Range = value;
+                            _headers._Range = value;
                             return;
                         }
                     }
@@ -2304,14 +2259,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Content-Length".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 2048L;
-                            _ContentLength = value;
+                            _headers._ContentLength = value;
                             return;
                         }
                     
                         if ("Accept-Charset".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 2097152L;
-                            _AcceptCharset = value;
+                            _headers._AcceptCharset = value;
                             return;
                         }
                     }
@@ -2322,14 +2277,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Content-Type".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 4096L;
-                            _ContentType = value;
+                            _headers._ContentType = value;
                             return;
                         }
                     
                         if ("Max-Forwards".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 17179869184L;
-                            _MaxForwards = value;
+                            _headers._MaxForwards = value;
                             return;
                         }
                     }
@@ -2340,21 +2295,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Content-Encoding".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 8192L;
-                            _ContentEncoding = value;
+                            _headers._ContentEncoding = value;
                             return;
                         }
                     
                         if ("Content-Language".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 16384L;
-                            _ContentLanguage = value;
+                            _headers._ContentLanguage = value;
                             return;
                         }
                     
                         if ("Content-Location".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 32768L;
-                            _ContentLocation = value;
+                            _headers._ContentLocation = value;
                             return;
                         }
                     }
@@ -2365,7 +2320,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Content-MD5".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 65536L;
-                            _ContentMD5 = value;
+                            _headers._ContentMD5 = value;
                             return;
                         }
                     }
@@ -2376,14 +2331,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Accept-Encoding".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 4194304L;
-                            _AcceptEncoding = value;
+                            _headers._AcceptEncoding = value;
                             return;
                         }
                     
                         if ("Accept-Language".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 8388608L;
-                            _AcceptLanguage = value;
+                            _headers._AcceptLanguage = value;
                             return;
                         }
                     }
@@ -2394,14 +2349,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("If-Match".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 536870912L;
-                            _IfMatch = value;
+                            _headers._IfMatch = value;
                             return;
                         }
                     
                         if ("If-Range".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 4294967296L;
-                            _IfRange = value;
+                            _headers._IfRange = value;
                             return;
                         }
                     }
@@ -2412,14 +2367,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("If-Unmodified-Since".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 8589934592L;
-                            _IfUnmodifiedSince = value;
+                            _headers._IfUnmodifiedSince = value;
                             return;
                         }
                     
                         if ("Proxy-Authorization".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 34359738368L;
-                            _ProxyAuthorization = value;
+                            _headers._ProxyAuthorization = value;
                             return;
                         }
                     }
@@ -2430,7 +2385,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("TE".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 274877906944L;
-                            _TE = value;
+                            _headers._TE = value;
                             return;
                         }
                     }
@@ -2441,7 +2396,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Translate".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 549755813888L;
-                            _Translate = value;
+                            _headers._Translate = value;
                             return;
                         }
                     }
@@ -2452,7 +2407,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Access-Control-Request-Method".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 4398046511104L;
-                            _AccessControlRequestMethod = value;
+                            _headers._AccessControlRequestMethod = value;
                             return;
                         }
                     }
@@ -2463,7 +2418,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Access-Control-Request-Headers".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 8796093022208L;
-                            _AccessControlRequestHeaders = value;
+                            _headers._AccessControlRequestHeaders = value;
                             return;
                         }
                     }
@@ -2484,7 +2439,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 1L;
-                            _CacheControl = value;
+                            _headers._CacheControl = value;
                             return;
                         }
                     
@@ -2495,7 +2450,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 131072L;
-                            _ContentRange = value;
+                            _headers._ContentRange = value;
                             return;
                         }
                     
@@ -2506,7 +2461,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 524288L;
-                            _LastModified = value;
+                            _headers._LastModified = value;
                             return;
                         }
                     
@@ -2517,7 +2472,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 16777216L;
-                            _Authorization = value;
+                            _headers._Authorization = value;
                             return;
                         }
                     
@@ -2528,7 +2483,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 2147483648L;
-                            _IfNoneMatch = value;
+                            _headers._IfNoneMatch = value;
                             return;
                         }
                     }
@@ -2543,7 +2498,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 2L;
-                            _Connection = value;
+                            _headers._Connection = value;
                             return;
                         }
                     
@@ -2554,7 +2509,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 8L;
-                            _KeepAlive = value;
+                            _headers._KeepAlive = value;
                             return;
                         }
                     
@@ -2565,7 +2520,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 1099511627776L;
-                            _UserAgent = value;
+                            _headers._UserAgent = value;
                             return;
                         }
                     }
@@ -2580,7 +2535,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 4L;
-                            _Date = value;
+                            _headers._Date = value;
                             return;
                         }
                     
@@ -2591,7 +2546,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 134217728L;
-                            _From = value;
+                            _headers._From = value;
                             return;
                         }
                     
@@ -2602,7 +2557,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 268435456L;
-                            _Host = value;
+                            _headers._Host = value;
                             return;
                         }
                     }
@@ -2617,7 +2572,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 16L;
-                            _Pragma = value;
+                            _headers._Pragma = value;
                             return;
                         }
                     
@@ -2628,7 +2583,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 1048576L;
-                            _Accept = value;
+                            _headers._Accept = value;
                             return;
                         }
                     
@@ -2639,7 +2594,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 33554432L;
-                            _Cookie = value;
+                            _headers._Cookie = value;
                             return;
                         }
                     
@@ -2650,7 +2605,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 67108864L;
-                            _Expect = value;
+                            _headers._Expect = value;
                             return;
                         }
                     
@@ -2661,7 +2616,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 2199023255552L;
-                            _Origin = value;
+                            _headers._Origin = value;
                             return;
                         }
                     }
@@ -2676,7 +2631,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 32L;
-                            _Trailer = value;
+                            _headers._Trailer = value;
                             return;
                         }
                     
@@ -2687,7 +2642,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 128L;
-                            _Upgrade = value;
+                            _headers._Upgrade = value;
                             return;
                         }
                     
@@ -2698,7 +2653,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 512L;
-                            _Warning = value;
+                            _headers._Warning = value;
                             return;
                         }
                     
@@ -2709,7 +2664,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 262144L;
-                            _Expires = value;
+                            _headers._Expires = value;
                             return;
                         }
                     
@@ -2720,7 +2675,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 68719476736L;
-                            _Referer = value;
+                            _headers._Referer = value;
                             return;
                         }
                     }
@@ -2735,7 +2690,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 64L;
-                            _TransferEncoding = value;
+                            _headers._TransferEncoding = value;
                             return;
                         }
                     
@@ -2746,7 +2701,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 1073741824L;
-                            _IfModifiedSince = value;
+                            _headers._IfModifiedSince = value;
                             return;
                         }
                     }
@@ -2761,7 +2716,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 256L;
-                            _Via = value;
+                            _headers._Via = value;
                             return;
                         }
                     }
@@ -2776,7 +2731,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 1024L;
-                            _Allow = value;
+                            _headers._Allow = value;
                             return;
                         }
                     
@@ -2787,7 +2742,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 137438953472L;
-                            _Range = value;
+                            _headers._Range = value;
                             return;
                         }
                     }
@@ -2802,7 +2757,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 2048L;
-                            _ContentLength = value;
+                            _headers._ContentLength = value;
                             return;
                         }
                     
@@ -2813,7 +2768,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 2097152L;
-                            _AcceptCharset = value;
+                            _headers._AcceptCharset = value;
                             return;
                         }
                     }
@@ -2828,7 +2783,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 4096L;
-                            _ContentType = value;
+                            _headers._ContentType = value;
                             return;
                         }
                     
@@ -2839,7 +2794,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 17179869184L;
-                            _MaxForwards = value;
+                            _headers._MaxForwards = value;
                             return;
                         }
                     }
@@ -2854,7 +2809,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 8192L;
-                            _ContentEncoding = value;
+                            _headers._ContentEncoding = value;
                             return;
                         }
                     
@@ -2865,7 +2820,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 16384L;
-                            _ContentLanguage = value;
+                            _headers._ContentLanguage = value;
                             return;
                         }
                     
@@ -2876,7 +2831,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 32768L;
-                            _ContentLocation = value;
+                            _headers._ContentLocation = value;
                             return;
                         }
                     }
@@ -2891,7 +2846,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 65536L;
-                            _ContentMD5 = value;
+                            _headers._ContentMD5 = value;
                             return;
                         }
                     }
@@ -2906,7 +2861,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 4194304L;
-                            _AcceptEncoding = value;
+                            _headers._AcceptEncoding = value;
                             return;
                         }
                     
@@ -2917,7 +2872,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 8388608L;
-                            _AcceptLanguage = value;
+                            _headers._AcceptLanguage = value;
                             return;
                         }
                     }
@@ -2932,7 +2887,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 536870912L;
-                            _IfMatch = value;
+                            _headers._IfMatch = value;
                             return;
                         }
                     
@@ -2943,7 +2898,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 4294967296L;
-                            _IfRange = value;
+                            _headers._IfRange = value;
                             return;
                         }
                     }
@@ -2958,7 +2913,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 8589934592L;
-                            _IfUnmodifiedSince = value;
+                            _headers._IfUnmodifiedSince = value;
                             return;
                         }
                     
@@ -2969,7 +2924,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 34359738368L;
-                            _ProxyAuthorization = value;
+                            _headers._ProxyAuthorization = value;
                             return;
                         }
                     }
@@ -2984,7 +2939,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 274877906944L;
-                            _TE = value;
+                            _headers._TE = value;
                             return;
                         }
                     }
@@ -2999,7 +2954,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 549755813888L;
-                            _Translate = value;
+                            _headers._Translate = value;
                             return;
                         }
                     }
@@ -3014,7 +2969,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 4398046511104L;
-                            _AccessControlRequestMethod = value;
+                            _headers._AccessControlRequestMethod = value;
                             return;
                         }
                     }
@@ -3029,7 +2984,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 8796093022208L;
-                            _AccessControlRequestHeaders = value;
+                            _headers._AccessControlRequestHeaders = value;
                             return;
                         }
                     }
@@ -3048,7 +3003,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 1L) != 0))
                             {
                                 _bits &= ~1L;
-                                _CacheControl = StringValues.Empty;
+                                _headers._CacheControl = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3062,7 +3017,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 131072L) != 0))
                             {
                                 _bits &= ~131072L;
-                                _ContentRange = StringValues.Empty;
+                                _headers._ContentRange = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3076,7 +3031,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 524288L) != 0))
                             {
                                 _bits &= ~524288L;
-                                _LastModified = StringValues.Empty;
+                                _headers._LastModified = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3090,7 +3045,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 16777216L) != 0))
                             {
                                 _bits &= ~16777216L;
-                                _Authorization = StringValues.Empty;
+                                _headers._Authorization = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3104,7 +3059,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 2147483648L) != 0))
                             {
                                 _bits &= ~2147483648L;
-                                _IfNoneMatch = StringValues.Empty;
+                                _headers._IfNoneMatch = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3122,7 +3077,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 2L) != 0))
                             {
                                 _bits &= ~2L;
-                                _Connection = StringValues.Empty;
+                                _headers._Connection = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3136,7 +3091,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 8L) != 0))
                             {
                                 _bits &= ~8L;
-                                _KeepAlive = StringValues.Empty;
+                                _headers._KeepAlive = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3150,7 +3105,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 1099511627776L) != 0))
                             {
                                 _bits &= ~1099511627776L;
-                                _UserAgent = StringValues.Empty;
+                                _headers._UserAgent = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3168,7 +3123,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 4L) != 0))
                             {
                                 _bits &= ~4L;
-                                _Date = StringValues.Empty;
+                                _headers._Date = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3182,7 +3137,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 134217728L) != 0))
                             {
                                 _bits &= ~134217728L;
-                                _From = StringValues.Empty;
+                                _headers._From = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3196,7 +3151,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 268435456L) != 0))
                             {
                                 _bits &= ~268435456L;
-                                _Host = StringValues.Empty;
+                                _headers._Host = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3214,7 +3169,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 16L) != 0))
                             {
                                 _bits &= ~16L;
-                                _Pragma = StringValues.Empty;
+                                _headers._Pragma = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3228,7 +3183,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 1048576L) != 0))
                             {
                                 _bits &= ~1048576L;
-                                _Accept = StringValues.Empty;
+                                _headers._Accept = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3242,7 +3197,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 33554432L) != 0))
                             {
                                 _bits &= ~33554432L;
-                                _Cookie = StringValues.Empty;
+                                _headers._Cookie = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3256,7 +3211,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 67108864L) != 0))
                             {
                                 _bits &= ~67108864L;
-                                _Expect = StringValues.Empty;
+                                _headers._Expect = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3270,7 +3225,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 2199023255552L) != 0))
                             {
                                 _bits &= ~2199023255552L;
-                                _Origin = StringValues.Empty;
+                                _headers._Origin = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3288,7 +3243,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 32L) != 0))
                             {
                                 _bits &= ~32L;
-                                _Trailer = StringValues.Empty;
+                                _headers._Trailer = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3302,7 +3257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 128L) != 0))
                             {
                                 _bits &= ~128L;
-                                _Upgrade = StringValues.Empty;
+                                _headers._Upgrade = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3316,7 +3271,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 512L) != 0))
                             {
                                 _bits &= ~512L;
-                                _Warning = StringValues.Empty;
+                                _headers._Warning = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3330,7 +3285,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 262144L) != 0))
                             {
                                 _bits &= ~262144L;
-                                _Expires = StringValues.Empty;
+                                _headers._Expires = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3344,7 +3299,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 68719476736L) != 0))
                             {
                                 _bits &= ~68719476736L;
-                                _Referer = StringValues.Empty;
+                                _headers._Referer = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3362,7 +3317,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 64L) != 0))
                             {
                                 _bits &= ~64L;
-                                _TransferEncoding = StringValues.Empty;
+                                _headers._TransferEncoding = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3376,7 +3331,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 1073741824L) != 0))
                             {
                                 _bits &= ~1073741824L;
-                                _IfModifiedSince = StringValues.Empty;
+                                _headers._IfModifiedSince = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3394,7 +3349,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 256L) != 0))
                             {
                                 _bits &= ~256L;
-                                _Via = StringValues.Empty;
+                                _headers._Via = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3412,7 +3367,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 1024L) != 0))
                             {
                                 _bits &= ~1024L;
-                                _Allow = StringValues.Empty;
+                                _headers._Allow = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3426,7 +3381,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 137438953472L) != 0))
                             {
                                 _bits &= ~137438953472L;
-                                _Range = StringValues.Empty;
+                                _headers._Range = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3444,7 +3399,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 2048L) != 0))
                             {
                                 _bits &= ~2048L;
-                                _ContentLength = StringValues.Empty;
+                                _headers._ContentLength = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3458,7 +3413,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 2097152L) != 0))
                             {
                                 _bits &= ~2097152L;
-                                _AcceptCharset = StringValues.Empty;
+                                _headers._AcceptCharset = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3476,7 +3431,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 4096L) != 0))
                             {
                                 _bits &= ~4096L;
-                                _ContentType = StringValues.Empty;
+                                _headers._ContentType = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3490,7 +3445,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 17179869184L) != 0))
                             {
                                 _bits &= ~17179869184L;
-                                _MaxForwards = StringValues.Empty;
+                                _headers._MaxForwards = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3508,7 +3463,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 8192L) != 0))
                             {
                                 _bits &= ~8192L;
-                                _ContentEncoding = StringValues.Empty;
+                                _headers._ContentEncoding = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3522,7 +3477,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 16384L) != 0))
                             {
                                 _bits &= ~16384L;
-                                _ContentLanguage = StringValues.Empty;
+                                _headers._ContentLanguage = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3536,7 +3491,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 32768L) != 0))
                             {
                                 _bits &= ~32768L;
-                                _ContentLocation = StringValues.Empty;
+                                _headers._ContentLocation = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3554,7 +3509,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 65536L) != 0))
                             {
                                 _bits &= ~65536L;
-                                _ContentMD5 = StringValues.Empty;
+                                _headers._ContentMD5 = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3572,7 +3527,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 4194304L) != 0))
                             {
                                 _bits &= ~4194304L;
-                                _AcceptEncoding = StringValues.Empty;
+                                _headers._AcceptEncoding = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3586,7 +3541,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 8388608L) != 0))
                             {
                                 _bits &= ~8388608L;
-                                _AcceptLanguage = StringValues.Empty;
+                                _headers._AcceptLanguage = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3604,7 +3559,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 536870912L) != 0))
                             {
                                 _bits &= ~536870912L;
-                                _IfMatch = StringValues.Empty;
+                                _headers._IfMatch = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3618,7 +3573,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 4294967296L) != 0))
                             {
                                 _bits &= ~4294967296L;
-                                _IfRange = StringValues.Empty;
+                                _headers._IfRange = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3636,7 +3591,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 8589934592L) != 0))
                             {
                                 _bits &= ~8589934592L;
-                                _IfUnmodifiedSince = StringValues.Empty;
+                                _headers._IfUnmodifiedSince = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3650,7 +3605,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 34359738368L) != 0))
                             {
                                 _bits &= ~34359738368L;
-                                _ProxyAuthorization = StringValues.Empty;
+                                _headers._ProxyAuthorization = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3668,7 +3623,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 274877906944L) != 0))
                             {
                                 _bits &= ~274877906944L;
-                                _TE = StringValues.Empty;
+                                _headers._TE = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3686,7 +3641,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 549755813888L) != 0))
                             {
                                 _bits &= ~549755813888L;
-                                _Translate = StringValues.Empty;
+                                _headers._Translate = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3704,7 +3659,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 4398046511104L) != 0))
                             {
                                 _bits &= ~4398046511104L;
-                                _AccessControlRequestMethod = StringValues.Empty;
+                                _headers._AccessControlRequestMethod = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3722,7 +3677,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 8796093022208L) != 0))
                             {
                                 _bits &= ~8796093022208L;
-                                _AccessControlRequestHeaders = StringValues.Empty;
+                                _headers._AccessControlRequestHeaders = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -3737,52 +3692,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         }
         protected override void ClearFast()
         {
-            if (((_bits & 1L) != 0)) _CacheControl = default(StringValues);
-            if (((_bits & 2L) != 0)) _Connection = default(StringValues);
-            if (((_bits & 4L) != 0)) _Date = default(StringValues);
-            if (((_bits & 8L) != 0)) _KeepAlive = default(StringValues);
-            if (((_bits & 16L) != 0)) _Pragma = default(StringValues);
-            if (((_bits & 32L) != 0)) _Trailer = default(StringValues);
-            if (((_bits & 64L) != 0)) _TransferEncoding = default(StringValues);
-            if (((_bits & 128L) != 0)) _Upgrade = default(StringValues);
-            if (((_bits & 256L) != 0)) _Via = default(StringValues);
-            if (((_bits & 512L) != 0)) _Warning = default(StringValues);
-            if (((_bits & 1024L) != 0)) _Allow = default(StringValues);
-            if (((_bits & 2048L) != 0)) _ContentLength = default(StringValues);
-            if (((_bits & 4096L) != 0)) _ContentType = default(StringValues);
-            if (((_bits & 8192L) != 0)) _ContentEncoding = default(StringValues);
-            if (((_bits & 16384L) != 0)) _ContentLanguage = default(StringValues);
-            if (((_bits & 32768L) != 0)) _ContentLocation = default(StringValues);
-            if (((_bits & 65536L) != 0)) _ContentMD5 = default(StringValues);
-            if (((_bits & 131072L) != 0)) _ContentRange = default(StringValues);
-            if (((_bits & 262144L) != 0)) _Expires = default(StringValues);
-            if (((_bits & 524288L) != 0)) _LastModified = default(StringValues);
-            if (((_bits & 1048576L) != 0)) _Accept = default(StringValues);
-            if (((_bits & 2097152L) != 0)) _AcceptCharset = default(StringValues);
-            if (((_bits & 4194304L) != 0)) _AcceptEncoding = default(StringValues);
-            if (((_bits & 8388608L) != 0)) _AcceptLanguage = default(StringValues);
-            if (((_bits & 16777216L) != 0)) _Authorization = default(StringValues);
-            if (((_bits & 33554432L) != 0)) _Cookie = default(StringValues);
-            if (((_bits & 67108864L) != 0)) _Expect = default(StringValues);
-            if (((_bits & 134217728L) != 0)) _From = default(StringValues);
-            if (((_bits & 268435456L) != 0)) _Host = default(StringValues);
-            if (((_bits & 536870912L) != 0)) _IfMatch = default(StringValues);
-            if (((_bits & 1073741824L) != 0)) _IfModifiedSince = default(StringValues);
-            if (((_bits & 2147483648L) != 0)) _IfNoneMatch = default(StringValues);
-            if (((_bits & 4294967296L) != 0)) _IfRange = default(StringValues);
-            if (((_bits & 8589934592L) != 0)) _IfUnmodifiedSince = default(StringValues);
-            if (((_bits & 17179869184L) != 0)) _MaxForwards = default(StringValues);
-            if (((_bits & 34359738368L) != 0)) _ProxyAuthorization = default(StringValues);
-            if (((_bits & 68719476736L) != 0)) _Referer = default(StringValues);
-            if (((_bits & 137438953472L) != 0)) _Range = default(StringValues);
-            if (((_bits & 274877906944L) != 0)) _TE = default(StringValues);
-            if (((_bits & 549755813888L) != 0)) _Translate = default(StringValues);
-            if (((_bits & 1099511627776L) != 0)) _UserAgent = default(StringValues);
-            if (((_bits & 2199023255552L) != 0)) _Origin = default(StringValues);
-            if (((_bits & 4398046511104L) != 0)) _AccessControlRequestMethod = default(StringValues);
-            if (((_bits & 8796093022208L) != 0)) _AccessControlRequestHeaders = default(StringValues);
-
             _bits = 0;
+            _headers = default(HeaderReferences);
             MaybeUnknown?.Clear();
         }
         
@@ -3800,7 +3711,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Cache-Control", _CacheControl);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Cache-Control", _headers._CacheControl);
                     ++arrayIndex;
                 }
             
@@ -3811,7 +3722,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Connection", _Connection);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Connection", _headers._Connection);
                     ++arrayIndex;
                 }
             
@@ -3822,7 +3733,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Date", _Date);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Date", _headers._Date);
                     ++arrayIndex;
                 }
             
@@ -3833,7 +3744,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Keep-Alive", _KeepAlive);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Keep-Alive", _headers._KeepAlive);
                     ++arrayIndex;
                 }
             
@@ -3844,7 +3755,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Pragma", _Pragma);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Pragma", _headers._Pragma);
                     ++arrayIndex;
                 }
             
@@ -3855,7 +3766,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Trailer", _Trailer);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Trailer", _headers._Trailer);
                     ++arrayIndex;
                 }
             
@@ -3866,7 +3777,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Transfer-Encoding", _TransferEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Transfer-Encoding", _headers._TransferEncoding);
                     ++arrayIndex;
                 }
             
@@ -3877,7 +3788,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Upgrade", _Upgrade);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Upgrade", _headers._Upgrade);
                     ++arrayIndex;
                 }
             
@@ -3888,7 +3799,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Via", _Via);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Via", _headers._Via);
                     ++arrayIndex;
                 }
             
@@ -3899,7 +3810,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Warning", _Warning);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Warning", _headers._Warning);
                     ++arrayIndex;
                 }
             
@@ -3910,7 +3821,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Allow", _Allow);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Allow", _headers._Allow);
                     ++arrayIndex;
                 }
             
@@ -3921,7 +3832,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Length", _ContentLength);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Length", _headers._ContentLength);
                     ++arrayIndex;
                 }
             
@@ -3932,7 +3843,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Type", _ContentType);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Type", _headers._ContentType);
                     ++arrayIndex;
                 }
             
@@ -3943,7 +3854,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Encoding", _ContentEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Encoding", _headers._ContentEncoding);
                     ++arrayIndex;
                 }
             
@@ -3954,7 +3865,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Language", _ContentLanguage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Language", _headers._ContentLanguage);
                     ++arrayIndex;
                 }
             
@@ -3965,7 +3876,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Location", _ContentLocation);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Location", _headers._ContentLocation);
                     ++arrayIndex;
                 }
             
@@ -3976,7 +3887,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-MD5", _ContentMD5);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-MD5", _headers._ContentMD5);
                     ++arrayIndex;
                 }
             
@@ -3987,7 +3898,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Range", _ContentRange);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Range", _headers._ContentRange);
                     ++arrayIndex;
                 }
             
@@ -3998,7 +3909,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Expires", _Expires);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Expires", _headers._Expires);
                     ++arrayIndex;
                 }
             
@@ -4009,7 +3920,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Last-Modified", _LastModified);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Last-Modified", _headers._LastModified);
                     ++arrayIndex;
                 }
             
@@ -4020,7 +3931,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept", _Accept);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept", _headers._Accept);
                     ++arrayIndex;
                 }
             
@@ -4031,7 +3942,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Charset", _AcceptCharset);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Charset", _headers._AcceptCharset);
                     ++arrayIndex;
                 }
             
@@ -4042,7 +3953,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Encoding", _AcceptEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Encoding", _headers._AcceptEncoding);
                     ++arrayIndex;
                 }
             
@@ -4053,7 +3964,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Language", _AcceptLanguage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Language", _headers._AcceptLanguage);
                     ++arrayIndex;
                 }
             
@@ -4064,7 +3975,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Authorization", _Authorization);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Authorization", _headers._Authorization);
                     ++arrayIndex;
                 }
             
@@ -4075,7 +3986,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Cookie", _Cookie);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Cookie", _headers._Cookie);
                     ++arrayIndex;
                 }
             
@@ -4086,7 +3997,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Expect", _Expect);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Expect", _headers._Expect);
                     ++arrayIndex;
                 }
             
@@ -4097,7 +4008,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("From", _From);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("From", _headers._From);
                     ++arrayIndex;
                 }
             
@@ -4108,7 +4019,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Host", _Host);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Host", _headers._Host);
                     ++arrayIndex;
                 }
             
@@ -4119,7 +4030,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Match", _IfMatch);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Match", _headers._IfMatch);
                     ++arrayIndex;
                 }
             
@@ -4130,7 +4041,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Modified-Since", _IfModifiedSince);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Modified-Since", _headers._IfModifiedSince);
                     ++arrayIndex;
                 }
             
@@ -4141,7 +4052,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-None-Match", _IfNoneMatch);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-None-Match", _headers._IfNoneMatch);
                     ++arrayIndex;
                 }
             
@@ -4152,7 +4063,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Range", _IfRange);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Range", _headers._IfRange);
                     ++arrayIndex;
                 }
             
@@ -4163,7 +4074,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Unmodified-Since", _IfUnmodifiedSince);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("If-Unmodified-Since", _headers._IfUnmodifiedSince);
                     ++arrayIndex;
                 }
             
@@ -4174,7 +4085,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Max-Forwards", _MaxForwards);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Max-Forwards", _headers._MaxForwards);
                     ++arrayIndex;
                 }
             
@@ -4185,7 +4096,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Proxy-Authorization", _ProxyAuthorization);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Proxy-Authorization", _headers._ProxyAuthorization);
                     ++arrayIndex;
                 }
             
@@ -4196,7 +4107,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Referer", _Referer);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Referer", _headers._Referer);
                     ++arrayIndex;
                 }
             
@@ -4207,7 +4118,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Range", _Range);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Range", _headers._Range);
                     ++arrayIndex;
                 }
             
@@ -4218,7 +4129,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("TE", _TE);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("TE", _headers._TE);
                     ++arrayIndex;
                 }
             
@@ -4229,7 +4140,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Translate", _Translate);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Translate", _headers._Translate);
                     ++arrayIndex;
                 }
             
@@ -4240,7 +4151,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("User-Agent", _UserAgent);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("User-Agent", _headers._UserAgent);
                     ++arrayIndex;
                 }
             
@@ -4251,7 +4162,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Origin", _Origin);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Origin", _headers._Origin);
                     ++arrayIndex;
                 }
             
@@ -4262,7 +4173,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Request-Method", _AccessControlRequestMethod);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Request-Method", _headers._AccessControlRequestMethod);
                     ++arrayIndex;
                 }
             
@@ -4273,7 +4184,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Request-Headers", _AccessControlRequestHeaders);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Request-Headers", _headers._AccessControlRequestHeaders);
                     ++arrayIndex;
                 }
             
@@ -4297,12 +4208,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 1L) != 0))
                                 {
-                                    _CacheControl = AppendValue(_CacheControl, value);
+                                    _headers._CacheControl = AppendValue(_headers._CacheControl, value);
                                 }
                                 else
                                 {
                                     _bits |= 1L;
-                                    _CacheControl = new StringValues(value);
+                                    _headers._CacheControl = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4311,12 +4222,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 131072L) != 0))
                                 {
-                                    _ContentRange = AppendValue(_ContentRange, value);
+                                    _headers._ContentRange = AppendValue(_headers._ContentRange, value);
                                 }
                                 else
                                 {
                                     _bits |= 131072L;
-                                    _ContentRange = new StringValues(value);
+                                    _headers._ContentRange = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4325,12 +4236,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 524288L) != 0))
                                 {
-                                    _LastModified = AppendValue(_LastModified, value);
+                                    _headers._LastModified = AppendValue(_headers._LastModified, value);
                                 }
                                 else
                                 {
                                     _bits |= 524288L;
-                                    _LastModified = new StringValues(value);
+                                    _headers._LastModified = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4339,12 +4250,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 16777216L) != 0))
                                 {
-                                    _Authorization = AppendValue(_Authorization, value);
+                                    _headers._Authorization = AppendValue(_headers._Authorization, value);
                                 }
                                 else
                                 {
                                     _bits |= 16777216L;
-                                    _Authorization = new StringValues(value);
+                                    _headers._Authorization = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4353,12 +4264,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 2147483648L) != 0))
                                 {
-                                    _IfNoneMatch = AppendValue(_IfNoneMatch, value);
+                                    _headers._IfNoneMatch = AppendValue(_headers._IfNoneMatch, value);
                                 }
                                 else
                                 {
                                     _bits |= 2147483648L;
-                                    _IfNoneMatch = new StringValues(value);
+                                    _headers._IfNoneMatch = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4371,12 +4282,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 2L) != 0))
                                 {
-                                    _Connection = AppendValue(_Connection, value);
+                                    _headers._Connection = AppendValue(_headers._Connection, value);
                                 }
                                 else
                                 {
                                     _bits |= 2L;
-                                    _Connection = new StringValues(value);
+                                    _headers._Connection = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4385,12 +4296,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 8L) != 0))
                                 {
-                                    _KeepAlive = AppendValue(_KeepAlive, value);
+                                    _headers._KeepAlive = AppendValue(_headers._KeepAlive, value);
                                 }
                                 else
                                 {
                                     _bits |= 8L;
-                                    _KeepAlive = new StringValues(value);
+                                    _headers._KeepAlive = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4399,12 +4310,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 1099511627776L) != 0))
                                 {
-                                    _UserAgent = AppendValue(_UserAgent, value);
+                                    _headers._UserAgent = AppendValue(_headers._UserAgent, value);
                                 }
                                 else
                                 {
                                     _bits |= 1099511627776L;
-                                    _UserAgent = new StringValues(value);
+                                    _headers._UserAgent = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4417,12 +4328,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 4L) != 0))
                                 {
-                                    _Date = AppendValue(_Date, value);
+                                    _headers._Date = AppendValue(_headers._Date, value);
                                 }
                                 else
                                 {
                                     _bits |= 4L;
-                                    _Date = new StringValues(value);
+                                    _headers._Date = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4431,12 +4342,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 134217728L) != 0))
                                 {
-                                    _From = AppendValue(_From, value);
+                                    _headers._From = AppendValue(_headers._From, value);
                                 }
                                 else
                                 {
                                     _bits |= 134217728L;
-                                    _From = new StringValues(value);
+                                    _headers._From = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4445,12 +4356,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 268435456L) != 0))
                                 {
-                                    _Host = AppendValue(_Host, value);
+                                    _headers._Host = AppendValue(_headers._Host, value);
                                 }
                                 else
                                 {
                                     _bits |= 268435456L;
-                                    _Host = new StringValues(value);
+                                    _headers._Host = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4463,12 +4374,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 16L) != 0))
                                 {
-                                    _Pragma = AppendValue(_Pragma, value);
+                                    _headers._Pragma = AppendValue(_headers._Pragma, value);
                                 }
                                 else
                                 {
                                     _bits |= 16L;
-                                    _Pragma = new StringValues(value);
+                                    _headers._Pragma = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4477,12 +4388,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 1048576L) != 0))
                                 {
-                                    _Accept = AppendValue(_Accept, value);
+                                    _headers._Accept = AppendValue(_headers._Accept, value);
                                 }
                                 else
                                 {
                                     _bits |= 1048576L;
-                                    _Accept = new StringValues(value);
+                                    _headers._Accept = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4491,12 +4402,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 33554432L) != 0))
                                 {
-                                    _Cookie = AppendValue(_Cookie, value);
+                                    _headers._Cookie = AppendValue(_headers._Cookie, value);
                                 }
                                 else
                                 {
                                     _bits |= 33554432L;
-                                    _Cookie = new StringValues(value);
+                                    _headers._Cookie = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4505,12 +4416,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 67108864L) != 0))
                                 {
-                                    _Expect = AppendValue(_Expect, value);
+                                    _headers._Expect = AppendValue(_headers._Expect, value);
                                 }
                                 else
                                 {
                                     _bits |= 67108864L;
-                                    _Expect = new StringValues(value);
+                                    _headers._Expect = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4519,12 +4430,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 2199023255552L) != 0))
                                 {
-                                    _Origin = AppendValue(_Origin, value);
+                                    _headers._Origin = AppendValue(_headers._Origin, value);
                                 }
                                 else
                                 {
                                     _bits |= 2199023255552L;
-                                    _Origin = new StringValues(value);
+                                    _headers._Origin = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4537,12 +4448,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 32L) != 0))
                                 {
-                                    _Trailer = AppendValue(_Trailer, value);
+                                    _headers._Trailer = AppendValue(_headers._Trailer, value);
                                 }
                                 else
                                 {
                                     _bits |= 32L;
-                                    _Trailer = new StringValues(value);
+                                    _headers._Trailer = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4551,12 +4462,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 128L) != 0))
                                 {
-                                    _Upgrade = AppendValue(_Upgrade, value);
+                                    _headers._Upgrade = AppendValue(_headers._Upgrade, value);
                                 }
                                 else
                                 {
                                     _bits |= 128L;
-                                    _Upgrade = new StringValues(value);
+                                    _headers._Upgrade = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4565,12 +4476,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 512L) != 0))
                                 {
-                                    _Warning = AppendValue(_Warning, value);
+                                    _headers._Warning = AppendValue(_headers._Warning, value);
                                 }
                                 else
                                 {
                                     _bits |= 512L;
-                                    _Warning = new StringValues(value);
+                                    _headers._Warning = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4579,12 +4490,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 262144L) != 0))
                                 {
-                                    _Expires = AppendValue(_Expires, value);
+                                    _headers._Expires = AppendValue(_headers._Expires, value);
                                 }
                                 else
                                 {
                                     _bits |= 262144L;
-                                    _Expires = new StringValues(value);
+                                    _headers._Expires = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4593,12 +4504,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 68719476736L) != 0))
                                 {
-                                    _Referer = AppendValue(_Referer, value);
+                                    _headers._Referer = AppendValue(_headers._Referer, value);
                                 }
                                 else
                                 {
                                     _bits |= 68719476736L;
-                                    _Referer = new StringValues(value);
+                                    _headers._Referer = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4611,12 +4522,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 64L) != 0))
                                 {
-                                    _TransferEncoding = AppendValue(_TransferEncoding, value);
+                                    _headers._TransferEncoding = AppendValue(_headers._TransferEncoding, value);
                                 }
                                 else
                                 {
                                     _bits |= 64L;
-                                    _TransferEncoding = new StringValues(value);
+                                    _headers._TransferEncoding = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4625,12 +4536,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 1073741824L) != 0))
                                 {
-                                    _IfModifiedSince = AppendValue(_IfModifiedSince, value);
+                                    _headers._IfModifiedSince = AppendValue(_headers._IfModifiedSince, value);
                                 }
                                 else
                                 {
                                     _bits |= 1073741824L;
-                                    _IfModifiedSince = new StringValues(value);
+                                    _headers._IfModifiedSince = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4643,12 +4554,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 256L) != 0))
                                 {
-                                    _Via = AppendValue(_Via, value);
+                                    _headers._Via = AppendValue(_headers._Via, value);
                                 }
                                 else
                                 {
                                     _bits |= 256L;
-                                    _Via = new StringValues(value);
+                                    _headers._Via = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4661,12 +4572,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 1024L) != 0))
                                 {
-                                    _Allow = AppendValue(_Allow, value);
+                                    _headers._Allow = AppendValue(_headers._Allow, value);
                                 }
                                 else
                                 {
                                     _bits |= 1024L;
-                                    _Allow = new StringValues(value);
+                                    _headers._Allow = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4675,12 +4586,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 137438953472L) != 0))
                                 {
-                                    _Range = AppendValue(_Range, value);
+                                    _headers._Range = AppendValue(_headers._Range, value);
                                 }
                                 else
                                 {
                                     _bits |= 137438953472L;
-                                    _Range = new StringValues(value);
+                                    _headers._Range = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4693,12 +4604,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 2048L) != 0))
                                 {
-                                    _ContentLength = AppendValue(_ContentLength, value);
+                                    _headers._ContentLength = AppendValue(_headers._ContentLength, value);
                                 }
                                 else
                                 {
                                     _bits |= 2048L;
-                                    _ContentLength = new StringValues(value);
+                                    _headers._ContentLength = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4707,12 +4618,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 2097152L) != 0))
                                 {
-                                    _AcceptCharset = AppendValue(_AcceptCharset, value);
+                                    _headers._AcceptCharset = AppendValue(_headers._AcceptCharset, value);
                                 }
                                 else
                                 {
                                     _bits |= 2097152L;
-                                    _AcceptCharset = new StringValues(value);
+                                    _headers._AcceptCharset = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4725,12 +4636,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 4096L) != 0))
                                 {
-                                    _ContentType = AppendValue(_ContentType, value);
+                                    _headers._ContentType = AppendValue(_headers._ContentType, value);
                                 }
                                 else
                                 {
                                     _bits |= 4096L;
-                                    _ContentType = new StringValues(value);
+                                    _headers._ContentType = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4739,12 +4650,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 17179869184L) != 0))
                                 {
-                                    _MaxForwards = AppendValue(_MaxForwards, value);
+                                    _headers._MaxForwards = AppendValue(_headers._MaxForwards, value);
                                 }
                                 else
                                 {
                                     _bits |= 17179869184L;
-                                    _MaxForwards = new StringValues(value);
+                                    _headers._MaxForwards = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4757,12 +4668,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 8192L) != 0))
                                 {
-                                    _ContentEncoding = AppendValue(_ContentEncoding, value);
+                                    _headers._ContentEncoding = AppendValue(_headers._ContentEncoding, value);
                                 }
                                 else
                                 {
                                     _bits |= 8192L;
-                                    _ContentEncoding = new StringValues(value);
+                                    _headers._ContentEncoding = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4771,12 +4682,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 16384L) != 0))
                                 {
-                                    _ContentLanguage = AppendValue(_ContentLanguage, value);
+                                    _headers._ContentLanguage = AppendValue(_headers._ContentLanguage, value);
                                 }
                                 else
                                 {
                                     _bits |= 16384L;
-                                    _ContentLanguage = new StringValues(value);
+                                    _headers._ContentLanguage = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4785,12 +4696,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 32768L) != 0))
                                 {
-                                    _ContentLocation = AppendValue(_ContentLocation, value);
+                                    _headers._ContentLocation = AppendValue(_headers._ContentLocation, value);
                                 }
                                 else
                                 {
                                     _bits |= 32768L;
-                                    _ContentLocation = new StringValues(value);
+                                    _headers._ContentLocation = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4803,12 +4714,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 65536L) != 0))
                                 {
-                                    _ContentMD5 = AppendValue(_ContentMD5, value);
+                                    _headers._ContentMD5 = AppendValue(_headers._ContentMD5, value);
                                 }
                                 else
                                 {
                                     _bits |= 65536L;
-                                    _ContentMD5 = new StringValues(value);
+                                    _headers._ContentMD5 = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4821,12 +4732,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 4194304L) != 0))
                                 {
-                                    _AcceptEncoding = AppendValue(_AcceptEncoding, value);
+                                    _headers._AcceptEncoding = AppendValue(_headers._AcceptEncoding, value);
                                 }
                                 else
                                 {
                                     _bits |= 4194304L;
-                                    _AcceptEncoding = new StringValues(value);
+                                    _headers._AcceptEncoding = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4835,12 +4746,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 8388608L) != 0))
                                 {
-                                    _AcceptLanguage = AppendValue(_AcceptLanguage, value);
+                                    _headers._AcceptLanguage = AppendValue(_headers._AcceptLanguage, value);
                                 }
                                 else
                                 {
                                     _bits |= 8388608L;
-                                    _AcceptLanguage = new StringValues(value);
+                                    _headers._AcceptLanguage = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4853,12 +4764,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 536870912L) != 0))
                                 {
-                                    _IfMatch = AppendValue(_IfMatch, value);
+                                    _headers._IfMatch = AppendValue(_headers._IfMatch, value);
                                 }
                                 else
                                 {
                                     _bits |= 536870912L;
-                                    _IfMatch = new StringValues(value);
+                                    _headers._IfMatch = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4867,12 +4778,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 4294967296L) != 0))
                                 {
-                                    _IfRange = AppendValue(_IfRange, value);
+                                    _headers._IfRange = AppendValue(_headers._IfRange, value);
                                 }
                                 else
                                 {
                                     _bits |= 4294967296L;
-                                    _IfRange = new StringValues(value);
+                                    _headers._IfRange = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4885,12 +4796,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 8589934592L) != 0))
                                 {
-                                    _IfUnmodifiedSince = AppendValue(_IfUnmodifiedSince, value);
+                                    _headers._IfUnmodifiedSince = AppendValue(_headers._IfUnmodifiedSince, value);
                                 }
                                 else
                                 {
                                     _bits |= 8589934592L;
-                                    _IfUnmodifiedSince = new StringValues(value);
+                                    _headers._IfUnmodifiedSince = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4899,12 +4810,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 34359738368L) != 0))
                                 {
-                                    _ProxyAuthorization = AppendValue(_ProxyAuthorization, value);
+                                    _headers._ProxyAuthorization = AppendValue(_headers._ProxyAuthorization, value);
                                 }
                                 else
                                 {
                                     _bits |= 34359738368L;
-                                    _ProxyAuthorization = new StringValues(value);
+                                    _headers._ProxyAuthorization = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4917,12 +4828,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 274877906944L) != 0))
                                 {
-                                    _TE = AppendValue(_TE, value);
+                                    _headers._TE = AppendValue(_headers._TE, value);
                                 }
                                 else
                                 {
                                     _bits |= 274877906944L;
-                                    _TE = new StringValues(value);
+                                    _headers._TE = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4935,12 +4846,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 549755813888L) != 0))
                                 {
-                                    _Translate = AppendValue(_Translate, value);
+                                    _headers._Translate = AppendValue(_headers._Translate, value);
                                 }
                                 else
                                 {
                                     _bits |= 549755813888L;
-                                    _Translate = new StringValues(value);
+                                    _headers._Translate = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4953,12 +4864,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 4398046511104L) != 0))
                                 {
-                                    _AccessControlRequestMethod = AppendValue(_AccessControlRequestMethod, value);
+                                    _headers._AccessControlRequestMethod = AppendValue(_headers._AccessControlRequestMethod, value);
                                 }
                                 else
                                 {
                                     _bits |= 4398046511104L;
-                                    _AccessControlRequestMethod = new StringValues(value);
+                                    _headers._AccessControlRequestMethod = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4971,12 +4882,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             {
                                 if (((_bits & 8796093022208L) != 0))
                                 {
-                                    _AccessControlRequestHeaders = AppendValue(_AccessControlRequestHeaders, value);
+                                    _headers._AccessControlRequestHeaders = AppendValue(_headers._AccessControlRequestHeaders, value);
                                 }
                                 else
                                 {
                                     _bits |= 8796093022208L;
-                                    _AccessControlRequestHeaders = new StringValues(value);
+                                    _headers._AccessControlRequestHeaders = new StringValues(value);
                                 }
                                 return;
                             }
@@ -4989,6 +4900,55 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             Unknown.TryGetValue(key, out existing);
             Unknown[key] = AppendValue(existing, value);
         }
+        private struct HeaderReferences
+        {
+            public StringValues _CacheControl;
+            public StringValues _Connection;
+            public StringValues _Date;
+            public StringValues _KeepAlive;
+            public StringValues _Pragma;
+            public StringValues _Trailer;
+            public StringValues _TransferEncoding;
+            public StringValues _Upgrade;
+            public StringValues _Via;
+            public StringValues _Warning;
+            public StringValues _Allow;
+            public StringValues _ContentLength;
+            public StringValues _ContentType;
+            public StringValues _ContentEncoding;
+            public StringValues _ContentLanguage;
+            public StringValues _ContentLocation;
+            public StringValues _ContentMD5;
+            public StringValues _ContentRange;
+            public StringValues _Expires;
+            public StringValues _LastModified;
+            public StringValues _Accept;
+            public StringValues _AcceptCharset;
+            public StringValues _AcceptEncoding;
+            public StringValues _AcceptLanguage;
+            public StringValues _Authorization;
+            public StringValues _Cookie;
+            public StringValues _Expect;
+            public StringValues _From;
+            public StringValues _Host;
+            public StringValues _IfMatch;
+            public StringValues _IfModifiedSince;
+            public StringValues _IfNoneMatch;
+            public StringValues _IfRange;
+            public StringValues _IfUnmodifiedSince;
+            public StringValues _MaxForwards;
+            public StringValues _ProxyAuthorization;
+            public StringValues _Referer;
+            public StringValues _Range;
+            public StringValues _TE;
+            public StringValues _Translate;
+            public StringValues _UserAgent;
+            public StringValues _Origin;
+            public StringValues _AccessControlRequestMethod;
+            public StringValues _AccessControlRequestHeaders;
+            
+        }
+
         public partial struct Enumerator
         {
             public bool MoveNext()
@@ -5135,7 +5095,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state0:
                     if (((_bits & 1L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Cache-Control", _collection._CacheControl);
+                        _current = new KeyValuePair<string, StringValues>("Cache-Control", _collection._headers._CacheControl);
                         _state = 1;
                         return true;
                     }
@@ -5143,7 +5103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state1:
                     if (((_bits & 2L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Connection", _collection._Connection);
+                        _current = new KeyValuePair<string, StringValues>("Connection", _collection._headers._Connection);
                         _state = 2;
                         return true;
                     }
@@ -5151,7 +5111,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state2:
                     if (((_bits & 4L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Date", _collection._Date);
+                        _current = new KeyValuePair<string, StringValues>("Date", _collection._headers._Date);
                         _state = 3;
                         return true;
                     }
@@ -5159,7 +5119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state3:
                     if (((_bits & 8L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Keep-Alive", _collection._KeepAlive);
+                        _current = new KeyValuePair<string, StringValues>("Keep-Alive", _collection._headers._KeepAlive);
                         _state = 4;
                         return true;
                     }
@@ -5167,7 +5127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state4:
                     if (((_bits & 16L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Pragma", _collection._Pragma);
+                        _current = new KeyValuePair<string, StringValues>("Pragma", _collection._headers._Pragma);
                         _state = 5;
                         return true;
                     }
@@ -5175,7 +5135,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state5:
                     if (((_bits & 32L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Trailer", _collection._Trailer);
+                        _current = new KeyValuePair<string, StringValues>("Trailer", _collection._headers._Trailer);
                         _state = 6;
                         return true;
                     }
@@ -5183,7 +5143,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state6:
                     if (((_bits & 64L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Transfer-Encoding", _collection._TransferEncoding);
+                        _current = new KeyValuePair<string, StringValues>("Transfer-Encoding", _collection._headers._TransferEncoding);
                         _state = 7;
                         return true;
                     }
@@ -5191,7 +5151,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state7:
                     if (((_bits & 128L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Upgrade", _collection._Upgrade);
+                        _current = new KeyValuePair<string, StringValues>("Upgrade", _collection._headers._Upgrade);
                         _state = 8;
                         return true;
                     }
@@ -5199,7 +5159,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state8:
                     if (((_bits & 256L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Via", _collection._Via);
+                        _current = new KeyValuePair<string, StringValues>("Via", _collection._headers._Via);
                         _state = 9;
                         return true;
                     }
@@ -5207,7 +5167,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state9:
                     if (((_bits & 512L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Warning", _collection._Warning);
+                        _current = new KeyValuePair<string, StringValues>("Warning", _collection._headers._Warning);
                         _state = 10;
                         return true;
                     }
@@ -5215,7 +5175,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state10:
                     if (((_bits & 1024L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Allow", _collection._Allow);
+                        _current = new KeyValuePair<string, StringValues>("Allow", _collection._headers._Allow);
                         _state = 11;
                         return true;
                     }
@@ -5223,7 +5183,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state11:
                     if (((_bits & 2048L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Length", _collection._ContentLength);
+                        _current = new KeyValuePair<string, StringValues>("Content-Length", _collection._headers._ContentLength);
                         _state = 12;
                         return true;
                     }
@@ -5231,7 +5191,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state12:
                     if (((_bits & 4096L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Type", _collection._ContentType);
+                        _current = new KeyValuePair<string, StringValues>("Content-Type", _collection._headers._ContentType);
                         _state = 13;
                         return true;
                     }
@@ -5239,7 +5199,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state13:
                     if (((_bits & 8192L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Encoding", _collection._ContentEncoding);
+                        _current = new KeyValuePair<string, StringValues>("Content-Encoding", _collection._headers._ContentEncoding);
                         _state = 14;
                         return true;
                     }
@@ -5247,7 +5207,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state14:
                     if (((_bits & 16384L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Language", _collection._ContentLanguage);
+                        _current = new KeyValuePair<string, StringValues>("Content-Language", _collection._headers._ContentLanguage);
                         _state = 15;
                         return true;
                     }
@@ -5255,7 +5215,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state15:
                     if (((_bits & 32768L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Location", _collection._ContentLocation);
+                        _current = new KeyValuePair<string, StringValues>("Content-Location", _collection._headers._ContentLocation);
                         _state = 16;
                         return true;
                     }
@@ -5263,7 +5223,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state16:
                     if (((_bits & 65536L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-MD5", _collection._ContentMD5);
+                        _current = new KeyValuePair<string, StringValues>("Content-MD5", _collection._headers._ContentMD5);
                         _state = 17;
                         return true;
                     }
@@ -5271,7 +5231,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state17:
                     if (((_bits & 131072L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Range", _collection._ContentRange);
+                        _current = new KeyValuePair<string, StringValues>("Content-Range", _collection._headers._ContentRange);
                         _state = 18;
                         return true;
                     }
@@ -5279,7 +5239,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state18:
                     if (((_bits & 262144L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Expires", _collection._Expires);
+                        _current = new KeyValuePair<string, StringValues>("Expires", _collection._headers._Expires);
                         _state = 19;
                         return true;
                     }
@@ -5287,7 +5247,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state19:
                     if (((_bits & 524288L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Last-Modified", _collection._LastModified);
+                        _current = new KeyValuePair<string, StringValues>("Last-Modified", _collection._headers._LastModified);
                         _state = 20;
                         return true;
                     }
@@ -5295,7 +5255,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state20:
                     if (((_bits & 1048576L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Accept", _collection._Accept);
+                        _current = new KeyValuePair<string, StringValues>("Accept", _collection._headers._Accept);
                         _state = 21;
                         return true;
                     }
@@ -5303,7 +5263,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state21:
                     if (((_bits & 2097152L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Accept-Charset", _collection._AcceptCharset);
+                        _current = new KeyValuePair<string, StringValues>("Accept-Charset", _collection._headers._AcceptCharset);
                         _state = 22;
                         return true;
                     }
@@ -5311,7 +5271,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state22:
                     if (((_bits & 4194304L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Accept-Encoding", _collection._AcceptEncoding);
+                        _current = new KeyValuePair<string, StringValues>("Accept-Encoding", _collection._headers._AcceptEncoding);
                         _state = 23;
                         return true;
                     }
@@ -5319,7 +5279,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state23:
                     if (((_bits & 8388608L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Accept-Language", _collection._AcceptLanguage);
+                        _current = new KeyValuePair<string, StringValues>("Accept-Language", _collection._headers._AcceptLanguage);
                         _state = 24;
                         return true;
                     }
@@ -5327,7 +5287,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state24:
                     if (((_bits & 16777216L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Authorization", _collection._Authorization);
+                        _current = new KeyValuePair<string, StringValues>("Authorization", _collection._headers._Authorization);
                         _state = 25;
                         return true;
                     }
@@ -5335,7 +5295,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state25:
                     if (((_bits & 33554432L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Cookie", _collection._Cookie);
+                        _current = new KeyValuePair<string, StringValues>("Cookie", _collection._headers._Cookie);
                         _state = 26;
                         return true;
                     }
@@ -5343,7 +5303,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state26:
                     if (((_bits & 67108864L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Expect", _collection._Expect);
+                        _current = new KeyValuePair<string, StringValues>("Expect", _collection._headers._Expect);
                         _state = 27;
                         return true;
                     }
@@ -5351,7 +5311,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state27:
                     if (((_bits & 134217728L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("From", _collection._From);
+                        _current = new KeyValuePair<string, StringValues>("From", _collection._headers._From);
                         _state = 28;
                         return true;
                     }
@@ -5359,7 +5319,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state28:
                     if (((_bits & 268435456L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Host", _collection._Host);
+                        _current = new KeyValuePair<string, StringValues>("Host", _collection._headers._Host);
                         _state = 29;
                         return true;
                     }
@@ -5367,7 +5327,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state29:
                     if (((_bits & 536870912L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("If-Match", _collection._IfMatch);
+                        _current = new KeyValuePair<string, StringValues>("If-Match", _collection._headers._IfMatch);
                         _state = 30;
                         return true;
                     }
@@ -5375,7 +5335,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state30:
                     if (((_bits & 1073741824L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("If-Modified-Since", _collection._IfModifiedSince);
+                        _current = new KeyValuePair<string, StringValues>("If-Modified-Since", _collection._headers._IfModifiedSince);
                         _state = 31;
                         return true;
                     }
@@ -5383,7 +5343,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state31:
                     if (((_bits & 2147483648L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("If-None-Match", _collection._IfNoneMatch);
+                        _current = new KeyValuePair<string, StringValues>("If-None-Match", _collection._headers._IfNoneMatch);
                         _state = 32;
                         return true;
                     }
@@ -5391,7 +5351,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state32:
                     if (((_bits & 4294967296L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("If-Range", _collection._IfRange);
+                        _current = new KeyValuePair<string, StringValues>("If-Range", _collection._headers._IfRange);
                         _state = 33;
                         return true;
                     }
@@ -5399,7 +5359,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state33:
                     if (((_bits & 8589934592L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("If-Unmodified-Since", _collection._IfUnmodifiedSince);
+                        _current = new KeyValuePair<string, StringValues>("If-Unmodified-Since", _collection._headers._IfUnmodifiedSince);
                         _state = 34;
                         return true;
                     }
@@ -5407,7 +5367,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state34:
                     if (((_bits & 17179869184L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Max-Forwards", _collection._MaxForwards);
+                        _current = new KeyValuePair<string, StringValues>("Max-Forwards", _collection._headers._MaxForwards);
                         _state = 35;
                         return true;
                     }
@@ -5415,7 +5375,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state35:
                     if (((_bits & 34359738368L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Proxy-Authorization", _collection._ProxyAuthorization);
+                        _current = new KeyValuePair<string, StringValues>("Proxy-Authorization", _collection._headers._ProxyAuthorization);
                         _state = 36;
                         return true;
                     }
@@ -5423,7 +5383,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state36:
                     if (((_bits & 68719476736L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Referer", _collection._Referer);
+                        _current = new KeyValuePair<string, StringValues>("Referer", _collection._headers._Referer);
                         _state = 37;
                         return true;
                     }
@@ -5431,7 +5391,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state37:
                     if (((_bits & 137438953472L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Range", _collection._Range);
+                        _current = new KeyValuePair<string, StringValues>("Range", _collection._headers._Range);
                         _state = 38;
                         return true;
                     }
@@ -5439,7 +5399,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state38:
                     if (((_bits & 274877906944L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("TE", _collection._TE);
+                        _current = new KeyValuePair<string, StringValues>("TE", _collection._headers._TE);
                         _state = 39;
                         return true;
                     }
@@ -5447,7 +5407,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state39:
                     if (((_bits & 549755813888L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Translate", _collection._Translate);
+                        _current = new KeyValuePair<string, StringValues>("Translate", _collection._headers._Translate);
                         _state = 40;
                         return true;
                     }
@@ -5455,7 +5415,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state40:
                     if (((_bits & 1099511627776L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("User-Agent", _collection._UserAgent);
+                        _current = new KeyValuePair<string, StringValues>("User-Agent", _collection._headers._UserAgent);
                         _state = 41;
                         return true;
                     }
@@ -5463,7 +5423,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state41:
                     if (((_bits & 2199023255552L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Origin", _collection._Origin);
+                        _current = new KeyValuePair<string, StringValues>("Origin", _collection._headers._Origin);
                         _state = 42;
                         return true;
                     }
@@ -5471,7 +5431,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state42:
                     if (((_bits & 4398046511104L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Access-Control-Request-Method", _collection._AccessControlRequestMethod);
+                        _current = new KeyValuePair<string, StringValues>("Access-Control-Request-Method", _collection._headers._AccessControlRequestMethod);
                         _state = 43;
                         return true;
                     }
@@ -5479,7 +5439,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state43:
                     if (((_bits & 8796093022208L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Access-Control-Request-Headers", _collection._AccessControlRequestHeaders);
+                        _current = new KeyValuePair<string, StringValues>("Access-Control-Request-Headers", _collection._headers._AccessControlRequestHeaders);
                         _state = 44;
                         return true;
                     }
@@ -5504,49 +5464,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         };
         
         private long _bits = 0;
-        
-        private StringValues _CacheControl;
-        private StringValues _Connection;
-        private StringValues _Date;
-        private StringValues _KeepAlive;
-        private StringValues _Pragma;
-        private StringValues _Trailer;
-        private StringValues _TransferEncoding;
-        private StringValues _Upgrade;
-        private StringValues _Via;
-        private StringValues _Warning;
-        private StringValues _Allow;
-        private StringValues _ContentLength;
-        private StringValues _ContentType;
-        private StringValues _ContentEncoding;
-        private StringValues _ContentLanguage;
-        private StringValues _ContentLocation;
-        private StringValues _ContentMD5;
-        private StringValues _ContentRange;
-        private StringValues _Expires;
-        private StringValues _LastModified;
-        private StringValues _AcceptRanges;
-        private StringValues _Age;
-        private StringValues _ETag;
-        private StringValues _Location;
-        private StringValues _ProxyAutheticate;
-        private StringValues _RetryAfter;
-        private StringValues _Server;
-        private StringValues _SetCookie;
-        private StringValues _Vary;
-        private StringValues _WWWAuthenticate;
-        private StringValues _AccessControlAllowCredentials;
-        private StringValues _AccessControlAllowHeaders;
-        private StringValues _AccessControlAllowMethods;
-        private StringValues _AccessControlAllowOrigin;
-        private StringValues _AccessControlExposeHeaders;
-        private StringValues _AccessControlMaxAge;
-        
-        private byte[] _rawConnection;
-        private byte[] _rawDate;
-        private byte[] _rawTransferEncoding;
-        private byte[] _rawContentLength;
-        private byte[] _rawServer;
+        private HeaderReferences _headers;
         
         public StringValues HeaderCacheControl
         {
@@ -5554,14 +5472,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 1L) != 0))
                 {
-                    return _CacheControl;
+                    return _headers._CacheControl;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 1L;
-                _CacheControl = value; 
+                _headers._CacheControl = value; 
             }
         }
         public StringValues HeaderConnection
@@ -5570,15 +5488,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 2L) != 0))
                 {
-                    return _Connection;
+                    return _headers._Connection;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 2L;
-                _Connection = value; 
-                _rawConnection = null;
+                _headers._Connection = value; 
+                _headers._rawConnection = null;
             }
         }
         public StringValues HeaderDate
@@ -5587,15 +5505,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 4L) != 0))
                 {
-                    return _Date;
+                    return _headers._Date;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 4L;
-                _Date = value; 
-                _rawDate = null;
+                _headers._Date = value; 
+                _headers._rawDate = null;
             }
         }
         public StringValues HeaderKeepAlive
@@ -5604,14 +5522,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 8L) != 0))
                 {
-                    return _KeepAlive;
+                    return _headers._KeepAlive;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 8L;
-                _KeepAlive = value; 
+                _headers._KeepAlive = value; 
             }
         }
         public StringValues HeaderPragma
@@ -5620,14 +5538,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 16L) != 0))
                 {
-                    return _Pragma;
+                    return _headers._Pragma;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 16L;
-                _Pragma = value; 
+                _headers._Pragma = value; 
             }
         }
         public StringValues HeaderTrailer
@@ -5636,14 +5554,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 32L) != 0))
                 {
-                    return _Trailer;
+                    return _headers._Trailer;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 32L;
-                _Trailer = value; 
+                _headers._Trailer = value; 
             }
         }
         public StringValues HeaderTransferEncoding
@@ -5652,15 +5570,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 64L) != 0))
                 {
-                    return _TransferEncoding;
+                    return _headers._TransferEncoding;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 64L;
-                _TransferEncoding = value; 
-                _rawTransferEncoding = null;
+                _headers._TransferEncoding = value; 
+                _headers._rawTransferEncoding = null;
             }
         }
         public StringValues HeaderUpgrade
@@ -5669,14 +5587,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 128L) != 0))
                 {
-                    return _Upgrade;
+                    return _headers._Upgrade;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 128L;
-                _Upgrade = value; 
+                _headers._Upgrade = value; 
             }
         }
         public StringValues HeaderVia
@@ -5685,14 +5603,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 256L) != 0))
                 {
-                    return _Via;
+                    return _headers._Via;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 256L;
-                _Via = value; 
+                _headers._Via = value; 
             }
         }
         public StringValues HeaderWarning
@@ -5701,14 +5619,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 512L) != 0))
                 {
-                    return _Warning;
+                    return _headers._Warning;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 512L;
-                _Warning = value; 
+                _headers._Warning = value; 
             }
         }
         public StringValues HeaderAllow
@@ -5717,14 +5635,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 1024L) != 0))
                 {
-                    return _Allow;
+                    return _headers._Allow;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 1024L;
-                _Allow = value; 
+                _headers._Allow = value; 
             }
         }
         public StringValues HeaderContentLength
@@ -5733,15 +5651,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 2048L) != 0))
                 {
-                    return _ContentLength;
+                    return _headers._ContentLength;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 2048L;
-                _ContentLength = value; 
-                _rawContentLength = null;
+                _headers._ContentLength = value; 
+                _headers._rawContentLength = null;
             }
         }
         public StringValues HeaderContentType
@@ -5750,14 +5668,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 4096L) != 0))
                 {
-                    return _ContentType;
+                    return _headers._ContentType;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 4096L;
-                _ContentType = value; 
+                _headers._ContentType = value; 
             }
         }
         public StringValues HeaderContentEncoding
@@ -5766,14 +5684,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 8192L) != 0))
                 {
-                    return _ContentEncoding;
+                    return _headers._ContentEncoding;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 8192L;
-                _ContentEncoding = value; 
+                _headers._ContentEncoding = value; 
             }
         }
         public StringValues HeaderContentLanguage
@@ -5782,14 +5700,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 16384L) != 0))
                 {
-                    return _ContentLanguage;
+                    return _headers._ContentLanguage;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 16384L;
-                _ContentLanguage = value; 
+                _headers._ContentLanguage = value; 
             }
         }
         public StringValues HeaderContentLocation
@@ -5798,14 +5716,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 32768L) != 0))
                 {
-                    return _ContentLocation;
+                    return _headers._ContentLocation;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 32768L;
-                _ContentLocation = value; 
+                _headers._ContentLocation = value; 
             }
         }
         public StringValues HeaderContentMD5
@@ -5814,14 +5732,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 65536L) != 0))
                 {
-                    return _ContentMD5;
+                    return _headers._ContentMD5;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 65536L;
-                _ContentMD5 = value; 
+                _headers._ContentMD5 = value; 
             }
         }
         public StringValues HeaderContentRange
@@ -5830,14 +5748,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 131072L) != 0))
                 {
-                    return _ContentRange;
+                    return _headers._ContentRange;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 131072L;
-                _ContentRange = value; 
+                _headers._ContentRange = value; 
             }
         }
         public StringValues HeaderExpires
@@ -5846,14 +5764,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 262144L) != 0))
                 {
-                    return _Expires;
+                    return _headers._Expires;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 262144L;
-                _Expires = value; 
+                _headers._Expires = value; 
             }
         }
         public StringValues HeaderLastModified
@@ -5862,14 +5780,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 524288L) != 0))
                 {
-                    return _LastModified;
+                    return _headers._LastModified;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 524288L;
-                _LastModified = value; 
+                _headers._LastModified = value; 
             }
         }
         public StringValues HeaderAcceptRanges
@@ -5878,14 +5796,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 1048576L) != 0))
                 {
-                    return _AcceptRanges;
+                    return _headers._AcceptRanges;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 1048576L;
-                _AcceptRanges = value; 
+                _headers._AcceptRanges = value; 
             }
         }
         public StringValues HeaderAge
@@ -5894,14 +5812,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 2097152L) != 0))
                 {
-                    return _Age;
+                    return _headers._Age;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 2097152L;
-                _Age = value; 
+                _headers._Age = value; 
             }
         }
         public StringValues HeaderETag
@@ -5910,14 +5828,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 4194304L) != 0))
                 {
-                    return _ETag;
+                    return _headers._ETag;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 4194304L;
-                _ETag = value; 
+                _headers._ETag = value; 
             }
         }
         public StringValues HeaderLocation
@@ -5926,14 +5844,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 8388608L) != 0))
                 {
-                    return _Location;
+                    return _headers._Location;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 8388608L;
-                _Location = value; 
+                _headers._Location = value; 
             }
         }
         public StringValues HeaderProxyAutheticate
@@ -5942,14 +5860,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 16777216L) != 0))
                 {
-                    return _ProxyAutheticate;
+                    return _headers._ProxyAutheticate;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 16777216L;
-                _ProxyAutheticate = value; 
+                _headers._ProxyAutheticate = value; 
             }
         }
         public StringValues HeaderRetryAfter
@@ -5958,14 +5876,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 33554432L) != 0))
                 {
-                    return _RetryAfter;
+                    return _headers._RetryAfter;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 33554432L;
-                _RetryAfter = value; 
+                _headers._RetryAfter = value; 
             }
         }
         public StringValues HeaderServer
@@ -5974,15 +5892,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 67108864L) != 0))
                 {
-                    return _Server;
+                    return _headers._Server;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 67108864L;
-                _Server = value; 
-                _rawServer = null;
+                _headers._Server = value; 
+                _headers._rawServer = null;
             }
         }
         public StringValues HeaderSetCookie
@@ -5991,14 +5909,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 134217728L) != 0))
                 {
-                    return _SetCookie;
+                    return _headers._SetCookie;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 134217728L;
-                _SetCookie = value; 
+                _headers._SetCookie = value; 
             }
         }
         public StringValues HeaderVary
@@ -6007,14 +5925,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 268435456L) != 0))
                 {
-                    return _Vary;
+                    return _headers._Vary;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 268435456L;
-                _Vary = value; 
+                _headers._Vary = value; 
             }
         }
         public StringValues HeaderWWWAuthenticate
@@ -6023,14 +5941,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 536870912L) != 0))
                 {
-                    return _WWWAuthenticate;
+                    return _headers._WWWAuthenticate;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 536870912L;
-                _WWWAuthenticate = value; 
+                _headers._WWWAuthenticate = value; 
             }
         }
         public StringValues HeaderAccessControlAllowCredentials
@@ -6039,14 +5957,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 1073741824L) != 0))
                 {
-                    return _AccessControlAllowCredentials;
+                    return _headers._AccessControlAllowCredentials;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 1073741824L;
-                _AccessControlAllowCredentials = value; 
+                _headers._AccessControlAllowCredentials = value; 
             }
         }
         public StringValues HeaderAccessControlAllowHeaders
@@ -6055,14 +5973,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 2147483648L) != 0))
                 {
-                    return _AccessControlAllowHeaders;
+                    return _headers._AccessControlAllowHeaders;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 2147483648L;
-                _AccessControlAllowHeaders = value; 
+                _headers._AccessControlAllowHeaders = value; 
             }
         }
         public StringValues HeaderAccessControlAllowMethods
@@ -6071,14 +5989,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 4294967296L) != 0))
                 {
-                    return _AccessControlAllowMethods;
+                    return _headers._AccessControlAllowMethods;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 4294967296L;
-                _AccessControlAllowMethods = value; 
+                _headers._AccessControlAllowMethods = value; 
             }
         }
         public StringValues HeaderAccessControlAllowOrigin
@@ -6087,14 +6005,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 8589934592L) != 0))
                 {
-                    return _AccessControlAllowOrigin;
+                    return _headers._AccessControlAllowOrigin;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 8589934592L;
-                _AccessControlAllowOrigin = value; 
+                _headers._AccessControlAllowOrigin = value; 
             }
         }
         public StringValues HeaderAccessControlExposeHeaders
@@ -6103,14 +6021,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 17179869184L) != 0))
                 {
-                    return _AccessControlExposeHeaders;
+                    return _headers._AccessControlExposeHeaders;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 17179869184L;
-                _AccessControlExposeHeaders = value; 
+                _headers._AccessControlExposeHeaders = value; 
             }
         }
         public StringValues HeaderAccessControlMaxAge
@@ -6119,46 +6037,46 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 if (((_bits & 34359738368L) != 0))
                 {
-                    return _AccessControlMaxAge;
+                    return _headers._AccessControlMaxAge;
                 }
                 return StringValues.Empty;
             }
             set
             {
                 _bits |= 34359738368L;
-                _AccessControlMaxAge = value; 
+                _headers._AccessControlMaxAge = value; 
             }
         }
         
         public void SetRawConnection(StringValues value, byte[] raw)
         {
             _bits |= 2L;
-            _Connection = value; 
-            _rawConnection = raw;
+            _headers._Connection = value; 
+            _headers._rawConnection = raw;
         }
         public void SetRawDate(StringValues value, byte[] raw)
         {
             _bits |= 4L;
-            _Date = value; 
-            _rawDate = raw;
+            _headers._Date = value; 
+            _headers._rawDate = raw;
         }
         public void SetRawTransferEncoding(StringValues value, byte[] raw)
         {
             _bits |= 64L;
-            _TransferEncoding = value; 
-            _rawTransferEncoding = raw;
+            _headers._TransferEncoding = value; 
+            _headers._rawTransferEncoding = raw;
         }
         public void SetRawContentLength(StringValues value, byte[] raw)
         {
             _bits |= 2048L;
-            _ContentLength = value; 
-            _rawContentLength = raw;
+            _headers._ContentLength = value; 
+            _headers._rawContentLength = raw;
         }
         public void SetRawServer(StringValues value, byte[] raw)
         {
             _bits |= 67108864L;
-            _Server = value; 
-            _rawServer = raw;
+            _headers._Server = value; 
+            _headers._rawServer = raw;
         }
         protected override int GetCountFast()
         {
@@ -6174,7 +6092,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1L) != 0))
                             {
-                                return _CacheControl;
+                                return _headers._CacheControl;
                             }
                             else
                             {
@@ -6186,7 +6104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 131072L) != 0))
                             {
-                                return _ContentRange;
+                                return _headers._ContentRange;
                             }
                             else
                             {
@@ -6198,7 +6116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 524288L) != 0))
                             {
-                                return _LastModified;
+                                return _headers._LastModified;
                             }
                             else
                             {
@@ -6210,7 +6128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1048576L) != 0))
                             {
-                                return _AcceptRanges;
+                                return _headers._AcceptRanges;
                             }
                             else
                             {
@@ -6226,7 +6144,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2L) != 0))
                             {
-                                return _Connection;
+                                return _headers._Connection;
                             }
                             else
                             {
@@ -6238,7 +6156,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8L) != 0))
                             {
-                                return _KeepAlive;
+                                return _headers._KeepAlive;
                             }
                             else
                             {
@@ -6250,7 +6168,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 134217728L) != 0))
                             {
-                                return _SetCookie;
+                                return _headers._SetCookie;
                             }
                             else
                             {
@@ -6266,7 +6184,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4L) != 0))
                             {
-                                return _Date;
+                                return _headers._Date;
                             }
                             else
                             {
@@ -6278,7 +6196,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4194304L) != 0))
                             {
-                                return _ETag;
+                                return _headers._ETag;
                             }
                             else
                             {
@@ -6290,7 +6208,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 268435456L) != 0))
                             {
-                                return _Vary;
+                                return _headers._Vary;
                             }
                             else
                             {
@@ -6306,7 +6224,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16L) != 0))
                             {
-                                return _Pragma;
+                                return _headers._Pragma;
                             }
                             else
                             {
@@ -6318,7 +6236,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 67108864L) != 0))
                             {
-                                return _Server;
+                                return _headers._Server;
                             }
                             else
                             {
@@ -6334,7 +6252,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32L) != 0))
                             {
-                                return _Trailer;
+                                return _headers._Trailer;
                             }
                             else
                             {
@@ -6346,7 +6264,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 128L) != 0))
                             {
-                                return _Upgrade;
+                                return _headers._Upgrade;
                             }
                             else
                             {
@@ -6358,7 +6276,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 512L) != 0))
                             {
-                                return _Warning;
+                                return _headers._Warning;
                             }
                             else
                             {
@@ -6370,7 +6288,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 262144L) != 0))
                             {
-                                return _Expires;
+                                return _headers._Expires;
                             }
                             else
                             {
@@ -6386,7 +6304,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 64L) != 0))
                             {
-                                return _TransferEncoding;
+                                return _headers._TransferEncoding;
                             }
                             else
                             {
@@ -6398,7 +6316,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16777216L) != 0))
                             {
-                                return _ProxyAutheticate;
+                                return _headers._ProxyAutheticate;
                             }
                             else
                             {
@@ -6414,7 +6332,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 256L) != 0))
                             {
-                                return _Via;
+                                return _headers._Via;
                             }
                             else
                             {
@@ -6426,7 +6344,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2097152L) != 0))
                             {
-                                return _Age;
+                                return _headers._Age;
                             }
                             else
                             {
@@ -6442,7 +6360,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1024L) != 0))
                             {
-                                return _Allow;
+                                return _headers._Allow;
                             }
                             else
                             {
@@ -6458,7 +6376,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2048L) != 0))
                             {
-                                return _ContentLength;
+                                return _headers._ContentLength;
                             }
                             else
                             {
@@ -6474,7 +6392,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4096L) != 0))
                             {
-                                return _ContentType;
+                                return _headers._ContentType;
                             }
                             else
                             {
@@ -6490,7 +6408,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8192L) != 0))
                             {
-                                return _ContentEncoding;
+                                return _headers._ContentEncoding;
                             }
                             else
                             {
@@ -6502,7 +6420,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16384L) != 0))
                             {
-                                return _ContentLanguage;
+                                return _headers._ContentLanguage;
                             }
                             else
                             {
@@ -6514,7 +6432,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32768L) != 0))
                             {
-                                return _ContentLocation;
+                                return _headers._ContentLocation;
                             }
                             else
                             {
@@ -6526,7 +6444,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 536870912L) != 0))
                             {
-                                return _WWWAuthenticate;
+                                return _headers._WWWAuthenticate;
                             }
                             else
                             {
@@ -6542,7 +6460,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 65536L) != 0))
                             {
-                                return _ContentMD5;
+                                return _headers._ContentMD5;
                             }
                             else
                             {
@@ -6554,7 +6472,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 33554432L) != 0))
                             {
-                                return _RetryAfter;
+                                return _headers._RetryAfter;
                             }
                             else
                             {
@@ -6570,7 +6488,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8388608L) != 0))
                             {
-                                return _Location;
+                                return _headers._Location;
                             }
                             else
                             {
@@ -6586,7 +6504,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1073741824L) != 0))
                             {
-                                return _AccessControlAllowCredentials;
+                                return _headers._AccessControlAllowCredentials;
                             }
                             else
                             {
@@ -6602,7 +6520,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2147483648L) != 0))
                             {
-                                return _AccessControlAllowHeaders;
+                                return _headers._AccessControlAllowHeaders;
                             }
                             else
                             {
@@ -6614,7 +6532,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4294967296L) != 0))
                             {
-                                return _AccessControlAllowMethods;
+                                return _headers._AccessControlAllowMethods;
                             }
                             else
                             {
@@ -6630,7 +6548,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8589934592L) != 0))
                             {
-                                return _AccessControlAllowOrigin;
+                                return _headers._AccessControlAllowOrigin;
                             }
                             else
                             {
@@ -6646,7 +6564,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 17179869184L) != 0))
                             {
-                                return _AccessControlExposeHeaders;
+                                return _headers._AccessControlExposeHeaders;
                             }
                             else
                             {
@@ -6662,7 +6580,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 34359738368L) != 0))
                             {
-                                return _AccessControlMaxAge;
+                                return _headers._AccessControlMaxAge;
                             }
                             else
                             {
@@ -6688,7 +6606,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1L) != 0))
                             {
-                                value = _CacheControl;
+                                value = _headers._CacheControl;
                                 return true;
                             }
                             else
@@ -6702,7 +6620,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 131072L) != 0))
                             {
-                                value = _ContentRange;
+                                value = _headers._ContentRange;
                                 return true;
                             }
                             else
@@ -6716,7 +6634,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 524288L) != 0))
                             {
-                                value = _LastModified;
+                                value = _headers._LastModified;
                                 return true;
                             }
                             else
@@ -6730,7 +6648,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1048576L) != 0))
                             {
-                                value = _AcceptRanges;
+                                value = _headers._AcceptRanges;
                                 return true;
                             }
                             else
@@ -6748,7 +6666,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2L) != 0))
                             {
-                                value = _Connection;
+                                value = _headers._Connection;
                                 return true;
                             }
                             else
@@ -6762,7 +6680,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8L) != 0))
                             {
-                                value = _KeepAlive;
+                                value = _headers._KeepAlive;
                                 return true;
                             }
                             else
@@ -6776,7 +6694,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 134217728L) != 0))
                             {
-                                value = _SetCookie;
+                                value = _headers._SetCookie;
                                 return true;
                             }
                             else
@@ -6794,7 +6712,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4L) != 0))
                             {
-                                value = _Date;
+                                value = _headers._Date;
                                 return true;
                             }
                             else
@@ -6808,7 +6726,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4194304L) != 0))
                             {
-                                value = _ETag;
+                                value = _headers._ETag;
                                 return true;
                             }
                             else
@@ -6822,7 +6740,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 268435456L) != 0))
                             {
-                                value = _Vary;
+                                value = _headers._Vary;
                                 return true;
                             }
                             else
@@ -6840,7 +6758,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16L) != 0))
                             {
-                                value = _Pragma;
+                                value = _headers._Pragma;
                                 return true;
                             }
                             else
@@ -6854,7 +6772,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 67108864L) != 0))
                             {
-                                value = _Server;
+                                value = _headers._Server;
                                 return true;
                             }
                             else
@@ -6872,7 +6790,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32L) != 0))
                             {
-                                value = _Trailer;
+                                value = _headers._Trailer;
                                 return true;
                             }
                             else
@@ -6886,7 +6804,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 128L) != 0))
                             {
-                                value = _Upgrade;
+                                value = _headers._Upgrade;
                                 return true;
                             }
                             else
@@ -6900,7 +6818,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 512L) != 0))
                             {
-                                value = _Warning;
+                                value = _headers._Warning;
                                 return true;
                             }
                             else
@@ -6914,7 +6832,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 262144L) != 0))
                             {
-                                value = _Expires;
+                                value = _headers._Expires;
                                 return true;
                             }
                             else
@@ -6932,7 +6850,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 64L) != 0))
                             {
-                                value = _TransferEncoding;
+                                value = _headers._TransferEncoding;
                                 return true;
                             }
                             else
@@ -6946,7 +6864,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16777216L) != 0))
                             {
-                                value = _ProxyAutheticate;
+                                value = _headers._ProxyAutheticate;
                                 return true;
                             }
                             else
@@ -6964,7 +6882,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 256L) != 0))
                             {
-                                value = _Via;
+                                value = _headers._Via;
                                 return true;
                             }
                             else
@@ -6978,7 +6896,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2097152L) != 0))
                             {
-                                value = _Age;
+                                value = _headers._Age;
                                 return true;
                             }
                             else
@@ -6996,7 +6914,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1024L) != 0))
                             {
-                                value = _Allow;
+                                value = _headers._Allow;
                                 return true;
                             }
                             else
@@ -7014,7 +6932,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2048L) != 0))
                             {
-                                value = _ContentLength;
+                                value = _headers._ContentLength;
                                 return true;
                             }
                             else
@@ -7032,7 +6950,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4096L) != 0))
                             {
-                                value = _ContentType;
+                                value = _headers._ContentType;
                                 return true;
                             }
                             else
@@ -7050,7 +6968,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8192L) != 0))
                             {
-                                value = _ContentEncoding;
+                                value = _headers._ContentEncoding;
                                 return true;
                             }
                             else
@@ -7064,7 +6982,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 16384L) != 0))
                             {
-                                value = _ContentLanguage;
+                                value = _headers._ContentLanguage;
                                 return true;
                             }
                             else
@@ -7078,7 +6996,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 32768L) != 0))
                             {
-                                value = _ContentLocation;
+                                value = _headers._ContentLocation;
                                 return true;
                             }
                             else
@@ -7092,7 +7010,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 536870912L) != 0))
                             {
-                                value = _WWWAuthenticate;
+                                value = _headers._WWWAuthenticate;
                                 return true;
                             }
                             else
@@ -7110,7 +7028,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 65536L) != 0))
                             {
-                                value = _ContentMD5;
+                                value = _headers._ContentMD5;
                                 return true;
                             }
                             else
@@ -7124,7 +7042,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 33554432L) != 0))
                             {
-                                value = _RetryAfter;
+                                value = _headers._RetryAfter;
                                 return true;
                             }
                             else
@@ -7142,7 +7060,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8388608L) != 0))
                             {
-                                value = _Location;
+                                value = _headers._Location;
                                 return true;
                             }
                             else
@@ -7160,7 +7078,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 1073741824L) != 0))
                             {
-                                value = _AccessControlAllowCredentials;
+                                value = _headers._AccessControlAllowCredentials;
                                 return true;
                             }
                             else
@@ -7178,7 +7096,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 2147483648L) != 0))
                             {
-                                value = _AccessControlAllowHeaders;
+                                value = _headers._AccessControlAllowHeaders;
                                 return true;
                             }
                             else
@@ -7192,7 +7110,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 4294967296L) != 0))
                             {
-                                value = _AccessControlAllowMethods;
+                                value = _headers._AccessControlAllowMethods;
                                 return true;
                             }
                             else
@@ -7210,7 +7128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 8589934592L) != 0))
                             {
-                                value = _AccessControlAllowOrigin;
+                                value = _headers._AccessControlAllowOrigin;
                                 return true;
                             }
                             else
@@ -7228,7 +7146,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 17179869184L) != 0))
                             {
-                                value = _AccessControlExposeHeaders;
+                                value = _headers._AccessControlExposeHeaders;
                                 return true;
                             }
                             else
@@ -7246,7 +7164,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (((_bits & 34359738368L) != 0))
                             {
-                                value = _AccessControlMaxAge;
+                                value = _headers._AccessControlMaxAge;
                                 return true;
                             }
                             else
@@ -7270,28 +7188,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Cache-Control".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 1L;
-                            _CacheControl = value;
+                            _headers._CacheControl = value;
                             return;
                         }
                     
                         if ("Content-Range".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 131072L;
-                            _ContentRange = value;
+                            _headers._ContentRange = value;
                             return;
                         }
                     
                         if ("Last-Modified".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 524288L;
-                            _LastModified = value;
+                            _headers._LastModified = value;
                             return;
                         }
                     
                         if ("Accept-Ranges".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 1048576L;
-                            _AcceptRanges = value;
+                            _headers._AcceptRanges = value;
                             return;
                         }
                     }
@@ -7302,22 +7220,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Connection".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 2L;
-                            _Connection = value;
-                            _rawConnection = null;
+                            _headers._Connection = value;
+                            _headers._rawConnection = null;
                             return;
                         }
                     
                         if ("Keep-Alive".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 8L;
-                            _KeepAlive = value;
+                            _headers._KeepAlive = value;
                             return;
                         }
                     
                         if ("Set-Cookie".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 134217728L;
-                            _SetCookie = value;
+                            _headers._SetCookie = value;
                             return;
                         }
                     }
@@ -7328,22 +7246,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Date".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 4L;
-                            _Date = value;
-                            _rawDate = null;
+                            _headers._Date = value;
+                            _headers._rawDate = null;
                             return;
                         }
                     
                         if ("ETag".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 4194304L;
-                            _ETag = value;
+                            _headers._ETag = value;
                             return;
                         }
                     
                         if ("Vary".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 268435456L;
-                            _Vary = value;
+                            _headers._Vary = value;
                             return;
                         }
                     }
@@ -7354,15 +7272,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Pragma".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 16L;
-                            _Pragma = value;
+                            _headers._Pragma = value;
                             return;
                         }
                     
                         if ("Server".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 67108864L;
-                            _Server = value;
-                            _rawServer = null;
+                            _headers._Server = value;
+                            _headers._rawServer = null;
                             return;
                         }
                     }
@@ -7373,28 +7291,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Trailer".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 32L;
-                            _Trailer = value;
+                            _headers._Trailer = value;
                             return;
                         }
                     
                         if ("Upgrade".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 128L;
-                            _Upgrade = value;
+                            _headers._Upgrade = value;
                             return;
                         }
                     
                         if ("Warning".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 512L;
-                            _Warning = value;
+                            _headers._Warning = value;
                             return;
                         }
                     
                         if ("Expires".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 262144L;
-                            _Expires = value;
+                            _headers._Expires = value;
                             return;
                         }
                     }
@@ -7405,15 +7323,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Transfer-Encoding".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 64L;
-                            _TransferEncoding = value;
-                            _rawTransferEncoding = null;
+                            _headers._TransferEncoding = value;
+                            _headers._rawTransferEncoding = null;
                             return;
                         }
                     
                         if ("Proxy-Autheticate".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 16777216L;
-                            _ProxyAutheticate = value;
+                            _headers._ProxyAutheticate = value;
                             return;
                         }
                     }
@@ -7424,14 +7342,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Via".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 256L;
-                            _Via = value;
+                            _headers._Via = value;
                             return;
                         }
                     
                         if ("Age".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 2097152L;
-                            _Age = value;
+                            _headers._Age = value;
                             return;
                         }
                     }
@@ -7442,7 +7360,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Allow".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 1024L;
-                            _Allow = value;
+                            _headers._Allow = value;
                             return;
                         }
                     }
@@ -7453,8 +7371,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Content-Length".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 2048L;
-                            _ContentLength = value;
-                            _rawContentLength = null;
+                            _headers._ContentLength = value;
+                            _headers._rawContentLength = null;
                             return;
                         }
                     }
@@ -7465,7 +7383,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Content-Type".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 4096L;
-                            _ContentType = value;
+                            _headers._ContentType = value;
                             return;
                         }
                     }
@@ -7476,28 +7394,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Content-Encoding".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 8192L;
-                            _ContentEncoding = value;
+                            _headers._ContentEncoding = value;
                             return;
                         }
                     
                         if ("Content-Language".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 16384L;
-                            _ContentLanguage = value;
+                            _headers._ContentLanguage = value;
                             return;
                         }
                     
                         if ("Content-Location".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 32768L;
-                            _ContentLocation = value;
+                            _headers._ContentLocation = value;
                             return;
                         }
                     
                         if ("WWW-Authenticate".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 536870912L;
-                            _WWWAuthenticate = value;
+                            _headers._WWWAuthenticate = value;
                             return;
                         }
                     }
@@ -7508,14 +7426,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Content-MD5".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 65536L;
-                            _ContentMD5 = value;
+                            _headers._ContentMD5 = value;
                             return;
                         }
                     
                         if ("Retry-After".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 33554432L;
-                            _RetryAfter = value;
+                            _headers._RetryAfter = value;
                             return;
                         }
                     }
@@ -7526,7 +7444,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Location".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 8388608L;
-                            _Location = value;
+                            _headers._Location = value;
                             return;
                         }
                     }
@@ -7537,7 +7455,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Access-Control-Allow-Credentials".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 1073741824L;
-                            _AccessControlAllowCredentials = value;
+                            _headers._AccessControlAllowCredentials = value;
                             return;
                         }
                     }
@@ -7548,14 +7466,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Access-Control-Allow-Headers".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 2147483648L;
-                            _AccessControlAllowHeaders = value;
+                            _headers._AccessControlAllowHeaders = value;
                             return;
                         }
                     
                         if ("Access-Control-Allow-Methods".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 4294967296L;
-                            _AccessControlAllowMethods = value;
+                            _headers._AccessControlAllowMethods = value;
                             return;
                         }
                     }
@@ -7566,7 +7484,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Access-Control-Allow-Origin".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 8589934592L;
-                            _AccessControlAllowOrigin = value;
+                            _headers._AccessControlAllowOrigin = value;
                             return;
                         }
                     }
@@ -7577,7 +7495,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Access-Control-Expose-Headers".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 17179869184L;
-                            _AccessControlExposeHeaders = value;
+                            _headers._AccessControlExposeHeaders = value;
                             return;
                         }
                     }
@@ -7588,7 +7506,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         if ("Access-Control-Max-Age".Equals(key, StringComparison.OrdinalIgnoreCase)) 
                         {
                             _bits |= 34359738368L;
-                            _AccessControlMaxAge = value;
+                            _headers._AccessControlMaxAge = value;
                             return;
                         }
                     }
@@ -7609,7 +7527,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 1L;
-                            _CacheControl = value;
+                            _headers._CacheControl = value;
                             return;
                         }
                     
@@ -7620,7 +7538,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 131072L;
-                            _ContentRange = value;
+                            _headers._ContentRange = value;
                             return;
                         }
                     
@@ -7631,7 +7549,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 524288L;
-                            _LastModified = value;
+                            _headers._LastModified = value;
                             return;
                         }
                     
@@ -7642,7 +7560,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 1048576L;
-                            _AcceptRanges = value;
+                            _headers._AcceptRanges = value;
                             return;
                         }
                     }
@@ -7657,8 +7575,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 2L;
-                            _Connection = value;
-                            _rawConnection = null;
+                            _headers._Connection = value;
+                            _headers._rawConnection = null;
                             return;
                         }
                     
@@ -7669,7 +7587,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 8L;
-                            _KeepAlive = value;
+                            _headers._KeepAlive = value;
                             return;
                         }
                     
@@ -7680,7 +7598,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 134217728L;
-                            _SetCookie = value;
+                            _headers._SetCookie = value;
                             return;
                         }
                     }
@@ -7695,8 +7613,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 4L;
-                            _Date = value;
-                            _rawDate = null;
+                            _headers._Date = value;
+                            _headers._rawDate = null;
                             return;
                         }
                     
@@ -7707,7 +7625,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 4194304L;
-                            _ETag = value;
+                            _headers._ETag = value;
                             return;
                         }
                     
@@ -7718,7 +7636,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 268435456L;
-                            _Vary = value;
+                            _headers._Vary = value;
                             return;
                         }
                     }
@@ -7733,7 +7651,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 16L;
-                            _Pragma = value;
+                            _headers._Pragma = value;
                             return;
                         }
                     
@@ -7744,8 +7662,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 67108864L;
-                            _Server = value;
-                            _rawServer = null;
+                            _headers._Server = value;
+                            _headers._rawServer = null;
                             return;
                         }
                     }
@@ -7760,7 +7678,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 32L;
-                            _Trailer = value;
+                            _headers._Trailer = value;
                             return;
                         }
                     
@@ -7771,7 +7689,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 128L;
-                            _Upgrade = value;
+                            _headers._Upgrade = value;
                             return;
                         }
                     
@@ -7782,7 +7700,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 512L;
-                            _Warning = value;
+                            _headers._Warning = value;
                             return;
                         }
                     
@@ -7793,7 +7711,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 262144L;
-                            _Expires = value;
+                            _headers._Expires = value;
                             return;
                         }
                     }
@@ -7808,8 +7726,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 64L;
-                            _TransferEncoding = value;
-                            _rawTransferEncoding = null;
+                            _headers._TransferEncoding = value;
+                            _headers._rawTransferEncoding = null;
                             return;
                         }
                     
@@ -7820,7 +7738,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 16777216L;
-                            _ProxyAutheticate = value;
+                            _headers._ProxyAutheticate = value;
                             return;
                         }
                     }
@@ -7835,7 +7753,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 256L;
-                            _Via = value;
+                            _headers._Via = value;
                             return;
                         }
                     
@@ -7846,7 +7764,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 2097152L;
-                            _Age = value;
+                            _headers._Age = value;
                             return;
                         }
                     }
@@ -7861,7 +7779,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 1024L;
-                            _Allow = value;
+                            _headers._Allow = value;
                             return;
                         }
                     }
@@ -7876,8 +7794,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 2048L;
-                            _ContentLength = value;
-                            _rawContentLength = null;
+                            _headers._ContentLength = value;
+                            _headers._rawContentLength = null;
                             return;
                         }
                     }
@@ -7892,7 +7810,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 4096L;
-                            _ContentType = value;
+                            _headers._ContentType = value;
                             return;
                         }
                     }
@@ -7907,7 +7825,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 8192L;
-                            _ContentEncoding = value;
+                            _headers._ContentEncoding = value;
                             return;
                         }
                     
@@ -7918,7 +7836,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 16384L;
-                            _ContentLanguage = value;
+                            _headers._ContentLanguage = value;
                             return;
                         }
                     
@@ -7929,7 +7847,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 32768L;
-                            _ContentLocation = value;
+                            _headers._ContentLocation = value;
                             return;
                         }
                     
@@ -7940,7 +7858,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 536870912L;
-                            _WWWAuthenticate = value;
+                            _headers._WWWAuthenticate = value;
                             return;
                         }
                     }
@@ -7955,7 +7873,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 65536L;
-                            _ContentMD5 = value;
+                            _headers._ContentMD5 = value;
                             return;
                         }
                     
@@ -7966,7 +7884,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 33554432L;
-                            _RetryAfter = value;
+                            _headers._RetryAfter = value;
                             return;
                         }
                     }
@@ -7981,7 +7899,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 8388608L;
-                            _Location = value;
+                            _headers._Location = value;
                             return;
                         }
                     }
@@ -7996,7 +7914,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 1073741824L;
-                            _AccessControlAllowCredentials = value;
+                            _headers._AccessControlAllowCredentials = value;
                             return;
                         }
                     }
@@ -8011,7 +7929,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 2147483648L;
-                            _AccessControlAllowHeaders = value;
+                            _headers._AccessControlAllowHeaders = value;
                             return;
                         }
                     
@@ -8022,7 +7940,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 4294967296L;
-                            _AccessControlAllowMethods = value;
+                            _headers._AccessControlAllowMethods = value;
                             return;
                         }
                     }
@@ -8037,7 +7955,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 8589934592L;
-                            _AccessControlAllowOrigin = value;
+                            _headers._AccessControlAllowOrigin = value;
                             return;
                         }
                     }
@@ -8052,7 +7970,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 17179869184L;
-                            _AccessControlExposeHeaders = value;
+                            _headers._AccessControlExposeHeaders = value;
                             return;
                         }
                     }
@@ -8067,7 +7985,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                                 ThrowDuplicateKeyException();
                             }
                             _bits |= 34359738368L;
-                            _AccessControlMaxAge = value;
+                            _headers._AccessControlMaxAge = value;
                             return;
                         }
                     }
@@ -8086,7 +8004,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 1L) != 0))
                             {
                                 _bits &= ~1L;
-                                _CacheControl = StringValues.Empty;
+                                _headers._CacheControl = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8100,7 +8018,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 131072L) != 0))
                             {
                                 _bits &= ~131072L;
-                                _ContentRange = StringValues.Empty;
+                                _headers._ContentRange = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8114,7 +8032,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 524288L) != 0))
                             {
                                 _bits &= ~524288L;
-                                _LastModified = StringValues.Empty;
+                                _headers._LastModified = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8128,7 +8046,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 1048576L) != 0))
                             {
                                 _bits &= ~1048576L;
-                                _AcceptRanges = StringValues.Empty;
+                                _headers._AcceptRanges = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8146,8 +8064,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 2L) != 0))
                             {
                                 _bits &= ~2L;
-                                _Connection = StringValues.Empty;
-                                _rawConnection = null;
+                                _headers._Connection = StringValues.Empty;
+                                _headers._rawConnection = null;
                                 return true;
                             }
                             else
@@ -8161,7 +8079,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 8L) != 0))
                             {
                                 _bits &= ~8L;
-                                _KeepAlive = StringValues.Empty;
+                                _headers._KeepAlive = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8175,7 +8093,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 134217728L) != 0))
                             {
                                 _bits &= ~134217728L;
-                                _SetCookie = StringValues.Empty;
+                                _headers._SetCookie = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8193,8 +8111,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 4L) != 0))
                             {
                                 _bits &= ~4L;
-                                _Date = StringValues.Empty;
-                                _rawDate = null;
+                                _headers._Date = StringValues.Empty;
+                                _headers._rawDate = null;
                                 return true;
                             }
                             else
@@ -8208,7 +8126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 4194304L) != 0))
                             {
                                 _bits &= ~4194304L;
-                                _ETag = StringValues.Empty;
+                                _headers._ETag = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8222,7 +8140,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 268435456L) != 0))
                             {
                                 _bits &= ~268435456L;
-                                _Vary = StringValues.Empty;
+                                _headers._Vary = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8240,7 +8158,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 16L) != 0))
                             {
                                 _bits &= ~16L;
-                                _Pragma = StringValues.Empty;
+                                _headers._Pragma = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8254,8 +8172,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 67108864L) != 0))
                             {
                                 _bits &= ~67108864L;
-                                _Server = StringValues.Empty;
-                                _rawServer = null;
+                                _headers._Server = StringValues.Empty;
+                                _headers._rawServer = null;
                                 return true;
                             }
                             else
@@ -8273,7 +8191,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 32L) != 0))
                             {
                                 _bits &= ~32L;
-                                _Trailer = StringValues.Empty;
+                                _headers._Trailer = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8287,7 +8205,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 128L) != 0))
                             {
                                 _bits &= ~128L;
-                                _Upgrade = StringValues.Empty;
+                                _headers._Upgrade = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8301,7 +8219,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 512L) != 0))
                             {
                                 _bits &= ~512L;
-                                _Warning = StringValues.Empty;
+                                _headers._Warning = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8315,7 +8233,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 262144L) != 0))
                             {
                                 _bits &= ~262144L;
-                                _Expires = StringValues.Empty;
+                                _headers._Expires = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8333,8 +8251,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 64L) != 0))
                             {
                                 _bits &= ~64L;
-                                _TransferEncoding = StringValues.Empty;
-                                _rawTransferEncoding = null;
+                                _headers._TransferEncoding = StringValues.Empty;
+                                _headers._rawTransferEncoding = null;
                                 return true;
                             }
                             else
@@ -8348,7 +8266,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 16777216L) != 0))
                             {
                                 _bits &= ~16777216L;
-                                _ProxyAutheticate = StringValues.Empty;
+                                _headers._ProxyAutheticate = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8366,7 +8284,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 256L) != 0))
                             {
                                 _bits &= ~256L;
-                                _Via = StringValues.Empty;
+                                _headers._Via = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8380,7 +8298,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 2097152L) != 0))
                             {
                                 _bits &= ~2097152L;
-                                _Age = StringValues.Empty;
+                                _headers._Age = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8398,7 +8316,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 1024L) != 0))
                             {
                                 _bits &= ~1024L;
-                                _Allow = StringValues.Empty;
+                                _headers._Allow = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8416,8 +8334,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 2048L) != 0))
                             {
                                 _bits &= ~2048L;
-                                _ContentLength = StringValues.Empty;
-                                _rawContentLength = null;
+                                _headers._ContentLength = StringValues.Empty;
+                                _headers._rawContentLength = null;
                                 return true;
                             }
                             else
@@ -8435,7 +8353,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 4096L) != 0))
                             {
                                 _bits &= ~4096L;
-                                _ContentType = StringValues.Empty;
+                                _headers._ContentType = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8453,7 +8371,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 8192L) != 0))
                             {
                                 _bits &= ~8192L;
-                                _ContentEncoding = StringValues.Empty;
+                                _headers._ContentEncoding = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8467,7 +8385,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 16384L) != 0))
                             {
                                 _bits &= ~16384L;
-                                _ContentLanguage = StringValues.Empty;
+                                _headers._ContentLanguage = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8481,7 +8399,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 32768L) != 0))
                             {
                                 _bits &= ~32768L;
-                                _ContentLocation = StringValues.Empty;
+                                _headers._ContentLocation = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8495,7 +8413,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 536870912L) != 0))
                             {
                                 _bits &= ~536870912L;
-                                _WWWAuthenticate = StringValues.Empty;
+                                _headers._WWWAuthenticate = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8513,7 +8431,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 65536L) != 0))
                             {
                                 _bits &= ~65536L;
-                                _ContentMD5 = StringValues.Empty;
+                                _headers._ContentMD5 = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8527,7 +8445,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 33554432L) != 0))
                             {
                                 _bits &= ~33554432L;
-                                _RetryAfter = StringValues.Empty;
+                                _headers._RetryAfter = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8545,7 +8463,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 8388608L) != 0))
                             {
                                 _bits &= ~8388608L;
-                                _Location = StringValues.Empty;
+                                _headers._Location = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8563,7 +8481,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 1073741824L) != 0))
                             {
                                 _bits &= ~1073741824L;
-                                _AccessControlAllowCredentials = StringValues.Empty;
+                                _headers._AccessControlAllowCredentials = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8581,7 +8499,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 2147483648L) != 0))
                             {
                                 _bits &= ~2147483648L;
-                                _AccessControlAllowHeaders = StringValues.Empty;
+                                _headers._AccessControlAllowHeaders = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8595,7 +8513,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 4294967296L) != 0))
                             {
                                 _bits &= ~4294967296L;
-                                _AccessControlAllowMethods = StringValues.Empty;
+                                _headers._AccessControlAllowMethods = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8613,7 +8531,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 8589934592L) != 0))
                             {
                                 _bits &= ~8589934592L;
-                                _AccessControlAllowOrigin = StringValues.Empty;
+                                _headers._AccessControlAllowOrigin = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8631,7 +8549,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 17179869184L) != 0))
                             {
                                 _bits &= ~17179869184L;
-                                _AccessControlExposeHeaders = StringValues.Empty;
+                                _headers._AccessControlExposeHeaders = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8649,7 +8567,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             if (((_bits & 34359738368L) != 0))
                             {
                                 _bits &= ~34359738368L;
-                                _AccessControlMaxAge = StringValues.Empty;
+                                _headers._AccessControlMaxAge = StringValues.Empty;
                                 return true;
                             }
                             else
@@ -8664,8 +8582,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         }
         protected override void ClearFast()
         {
-
             _bits = 0;
+            _headers = default(HeaderReferences);
             MaybeUnknown?.Clear();
         }
         
@@ -8683,7 +8601,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Cache-Control", _CacheControl);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Cache-Control", _headers._CacheControl);
                     ++arrayIndex;
                 }
             
@@ -8694,7 +8612,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Connection", _Connection);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Connection", _headers._Connection);
                     ++arrayIndex;
                 }
             
@@ -8705,7 +8623,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Date", _Date);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Date", _headers._Date);
                     ++arrayIndex;
                 }
             
@@ -8716,7 +8634,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Keep-Alive", _KeepAlive);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Keep-Alive", _headers._KeepAlive);
                     ++arrayIndex;
                 }
             
@@ -8727,7 +8645,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Pragma", _Pragma);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Pragma", _headers._Pragma);
                     ++arrayIndex;
                 }
             
@@ -8738,7 +8656,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Trailer", _Trailer);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Trailer", _headers._Trailer);
                     ++arrayIndex;
                 }
             
@@ -8749,7 +8667,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Transfer-Encoding", _TransferEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Transfer-Encoding", _headers._TransferEncoding);
                     ++arrayIndex;
                 }
             
@@ -8760,7 +8678,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Upgrade", _Upgrade);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Upgrade", _headers._Upgrade);
                     ++arrayIndex;
                 }
             
@@ -8771,7 +8689,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Via", _Via);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Via", _headers._Via);
                     ++arrayIndex;
                 }
             
@@ -8782,7 +8700,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Warning", _Warning);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Warning", _headers._Warning);
                     ++arrayIndex;
                 }
             
@@ -8793,7 +8711,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Allow", _Allow);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Allow", _headers._Allow);
                     ++arrayIndex;
                 }
             
@@ -8804,7 +8722,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Length", _ContentLength);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Length", _headers._ContentLength);
                     ++arrayIndex;
                 }
             
@@ -8815,7 +8733,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Type", _ContentType);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Type", _headers._ContentType);
                     ++arrayIndex;
                 }
             
@@ -8826,7 +8744,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Encoding", _ContentEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Encoding", _headers._ContentEncoding);
                     ++arrayIndex;
                 }
             
@@ -8837,7 +8755,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Language", _ContentLanguage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Language", _headers._ContentLanguage);
                     ++arrayIndex;
                 }
             
@@ -8848,7 +8766,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Location", _ContentLocation);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Location", _headers._ContentLocation);
                     ++arrayIndex;
                 }
             
@@ -8859,7 +8777,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-MD5", _ContentMD5);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-MD5", _headers._ContentMD5);
                     ++arrayIndex;
                 }
             
@@ -8870,7 +8788,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Range", _ContentRange);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Content-Range", _headers._ContentRange);
                     ++arrayIndex;
                 }
             
@@ -8881,7 +8799,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Expires", _Expires);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Expires", _headers._Expires);
                     ++arrayIndex;
                 }
             
@@ -8892,7 +8810,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Last-Modified", _LastModified);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Last-Modified", _headers._LastModified);
                     ++arrayIndex;
                 }
             
@@ -8903,7 +8821,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Ranges", _AcceptRanges);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Accept-Ranges", _headers._AcceptRanges);
                     ++arrayIndex;
                 }
             
@@ -8914,7 +8832,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Age", _Age);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Age", _headers._Age);
                     ++arrayIndex;
                 }
             
@@ -8925,7 +8843,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("ETag", _ETag);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("ETag", _headers._ETag);
                     ++arrayIndex;
                 }
             
@@ -8936,7 +8854,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Location", _Location);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Location", _headers._Location);
                     ++arrayIndex;
                 }
             
@@ -8947,7 +8865,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Proxy-Autheticate", _ProxyAutheticate);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Proxy-Autheticate", _headers._ProxyAutheticate);
                     ++arrayIndex;
                 }
             
@@ -8958,7 +8876,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Retry-After", _RetryAfter);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Retry-After", _headers._RetryAfter);
                     ++arrayIndex;
                 }
             
@@ -8969,7 +8887,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Server", _Server);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Server", _headers._Server);
                     ++arrayIndex;
                 }
             
@@ -8980,7 +8898,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Set-Cookie", _SetCookie);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Set-Cookie", _headers._SetCookie);
                     ++arrayIndex;
                 }
             
@@ -8991,7 +8909,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Vary", _Vary);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Vary", _headers._Vary);
                     ++arrayIndex;
                 }
             
@@ -9002,7 +8920,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("WWW-Authenticate", _WWWAuthenticate);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("WWW-Authenticate", _headers._WWWAuthenticate);
                     ++arrayIndex;
                 }
             
@@ -9013,7 +8931,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Credentials", _AccessControlAllowCredentials);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Credentials", _headers._AccessControlAllowCredentials);
                     ++arrayIndex;
                 }
             
@@ -9024,7 +8942,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Headers", _AccessControlAllowHeaders);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Headers", _headers._AccessControlAllowHeaders);
                     ++arrayIndex;
                 }
             
@@ -9035,7 +8953,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Methods", _AccessControlAllowMethods);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Methods", _headers._AccessControlAllowMethods);
                     ++arrayIndex;
                 }
             
@@ -9046,7 +8964,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Origin", _AccessControlAllowOrigin);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Allow-Origin", _headers._AccessControlAllowOrigin);
                     ++arrayIndex;
                 }
             
@@ -9057,7 +8975,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Expose-Headers", _AccessControlExposeHeaders);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Expose-Headers", _headers._AccessControlExposeHeaders);
                     ++arrayIndex;
                 }
             
@@ -9068,7 +8986,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         ThrowArgumentException();
                     }
 
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Max-Age", _AccessControlMaxAge);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>("Access-Control-Max-Age", _headers._AccessControlMaxAge);
                     ++arrayIndex;
                 }
             
@@ -9080,7 +8998,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 1L) != 0)) 
                 { 
-                        foreach (var value in _CacheControl)
+                        foreach (var value in _headers._CacheControl)
                         {
                             if (value != null)
                             {
@@ -9092,12 +9010,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 2L) != 0)) 
                 { 
-                    if (_rawConnection != null) 
+                    if (_headers._rawConnection != null) 
                     {
-                        output.CopyFrom(_rawConnection, 0, _rawConnection.Length);
+                        output.CopyFrom(_headers._rawConnection, 0, _headers._rawConnection.Length);
                     } 
                     else 
-                        foreach (var value in _Connection)
+                        foreach (var value in _headers._Connection)
                         {
                             if (value != null)
                             {
@@ -9109,12 +9027,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 4L) != 0)) 
                 { 
-                    if (_rawDate != null) 
+                    if (_headers._rawDate != null) 
                     {
-                        output.CopyFrom(_rawDate, 0, _rawDate.Length);
+                        output.CopyFrom(_headers._rawDate, 0, _headers._rawDate.Length);
                     } 
                     else 
-                        foreach (var value in _Date)
+                        foreach (var value in _headers._Date)
                         {
                             if (value != null)
                             {
@@ -9126,7 +9044,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 8L) != 0)) 
                 { 
-                        foreach (var value in _KeepAlive)
+                        foreach (var value in _headers._KeepAlive)
                         {
                             if (value != null)
                             {
@@ -9138,7 +9056,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 16L) != 0)) 
                 { 
-                        foreach (var value in _Pragma)
+                        foreach (var value in _headers._Pragma)
                         {
                             if (value != null)
                             {
@@ -9150,7 +9068,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 32L) != 0)) 
                 { 
-                        foreach (var value in _Trailer)
+                        foreach (var value in _headers._Trailer)
                         {
                             if (value != null)
                             {
@@ -9162,12 +9080,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 64L) != 0)) 
                 { 
-                    if (_rawTransferEncoding != null) 
+                    if (_headers._rawTransferEncoding != null) 
                     {
-                        output.CopyFrom(_rawTransferEncoding, 0, _rawTransferEncoding.Length);
+                        output.CopyFrom(_headers._rawTransferEncoding, 0, _headers._rawTransferEncoding.Length);
                     } 
                     else 
-                        foreach (var value in _TransferEncoding)
+                        foreach (var value in _headers._TransferEncoding)
                         {
                             if (value != null)
                             {
@@ -9179,7 +9097,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 128L) != 0)) 
                 { 
-                        foreach (var value in _Upgrade)
+                        foreach (var value in _headers._Upgrade)
                         {
                             if (value != null)
                             {
@@ -9191,7 +9109,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 256L) != 0)) 
                 { 
-                        foreach (var value in _Via)
+                        foreach (var value in _headers._Via)
                         {
                             if (value != null)
                             {
@@ -9203,7 +9121,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 512L) != 0)) 
                 { 
-                        foreach (var value in _Warning)
+                        foreach (var value in _headers._Warning)
                         {
                             if (value != null)
                             {
@@ -9215,7 +9133,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 1024L) != 0)) 
                 { 
-                        foreach (var value in _Allow)
+                        foreach (var value in _headers._Allow)
                         {
                             if (value != null)
                             {
@@ -9227,12 +9145,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 2048L) != 0)) 
                 { 
-                    if (_rawContentLength != null) 
+                    if (_headers._rawContentLength != null) 
                     {
-                        output.CopyFrom(_rawContentLength, 0, _rawContentLength.Length);
+                        output.CopyFrom(_headers._rawContentLength, 0, _headers._rawContentLength.Length);
                     } 
                     else 
-                        foreach (var value in _ContentLength)
+                        foreach (var value in _headers._ContentLength)
                         {
                             if (value != null)
                             {
@@ -9244,7 +9162,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 4096L) != 0)) 
                 { 
-                        foreach (var value in _ContentType)
+                        foreach (var value in _headers._ContentType)
                         {
                             if (value != null)
                             {
@@ -9256,7 +9174,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 8192L) != 0)) 
                 { 
-                        foreach (var value in _ContentEncoding)
+                        foreach (var value in _headers._ContentEncoding)
                         {
                             if (value != null)
                             {
@@ -9268,7 +9186,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 16384L) != 0)) 
                 { 
-                        foreach (var value in _ContentLanguage)
+                        foreach (var value in _headers._ContentLanguage)
                         {
                             if (value != null)
                             {
@@ -9280,7 +9198,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 32768L) != 0)) 
                 { 
-                        foreach (var value in _ContentLocation)
+                        foreach (var value in _headers._ContentLocation)
                         {
                             if (value != null)
                             {
@@ -9292,7 +9210,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 65536L) != 0)) 
                 { 
-                        foreach (var value in _ContentMD5)
+                        foreach (var value in _headers._ContentMD5)
                         {
                             if (value != null)
                             {
@@ -9304,7 +9222,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 131072L) != 0)) 
                 { 
-                        foreach (var value in _ContentRange)
+                        foreach (var value in _headers._ContentRange)
                         {
                             if (value != null)
                             {
@@ -9316,7 +9234,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 262144L) != 0)) 
                 { 
-                        foreach (var value in _Expires)
+                        foreach (var value in _headers._Expires)
                         {
                             if (value != null)
                             {
@@ -9328,7 +9246,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 524288L) != 0)) 
                 { 
-                        foreach (var value in _LastModified)
+                        foreach (var value in _headers._LastModified)
                         {
                             if (value != null)
                             {
@@ -9340,7 +9258,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 1048576L) != 0)) 
                 { 
-                        foreach (var value in _AcceptRanges)
+                        foreach (var value in _headers._AcceptRanges)
                         {
                             if (value != null)
                             {
@@ -9352,7 +9270,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 2097152L) != 0)) 
                 { 
-                        foreach (var value in _Age)
+                        foreach (var value in _headers._Age)
                         {
                             if (value != null)
                             {
@@ -9364,7 +9282,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 4194304L) != 0)) 
                 { 
-                        foreach (var value in _ETag)
+                        foreach (var value in _headers._ETag)
                         {
                             if (value != null)
                             {
@@ -9376,7 +9294,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 8388608L) != 0)) 
                 { 
-                        foreach (var value in _Location)
+                        foreach (var value in _headers._Location)
                         {
                             if (value != null)
                             {
@@ -9388,7 +9306,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 16777216L) != 0)) 
                 { 
-                        foreach (var value in _ProxyAutheticate)
+                        foreach (var value in _headers._ProxyAutheticate)
                         {
                             if (value != null)
                             {
@@ -9400,7 +9318,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 33554432L) != 0)) 
                 { 
-                        foreach (var value in _RetryAfter)
+                        foreach (var value in _headers._RetryAfter)
                         {
                             if (value != null)
                             {
@@ -9412,12 +9330,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 67108864L) != 0)) 
                 { 
-                    if (_rawServer != null) 
+                    if (_headers._rawServer != null) 
                     {
-                        output.CopyFrom(_rawServer, 0, _rawServer.Length);
+                        output.CopyFrom(_headers._rawServer, 0, _headers._rawServer.Length);
                     } 
                     else 
-                        foreach (var value in _Server)
+                        foreach (var value in _headers._Server)
                         {
                             if (value != null)
                             {
@@ -9429,7 +9347,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 134217728L) != 0)) 
                 { 
-                        foreach (var value in _SetCookie)
+                        foreach (var value in _headers._SetCookie)
                         {
                             if (value != null)
                             {
@@ -9441,7 +9359,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 268435456L) != 0)) 
                 { 
-                        foreach (var value in _Vary)
+                        foreach (var value in _headers._Vary)
                         {
                             if (value != null)
                             {
@@ -9453,7 +9371,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 536870912L) != 0)) 
                 { 
-                        foreach (var value in _WWWAuthenticate)
+                        foreach (var value in _headers._WWWAuthenticate)
                         {
                             if (value != null)
                             {
@@ -9465,7 +9383,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 1073741824L) != 0)) 
                 { 
-                        foreach (var value in _AccessControlAllowCredentials)
+                        foreach (var value in _headers._AccessControlAllowCredentials)
                         {
                             if (value != null)
                             {
@@ -9477,7 +9395,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 2147483648L) != 0)) 
                 { 
-                        foreach (var value in _AccessControlAllowHeaders)
+                        foreach (var value in _headers._AccessControlAllowHeaders)
                         {
                             if (value != null)
                             {
@@ -9489,7 +9407,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 4294967296L) != 0)) 
                 { 
-                        foreach (var value in _AccessControlAllowMethods)
+                        foreach (var value in _headers._AccessControlAllowMethods)
                         {
                             if (value != null)
                             {
@@ -9501,7 +9419,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 8589934592L) != 0)) 
                 { 
-                        foreach (var value in _AccessControlAllowOrigin)
+                        foreach (var value in _headers._AccessControlAllowOrigin)
                         {
                             if (value != null)
                             {
@@ -9513,7 +9431,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 17179869184L) != 0)) 
                 { 
-                        foreach (var value in _AccessControlExposeHeaders)
+                        foreach (var value in _headers._AccessControlExposeHeaders)
                         {
                             if (value != null)
                             {
@@ -9525,7 +9443,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
                 if (((_bits & 34359738368L) != 0)) 
                 { 
-                        foreach (var value in _AccessControlMaxAge)
+                        foreach (var value in _headers._AccessControlMaxAge)
                         {
                             if (value != null)
                             {
@@ -9537,6 +9455,52 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             
         }
         
+        private struct HeaderReferences
+        {
+            public StringValues _CacheControl;
+            public StringValues _Connection;
+            public StringValues _Date;
+            public StringValues _KeepAlive;
+            public StringValues _Pragma;
+            public StringValues _Trailer;
+            public StringValues _TransferEncoding;
+            public StringValues _Upgrade;
+            public StringValues _Via;
+            public StringValues _Warning;
+            public StringValues _Allow;
+            public StringValues _ContentLength;
+            public StringValues _ContentType;
+            public StringValues _ContentEncoding;
+            public StringValues _ContentLanguage;
+            public StringValues _ContentLocation;
+            public StringValues _ContentMD5;
+            public StringValues _ContentRange;
+            public StringValues _Expires;
+            public StringValues _LastModified;
+            public StringValues _AcceptRanges;
+            public StringValues _Age;
+            public StringValues _ETag;
+            public StringValues _Location;
+            public StringValues _ProxyAutheticate;
+            public StringValues _RetryAfter;
+            public StringValues _Server;
+            public StringValues _SetCookie;
+            public StringValues _Vary;
+            public StringValues _WWWAuthenticate;
+            public StringValues _AccessControlAllowCredentials;
+            public StringValues _AccessControlAllowHeaders;
+            public StringValues _AccessControlAllowMethods;
+            public StringValues _AccessControlAllowOrigin;
+            public StringValues _AccessControlExposeHeaders;
+            public StringValues _AccessControlMaxAge;
+            
+            public byte[] _rawConnection;
+            public byte[] _rawDate;
+            public byte[] _rawTransferEncoding;
+            public byte[] _rawContentLength;
+            public byte[] _rawServer;
+        }
+
         public partial struct Enumerator
         {
             public bool MoveNext()
@@ -9659,7 +9623,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state0:
                     if (((_bits & 1L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Cache-Control", _collection._CacheControl);
+                        _current = new KeyValuePair<string, StringValues>("Cache-Control", _collection._headers._CacheControl);
                         _state = 1;
                         return true;
                     }
@@ -9667,7 +9631,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state1:
                     if (((_bits & 2L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Connection", _collection._Connection);
+                        _current = new KeyValuePair<string, StringValues>("Connection", _collection._headers._Connection);
                         _state = 2;
                         return true;
                     }
@@ -9675,7 +9639,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state2:
                     if (((_bits & 4L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Date", _collection._Date);
+                        _current = new KeyValuePair<string, StringValues>("Date", _collection._headers._Date);
                         _state = 3;
                         return true;
                     }
@@ -9683,7 +9647,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state3:
                     if (((_bits & 8L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Keep-Alive", _collection._KeepAlive);
+                        _current = new KeyValuePair<string, StringValues>("Keep-Alive", _collection._headers._KeepAlive);
                         _state = 4;
                         return true;
                     }
@@ -9691,7 +9655,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state4:
                     if (((_bits & 16L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Pragma", _collection._Pragma);
+                        _current = new KeyValuePair<string, StringValues>("Pragma", _collection._headers._Pragma);
                         _state = 5;
                         return true;
                     }
@@ -9699,7 +9663,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state5:
                     if (((_bits & 32L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Trailer", _collection._Trailer);
+                        _current = new KeyValuePair<string, StringValues>("Trailer", _collection._headers._Trailer);
                         _state = 6;
                         return true;
                     }
@@ -9707,7 +9671,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state6:
                     if (((_bits & 64L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Transfer-Encoding", _collection._TransferEncoding);
+                        _current = new KeyValuePair<string, StringValues>("Transfer-Encoding", _collection._headers._TransferEncoding);
                         _state = 7;
                         return true;
                     }
@@ -9715,7 +9679,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state7:
                     if (((_bits & 128L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Upgrade", _collection._Upgrade);
+                        _current = new KeyValuePair<string, StringValues>("Upgrade", _collection._headers._Upgrade);
                         _state = 8;
                         return true;
                     }
@@ -9723,7 +9687,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state8:
                     if (((_bits & 256L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Via", _collection._Via);
+                        _current = new KeyValuePair<string, StringValues>("Via", _collection._headers._Via);
                         _state = 9;
                         return true;
                     }
@@ -9731,7 +9695,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state9:
                     if (((_bits & 512L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Warning", _collection._Warning);
+                        _current = new KeyValuePair<string, StringValues>("Warning", _collection._headers._Warning);
                         _state = 10;
                         return true;
                     }
@@ -9739,7 +9703,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state10:
                     if (((_bits & 1024L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Allow", _collection._Allow);
+                        _current = new KeyValuePair<string, StringValues>("Allow", _collection._headers._Allow);
                         _state = 11;
                         return true;
                     }
@@ -9747,7 +9711,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state11:
                     if (((_bits & 2048L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Length", _collection._ContentLength);
+                        _current = new KeyValuePair<string, StringValues>("Content-Length", _collection._headers._ContentLength);
                         _state = 12;
                         return true;
                     }
@@ -9755,7 +9719,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state12:
                     if (((_bits & 4096L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Type", _collection._ContentType);
+                        _current = new KeyValuePair<string, StringValues>("Content-Type", _collection._headers._ContentType);
                         _state = 13;
                         return true;
                     }
@@ -9763,7 +9727,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state13:
                     if (((_bits & 8192L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Encoding", _collection._ContentEncoding);
+                        _current = new KeyValuePair<string, StringValues>("Content-Encoding", _collection._headers._ContentEncoding);
                         _state = 14;
                         return true;
                     }
@@ -9771,7 +9735,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state14:
                     if (((_bits & 16384L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Language", _collection._ContentLanguage);
+                        _current = new KeyValuePair<string, StringValues>("Content-Language", _collection._headers._ContentLanguage);
                         _state = 15;
                         return true;
                     }
@@ -9779,7 +9743,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state15:
                     if (((_bits & 32768L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Location", _collection._ContentLocation);
+                        _current = new KeyValuePair<string, StringValues>("Content-Location", _collection._headers._ContentLocation);
                         _state = 16;
                         return true;
                     }
@@ -9787,7 +9751,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state16:
                     if (((_bits & 65536L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-MD5", _collection._ContentMD5);
+                        _current = new KeyValuePair<string, StringValues>("Content-MD5", _collection._headers._ContentMD5);
                         _state = 17;
                         return true;
                     }
@@ -9795,7 +9759,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state17:
                     if (((_bits & 131072L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Content-Range", _collection._ContentRange);
+                        _current = new KeyValuePair<string, StringValues>("Content-Range", _collection._headers._ContentRange);
                         _state = 18;
                         return true;
                     }
@@ -9803,7 +9767,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state18:
                     if (((_bits & 262144L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Expires", _collection._Expires);
+                        _current = new KeyValuePair<string, StringValues>("Expires", _collection._headers._Expires);
                         _state = 19;
                         return true;
                     }
@@ -9811,7 +9775,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state19:
                     if (((_bits & 524288L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Last-Modified", _collection._LastModified);
+                        _current = new KeyValuePair<string, StringValues>("Last-Modified", _collection._headers._LastModified);
                         _state = 20;
                         return true;
                     }
@@ -9819,7 +9783,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state20:
                     if (((_bits & 1048576L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Accept-Ranges", _collection._AcceptRanges);
+                        _current = new KeyValuePair<string, StringValues>("Accept-Ranges", _collection._headers._AcceptRanges);
                         _state = 21;
                         return true;
                     }
@@ -9827,7 +9791,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state21:
                     if (((_bits & 2097152L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Age", _collection._Age);
+                        _current = new KeyValuePair<string, StringValues>("Age", _collection._headers._Age);
                         _state = 22;
                         return true;
                     }
@@ -9835,7 +9799,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state22:
                     if (((_bits & 4194304L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("ETag", _collection._ETag);
+                        _current = new KeyValuePair<string, StringValues>("ETag", _collection._headers._ETag);
                         _state = 23;
                         return true;
                     }
@@ -9843,7 +9807,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state23:
                     if (((_bits & 8388608L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Location", _collection._Location);
+                        _current = new KeyValuePair<string, StringValues>("Location", _collection._headers._Location);
                         _state = 24;
                         return true;
                     }
@@ -9851,7 +9815,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state24:
                     if (((_bits & 16777216L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Proxy-Autheticate", _collection._ProxyAutheticate);
+                        _current = new KeyValuePair<string, StringValues>("Proxy-Autheticate", _collection._headers._ProxyAutheticate);
                         _state = 25;
                         return true;
                     }
@@ -9859,7 +9823,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state25:
                     if (((_bits & 33554432L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Retry-After", _collection._RetryAfter);
+                        _current = new KeyValuePair<string, StringValues>("Retry-After", _collection._headers._RetryAfter);
                         _state = 26;
                         return true;
                     }
@@ -9867,7 +9831,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state26:
                     if (((_bits & 67108864L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Server", _collection._Server);
+                        _current = new KeyValuePair<string, StringValues>("Server", _collection._headers._Server);
                         _state = 27;
                         return true;
                     }
@@ -9875,7 +9839,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state27:
                     if (((_bits & 134217728L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Set-Cookie", _collection._SetCookie);
+                        _current = new KeyValuePair<string, StringValues>("Set-Cookie", _collection._headers._SetCookie);
                         _state = 28;
                         return true;
                     }
@@ -9883,7 +9847,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state28:
                     if (((_bits & 268435456L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Vary", _collection._Vary);
+                        _current = new KeyValuePair<string, StringValues>("Vary", _collection._headers._Vary);
                         _state = 29;
                         return true;
                     }
@@ -9891,7 +9855,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state29:
                     if (((_bits & 536870912L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("WWW-Authenticate", _collection._WWWAuthenticate);
+                        _current = new KeyValuePair<string, StringValues>("WWW-Authenticate", _collection._headers._WWWAuthenticate);
                         _state = 30;
                         return true;
                     }
@@ -9899,7 +9863,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state30:
                     if (((_bits & 1073741824L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Access-Control-Allow-Credentials", _collection._AccessControlAllowCredentials);
+                        _current = new KeyValuePair<string, StringValues>("Access-Control-Allow-Credentials", _collection._headers._AccessControlAllowCredentials);
                         _state = 31;
                         return true;
                     }
@@ -9907,7 +9871,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state31:
                     if (((_bits & 2147483648L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Access-Control-Allow-Headers", _collection._AccessControlAllowHeaders);
+                        _current = new KeyValuePair<string, StringValues>("Access-Control-Allow-Headers", _collection._headers._AccessControlAllowHeaders);
                         _state = 32;
                         return true;
                     }
@@ -9915,7 +9879,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state32:
                     if (((_bits & 4294967296L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Access-Control-Allow-Methods", _collection._AccessControlAllowMethods);
+                        _current = new KeyValuePair<string, StringValues>("Access-Control-Allow-Methods", _collection._headers._AccessControlAllowMethods);
                         _state = 33;
                         return true;
                     }
@@ -9923,7 +9887,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state33:
                     if (((_bits & 8589934592L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Access-Control-Allow-Origin", _collection._AccessControlAllowOrigin);
+                        _current = new KeyValuePair<string, StringValues>("Access-Control-Allow-Origin", _collection._headers._AccessControlAllowOrigin);
                         _state = 34;
                         return true;
                     }
@@ -9931,7 +9895,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state34:
                     if (((_bits & 17179869184L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Access-Control-Expose-Headers", _collection._AccessControlExposeHeaders);
+                        _current = new KeyValuePair<string, StringValues>("Access-Control-Expose-Headers", _collection._headers._AccessControlExposeHeaders);
                         _state = 35;
                         return true;
                     }
@@ -9939,7 +9903,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 state35:
                     if (((_bits & 34359738368L) != 0))
                     {
-                        _current = new KeyValuePair<string, StringValues>("Access-Control-Max-Age", _collection._AccessControlMaxAge);
+                        _current = new KeyValuePair<string, StringValues>("Access-Control-Max-Age", _collection._headers._AccessControlMaxAge);
                         _state = 36;
                         return true;
                     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameOfT.cs
@@ -131,14 +131,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             }
             catch (Exception ex)
             {
+                // Error occurred, do not return components to pool
+                _poolingPermitted = false;
                 Log.LogWarning(0, ex, "Connection processing ended abnormally");
             }
             finally
             {
-                // Error occurred, do not return components to pool
-                ResetComponents(poolingPermitted: false);
                 try
                 {
+                    ResetComponents(poolingPermitted: _poolingPermitted);
                     _abortedCts = null;
 
                     // If _requestAborted is set, the connection has already been closed.

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameResponseStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameResponseStream.cs
@@ -11,12 +11,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 {
     class FrameResponseStream : Stream
     {
-        private readonly FrameContext _context;
+        private FrameContext _context;
         private FrameStreamState _state;
 
-        public FrameResponseStream(FrameContext context)
+        public FrameResponseStream()
         {
-            _context = context;
             _state = FrameStreamState.Closed;
         }
 
@@ -123,6 +122,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             {
                 _state = FrameStreamState.Aborted;
             }
+        }
+
+        public void Initialize(FrameContext context)
+        {
+            _context = context;
+        }
+
+        public void Uninitialize()
+        {
+            _context = null;
+            _state = FrameStreamState.Closed;
         }
 
         private Task ValidateState(CancellationToken cancellationToken)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListener.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         {
             var socket = new UvTcpHandle(Log);
             socket.Init(Thread.Loop, Thread.QueueCloseHandle);
-            socket.NoDelay(NoDelay);
+            socket.NoDelay(ServerInformation.NoDelay);
             socket.Bind(ServerAddress);
             socket.Listen(Constants.ListenBacklog, (stream, status, error, state) => ConnectionCallback(stream, status, error, state), this);
             return socket;
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             try
             {
                 acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
-                acceptSocket.NoDelay(NoDelay);
+                acceptSocket.NoDelay(ServerInformation.NoDelay);
                 listenSocket.Accept(acceptSocket);
                 DispatchConnection(acceptSocket);
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerPrimary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerPrimary.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         {
             var socket = new UvTcpHandle(Log);
             socket.Init(Thread.Loop, Thread.QueueCloseHandle);
-            socket.NoDelay(NoDelay);
+            socket.NoDelay(ServerInformation.NoDelay);
             socket.Bind(ServerAddress);
             socket.Listen(Constants.ListenBacklog, (stream, status, error, state) => ConnectionCallback(stream, status, error, state), this);
             return socket;
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             try
             {
                 acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
-                acceptSocket.NoDelay(NoDelay);
+                acceptSocket.NoDelay(ServerInformation.NoDelay);
                 listenSocket.Accept(acceptSocket);
                 DispatchConnection(acceptSocket);
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerSecondary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/TcpListenerSecondary.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         {
             var acceptSocket = new UvTcpHandle(Log);
             acceptSocket.Init(Thread.Loop, Thread.QueueCloseHandle);
-            acceptSocket.NoDelay(NoDelay);
+            acceptSocket.NoDelay(ServerInformation.NoDelay);
             return acceptSocket;
         }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/IKestrelServerInformation.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/IKestrelServerInformation.cs
@@ -12,17 +12,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         bool NoDelay { get; set; }
 
         /// <summary>
-        /// Gets or sets a flag that instructs <seealso cref="KestrelServer"/> whether it is safe to 
-        /// reuse the Request and Response <seealso cref="System.IO.Stream"/> objects
+        /// Gets or sets values that instruct <seealso cref="KestrelServer"/> whether it is safe to 
+        /// pool the Request and Response <seealso cref="System.IO.Stream"/> objects, Headers etc
         /// for another request after the Response's OnCompleted callback has fired. 
-        /// When this is set to true it is not safe to retain references to these streams after this event has fired.
-        /// It is false by default.
+        /// When these values are greater than zero it is not safe to retain references to feature components after this event has fired.
+        /// They are zero by default.
         /// </summary>
-        /// <remarks>
-        /// When this is set to true it is not safe to retain references to these streams after this event has fired.
-        /// It is false by default.
-        /// </remarks>
-        bool ReuseStreams { get; set; }
+        KestrelServerPoolingParameters PoolingParameters { get; }
 
         IConnectionFilter ConnectionFilter { get; set; }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/HttpComponentFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/HttpComponentFactory.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Server.Kestrel.Http;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
+{
+    class HttpComponentFactory : IHttpComponentFactory
+    {
+        private const int _maxPooledComponents = 128;
+        private ConcurrentQueue<Streams> _streamPool = new ConcurrentQueue<Streams>();
+        private ConcurrentQueue<Headers> _headerPool = new ConcurrentQueue<Headers>();
+
+        public Streams CreateStreams(FrameContext owner)
+        {
+            Streams streams;
+
+            if (!_streamPool.TryDequeue(out streams))
+            {
+                streams = new Streams();
+            }
+
+            streams.Initialize(owner);
+
+            return streams;
+        }
+
+        public void DisposeStreams(Streams streams, bool poolingPermitted)
+        {
+            if (poolingPermitted && _streamPool.Count < _maxPooledComponents)
+            {
+                streams.Uninitialize();
+
+                _streamPool.Enqueue(streams);
+            }
+        }
+
+        public Headers CreateHeaders(DateHeaderValueManager dateValueManager)
+        {
+            Headers headers;
+
+            if (!_headerPool.TryDequeue(out headers))
+            {
+                headers = new Headers();
+            }
+
+            headers.Initialize(dateValueManager);
+
+            return headers;
+        }
+
+        public void DisposeHeaders(Headers headers, bool poolingPermitted)
+        {
+            if (poolingPermitted && _headerPool.Count < _maxPooledComponents)
+            {
+                headers.Uninitialize();
+
+                _headerPool.Enqueue(headers);
+            }
+        }
+    }
+
+    internal class Headers
+    {
+        public static readonly byte[] BytesServer = Encoding.ASCII.GetBytes("\r\nServer: Kestrel");
+
+        public readonly FrameRequestHeaders RequestHeaders = new FrameRequestHeaders();
+        public readonly FrameResponseHeaders ResponseHeaders = new FrameResponseHeaders();
+
+        public Headers()
+        {
+            RequestHeaders = new FrameRequestHeaders();
+            ResponseHeaders = new FrameResponseHeaders();
+        }
+
+        public void Initialize(DateHeaderValueManager dateValueManager)
+        {
+            ResponseHeaders.SetRawDate(
+                dateValueManager.GetDateHeaderValue(),
+                dateValueManager.GetDateHeaderValueBytes());
+            ResponseHeaders.SetRawServer("Kestrel", BytesServer);
+        }
+
+        public void Uninitialize()
+        {
+            RequestHeaders.Reset();
+            ResponseHeaders.Reset();
+        }
+    }
+
+    internal class Streams
+    {
+        public readonly FrameRequestStream RequestBody;
+        public readonly FrameResponseStream ResponseBody;
+        public readonly FrameDuplexStream DuplexStream;
+
+        public Streams()
+        {
+            RequestBody = new FrameRequestStream();
+            ResponseBody = new FrameResponseStream();
+            DuplexStream = new FrameDuplexStream(RequestBody, ResponseBody);
+        }
+
+        public void Initialize(FrameContext renter)
+        {
+            ResponseBody.Initialize(renter);
+        }
+
+        public void Uninitialize()
+        {
+            ResponseBody.Uninitialize();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/IHttpComponentFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/IHttpComponentFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Http;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
+{
+    interface IHttpComponentFactory
+    {
+        Streams CreateStreams(FrameContext owner);
+
+        void DisposeStreams(Streams streams, bool poolingPermitted);
+
+        Headers CreateHeaders(DateHeaderValueManager dateValueManager);
+
+        void DisposeHeaders(Headers headers, bool poolingPermitted);
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/IHttpComponentFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/IHttpComponentFactory.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
 {
     interface IHttpComponentFactory
     {
+        IKestrelServerInformation ServerInformation { get; set; }
+
         Streams CreateStreams(FrameContext owner);
 
         void DisposeStreams(Streams streams, bool poolingPermitted);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
@@ -54,9 +54,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             try
             {
                 var information = (KestrelServerInformation)Features.Get<IKestrelServerInformation>();
+                var componentFactory = Features.Get<IHttpComponentFactory>();
                 var dateHeaderValueManager = new DateHeaderValueManager();
                 var trace = new KestrelTrace(_logger);
-                var componentFactory = new HttpComponentFactory();
                 var engine = new KestrelEngine(new ServiceContext
                 {
                     FrameFactory = (context, remoteEP, localEP, prepareRequest) => 
@@ -67,9 +67,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     Log = trace,
                     ThreadPool = new LoggingThreadPool(trace),
                     DateHeaderValueManager = dateHeaderValueManager,
-                    ConnectionFilter = information.ConnectionFilter,
-                    NoDelay = information.NoDelay,
-                    ReuseStreams = information.ReuseStreams,
+                    ServerInformation = information,
                     HttpComponentFactory = componentFactory
                 });
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
@@ -56,6 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 var information = (KestrelServerInformation)Features.Get<IKestrelServerInformation>();
                 var dateHeaderValueManager = new DateHeaderValueManager();
                 var trace = new KestrelTrace(_logger);
+                var componentFactory = new HttpComponentFactory();
                 var engine = new KestrelEngine(new ServiceContext
                 {
                     FrameFactory = (context, remoteEP, localEP, prepareRequest) => 
@@ -68,7 +69,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     DateHeaderValueManager = dateHeaderValueManager,
                     ConnectionFilter = information.ConnectionFilter,
                     NoDelay = information.NoDelay,
-                    ReuseStreams = information.ReuseStreams
+                    ReuseStreams = information.ReuseStreams,
+                    HttpComponentFactory = componentFactory
                 });
 
                 _disposables.Push(engine);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerInformation.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerInformation.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             Addresses = GetAddresses(configuration);
             ThreadCount = GetThreadCount(configuration);
             NoDelay = GetNoDelay(configuration);
-            ReuseStreams = GetReuseStreams(configuration);
+            PoolingParameters = new KestrelServerPoolingParameters(configuration);
         }
 
         public ICollection<string> Addresses { get; }
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
 
         public bool NoDelay { get; set; }
 
-        public bool ReuseStreams { get; set; }
+        public KestrelServerPoolingParameters PoolingParameters { get; }
 
         public IConnectionFilter ConnectionFilter { get; set; }
 
@@ -109,19 +109,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             }
 
             return true;
-        }
-
-        private static bool GetReuseStreams(IConfiguration configuration)
-        {
-            var reuseStreamsString = configuration["kestrel.reuseStreams"];
-
-            bool reuseStreams;
-            if (bool.TryParse(reuseStreamsString, out reuseStreams))
-            {
-                return reuseStreams;
-            }
-
-            return false;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerPoolingParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerPoolingParameters.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.AspNetCore.Server.Kestrel
+{
+    public class KestrelServerPoolingParameters
+    {
+        public KestrelServerPoolingParameters(IConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            MaxPooledStreams = GetPooledCount(configuration["kestrel.maxPooledStreams"]);
+            MaxPooledHeaders = GetPooledCount(configuration["kestrel.maxPooledHeaders"]);
+        }
+
+        public int MaxPooledStreams { get; set; }
+
+        public int MaxPooledHeaders { get; set; }
+
+        private static int GetPooledCount(string countString)
+        {
+            if (string.IsNullOrEmpty(countString))
+            {
+                return 0;
+            }
+
+            int count;
+            if (int.TryParse(countString, NumberStyles.Integer, CultureInfo.InvariantCulture, out count))
+            {
+                return count;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/ServerFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/ServerFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -28,8 +29,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         public IServer CreateServer(IConfiguration configuration)
         {
             var information = new KestrelServerInformation(configuration);
+            var componentFactory = new HttpComponentFactory(information);
             var serverFeatures = new FeatureCollection();
             serverFeatures.Set<IKestrelServerInformation>(information);
+            serverFeatures.Set<IHttpComponentFactory>(componentFactory);
             serverFeatures.Set<IServerAddressesFeature>(information);
             return new KestrelServer(serverFeatures, _appLifetime, _loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel"));
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/ServiceContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/ServiceContext.cs
@@ -24,9 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             ThreadPool = context.ThreadPool;
             FrameFactory = context.FrameFactory;
             DateHeaderValueManager = context.DateHeaderValueManager;
-            ConnectionFilter = context.ConnectionFilter;
-            NoDelay = context.NoDelay;
-            ReuseStreams = context.ReuseStreams;
+            ServerInformation = context.ServerInformation;
             HttpComponentFactory = context.HttpComponentFactory;
         }
 
@@ -40,11 +38,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
 
         public DateHeaderValueManager DateHeaderValueManager { get; set; }
 
-        public IConnectionFilter ConnectionFilter { get; set; }
-
-        public bool NoDelay { get; set; }
-
-        public bool ReuseStreams { get; set; }
+        public IKestrelServerInformation ServerInformation { get; set; }
 
         internal IHttpComponentFactory HttpComponentFactory { get; set; }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/ServiceContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/ServiceContext.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             ConnectionFilter = context.ConnectionFilter;
             NoDelay = context.NoDelay;
             ReuseStreams = context.ReuseStreams;
+            HttpComponentFactory = context.HttpComponentFactory;
         }
 
         public IApplicationLifetime AppLifetime { get; set; }
@@ -44,5 +45,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         public bool NoDelay { get; set; }
 
         public bool ReuseStreams { get; set; }
+
+        internal IHttpComponentFactory HttpComponentFactory { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
-        public async Task RequestPathIsNormalized()
+        public void RequestPathIsNormalized()
         {
             var port = PortManager.GetPort();
             var config = new ConfigurationBuilder().AddInMemoryCollection(

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionFilterTests.cs
@@ -36,10 +36,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public async Task CanReadAndWriteWithRewritingConnectionFilter()
         {
             var filter = new RewritingConnectionFilter();
-            var serviceContext = new TestServiceContext()
-            {
-                ConnectionFilter = filter
-            };
+            var serviceContext = new TestServiceContext(filter);
+
             var sendString = "POST / HTTP/1.0\r\n\r\nHello World?";
 
             using (var server = new TestServer(App, serviceContext))
@@ -62,10 +60,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task CanReadAndWriteWithAsyncConnectionFilter()
         {
-            var serviceContext = new TestServiceContext()
-            {
-                ConnectionFilter = new AsyncConnectionFilter()
-            };
+            var serviceContext = new TestServiceContext(new AsyncConnectionFilter());
 
             using (var server = new TestServer(App, serviceContext))
             {
@@ -87,10 +82,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingSynchronousConnectionFilterDoesNotCrashServer()
         {
-            var serviceContext = new TestServiceContext()
-            {
-                ConnectionFilter = new ThrowingConnectionFilter()
-            };
+            var serviceContext = new TestServiceContext(new ThrowingConnectionFilter());
 
             using (var server = new TestServer(App, serviceContext))
             {

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
@@ -35,10 +35,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         new TestServiceContext()
                     },
                     {
-                        new TestServiceContext
-                        {
-                            ConnectionFilter = new PassThroughConnectionFilter()
-                        }
+                        new TestServiceContext(new PassThroughConnectionFilter())
                     }
                 };
             }
@@ -188,7 +185,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [MemberData(nameof(ConnectionFilterData))]
         public async Task ReuseStreamsOn(ServiceContext testContext)
         {
-            testContext.ReuseStreams = true;
+            testContext.ServerInformation.PoolingParameters.MaxPooledStreams = 120;
 
             var streamCount = 0;
             var loopCount = 20;
@@ -231,7 +228,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [MemberData(nameof(ConnectionFilterData))]
         public async Task ReuseStreamsOff(ServiceContext testContext)
         {
-            testContext.ReuseStreams = false;
+            testContext.ServerInformation.PoolingParameters.MaxPooledStreams = 0;
 
             var streamCount = 0;
             var loopCount = 20;

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 
@@ -18,9 +19,12 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var connectionContext = new ConnectionContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                HttpComponentFactory = new HttpComponentFactory()
             };
-            var frame = new Frame<object>(application: null, context: connectionContext);
+            var frame = new Frame<object>(application: null, context: connectionContext)
+                            .InitializeHeaders();
+
             IDictionary<string, StringValues> headers = frame.ResponseHeaders;
 
             Assert.Equal(2, headers.Count);
@@ -46,10 +50,12 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var connectionContext = new ConnectionContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                HttpComponentFactory = new HttpComponentFactory()
             };
-            var frame = new Frame<object>(application: null, context: connectionContext);
-            
+            var frame = new Frame<object>(application: null, context: connectionContext)
+                            .InitializeHeaders();
+
             Assert.True(frame.ResponseHeaders.Count > 0);
 
             frame.ResponseHeaders.Clear();

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 
@@ -16,12 +17,15 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [Fact]
         public void InitialDictionaryContainsServerAndDate()
         {
+            var configuration = new ConfigurationBuilder().Build();
+            var serverInformation = new KestrelServerInformation(configuration);
             var connectionContext = new ConnectionContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
                 ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                HttpComponentFactory = new HttpComponentFactory()
-            };
+                ServerInformation = serverInformation,
+                HttpComponentFactory = new HttpComponentFactory(serverInformation)
+        };
             var frame = new Frame<object>(application: null, context: connectionContext)
                             .InitializeHeaders();
 
@@ -47,11 +51,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [Fact]
         public void InitialEntriesCanBeCleared()
         {
+            var configuration = new ConfigurationBuilder().Build();
+            var serverInformation = new KestrelServerInformation(configuration);
             var connectionContext = new ConnectionContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
                 ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                HttpComponentFactory = new HttpComponentFactory()
+                ServerInformation = serverInformation,
+                HttpComponentFactory = new HttpComponentFactory(serverInformation)
             };
             var frame = new Frame<object>(application: null, context: connectionContext)
                             .InitializeHeaders();

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
@@ -59,13 +59,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 handler.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
 #endif
                 var serverAddress = $"https://localhost:{TestServer.GetNextPort()}/";
-                var serviceContext = new TestServiceContext()
-                {
-                    ConnectionFilter = new HttpsConnectionFilter(
+                var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
                         new HttpsConnectionFilterOptions
-                        { ServerCertificate = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword")},
+                        { ServerCertificate = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword") },
                         new NoOpConnectionFilter())
-                };
+                );
 
                 using (var server = new TestServer(App, serviceContext, serverAddress))
                 {
@@ -108,16 +106,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 #endif
 
                 var serverAddress = $"https://localhost:{TestServer.GetNextPort()}/";
-                var serviceContext = new TestServiceContext()
-                {
-                    ConnectionFilter = new HttpsConnectionFilter(
+                var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
                         new HttpsConnectionFilterOptions
                         {
                             ServerCertificate = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword"),
                             ClientCertificateMode = ClientCertificateMode.RequireCertificate
                         },
                         new NoOpConnectionFilter())
-                };
+                );
 
                 using (var server = new TestServer(App, serviceContext, serverAddress))
                 {
@@ -157,16 +153,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 #endif
 
                 var serverAddress = $"https://localhost:{TestServer.GetNextPort()}/";
-                var serviceContext = new TestServiceContext()
-                {
-                    ConnectionFilter = new HttpsConnectionFilter(
-                        new HttpsConnectionFilterOptions
-                        {
-                            ServerCertificate = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword"),
-                            ClientCertificateMode = ClientCertificateMode.AllowCertificate
-                        },
-                        new NoOpConnectionFilter())
-                };
+                var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
+                    new HttpsConnectionFilterOptions
+                    {
+                        ServerCertificate = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword"),
+                        ClientCertificateMode = ClientCertificateMode.AllowCertificate
+                    },
+                    new NoOpConnectionFilter())
+                );
 
                 RequestDelegate app = context =>
                 {
@@ -209,17 +203,15 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 #endif
 
                 var serverAddress = $"https://localhost:{TestServer.GetNextPort()}/";
-                var serviceContext = new TestServiceContext()
-                {
-                    ConnectionFilter = new HttpsConnectionFilter(
-                        new HttpsConnectionFilterOptions
-                        {
-                            ServerCertificate = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword"),
-                            ClientCertificateMode = ClientCertificateMode.RequireCertificate,
-                            ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => true
-                        },
-                        new NoOpConnectionFilter())
-                };
+                var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
+                    new HttpsConnectionFilterOptions
+                    {
+                        ServerCertificate = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword"),
+                        ClientCertificateMode = ClientCertificateMode.RequireCertificate,
+                        ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => true
+                    },
+                    new NoOpConnectionFilter())
+                );
 
                 RequestDelegate app = context =>
                 {
@@ -281,15 +273,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 #endif
 
                 var serverAddress = $"https://localhost:{TestServer.GetNextPort()}/";
-                var serviceContext = new TestServiceContext()
-                {
-                    ConnectionFilter = new HttpsConnectionFilter(
+                var serviceContext = new TestServiceContext(
+                    new HttpsConnectionFilter(
                         new HttpsConnectionFilterOptions
                         {
                             ServerCertificate = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword")
                         },
                         new NoOpConnectionFilter())
-                };
+                );
 
                 RequestDelegate app = context => context.Response.WriteAsync(context.Request.Scheme);
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerInformationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerInformationTests.cs
@@ -86,19 +86,19 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData("", false)]
-        [InlineData("false", false)]
-        [InlineData("False", false)]
-        [InlineData("true", true)]
-        [InlineData("True", true)]
-        [InlineData("Foo", false)]
-        [InlineData("FooBar", false)]
-        public void SetReuseStreamsUsingConfiguration(string input, bool expected)
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        [InlineData("0", 0)]
+        [InlineData("00", 0)]
+        [InlineData("0.0", 0)]
+        [InlineData("1", 1)]
+        [InlineData("16", 16)]
+        [InlineData("1000", 1000)]
+        public void SetMaxPooledStreamsUsingConfiguration(string input, int expected)
         {
             var values = new Dictionary<string, string>
             {
-                { "kestrel.reuseStreams", input }
+                { "kestrel.maxPooledStreams", input }
             };
 
             var configuration = new ConfigurationBuilder()
@@ -107,7 +107,33 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             var information = new KestrelServerInformation(configuration);
 
-            Assert.Equal(expected, information.ReuseStreams);
+            Assert.Equal(expected, information.PoolingParameters.MaxPooledStreams);
+        }
+
+
+        [Theory]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        [InlineData("0", 0)]
+        [InlineData("00", 0)]
+        [InlineData("0.0", 0)]
+        [InlineData("1", 1)]
+        [InlineData("16", 16)]
+        [InlineData("1000", 1000)]
+        public void SetMaxPooledHeadersUsingConfiguration(string input, int expected)
+        {
+            var values = new Dictionary<string, string>
+            {
+                { "kestrel.maxPooledHeaders", input }
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(values)
+                .Build();
+
+            var information = new KestrelServerInformation(configuration);
+
+            Assert.Equal(expected, information.PoolingParameters.MaxPooledHeaders);
         }
 
         private static int Clamp(int value, int min, int max)

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestServiceContext.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestServiceContext.cs
@@ -3,8 +3,10 @@
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel;
+using Microsoft.AspNetCore.Server.Kestrel.Filter;
 using Microsoft.AspNetCore.Server.Kestrel.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
 {
@@ -18,7 +20,16 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Log = new TestKestrelTrace();
             ThreadPool = new LoggingThreadPool(Log);
             DateHeaderValueManager = new TestDateHeaderValueManager();
-            HttpComponentFactory = new HttpComponentFactory();
+
+            var configuration = new ConfigurationBuilder().Build();
+            ServerInformation = new KestrelServerInformation(configuration);
+            HttpComponentFactory = new HttpComponentFactory(ServerInformation);
+        }
+
+        public TestServiceContext(IConnectionFilter filter)
+            : base()
+        {
+            ServerInformation.ConnectionFilter = filter;
         }
 
         public RequestDelegate App

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestServiceContext.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestServiceContext.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Log = new TestKestrelTrace();
             ThreadPool = new LoggingThreadPool(Log);
             DateHeaderValueManager = new TestDateHeaderValueManager();
+            HttpComponentFactory = new HttpComponentFactory();
         }
 
         public RequestDelegate App

--- a/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
+++ b/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             }}
                             else
                             {{
-                                throw new System.Collections.Generic.KeyNotFoundException();
+                                ThrowKeyNotFoundException();
                             }}
                         }}
                     ")}}}
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 ")}}}
             if (MaybeUnknown == null) 
             {{
-                throw new System.Collections.Generic.KeyNotFoundException();
+                ThrowKeyNotFoundException();
             }}
             return MaybeUnknown[key];
         }}
@@ -328,7 +328,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {{
                             if ({header.TestBit()})
                             {{
-                                throw new ArgumentException(""An item with the same key has already been added."");
+                                ThrowDuplicateKeyException();
                             }}
                             {header.SetBit()};
                             _{header.Identifier} = value;{(header.EnhancedSetter == false ? "" : $@"
@@ -377,14 +377,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         {{
             if (arrayIndex < 0)
             {{
-                throw new ArgumentException();
+                ThrowArgumentException();
             }}
             {Each(loop.Headers, header => $@"
                 if ({header.TestBit()}) 
                 {{
                     if (arrayIndex == array.Length)
                     {{
-                        throw new ArgumentException();
+                        ThrowArgumentException();
                     }}
 
                     array[arrayIndex] = new KeyValuePair<string, StringValues>(""{header.Name}"", _{header.Identifier});
@@ -415,6 +415,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 }}
             ")}
         }}" : "")}
+        {(loop.ClassName == "FrameRequestHeaders" ? $@"
         public unsafe void Append(byte[] keyBytes, int keyOffset, int keyLength, string value)
         {{
             fixed (byte* ptr = &keyBytes[keyOffset]) 
@@ -449,7 +450,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             StringValues existing;
             Unknown.TryGetValue(key, out existing);
             Unknown[key] = AppendValue(existing, value);
-        }}
+        }}" : "")}
         public partial struct Enumerator
         {{
             public bool MoveNext()

--- a/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
+++ b/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
@@ -366,7 +366,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             return MaybeUnknown?.Remove(key) ?? false;
         }}
         protected override void ClearFast()
-        {{
+        {{{(loop.ClassName != "FrameRequestHeaders" ? "" : Each(loop.Headers, header => $@"
+            if ({header.TestBit()}) _{header.Identifier} = default(StringValues);"))}
+
             _bits = 0;
             MaybeUnknown?.Clear();
         }}


### PR DESCRIPTION
For common header values (non-dictionary backed ones)

* `IHttpComponentFactory` controls header and stream creation, disposal
* Headers are attached at request start and detached at request end
* Streams are attached at message body start and detached at request end
* `HttpComponentFactory` implementation pools the headers, and streams *if* `ReuseStreams == true`
* Request header values are nulled before detach (User input could be of indeterminate length)
* If connection errors in-use headers & streams are not returned to pool

Faster cycling of header objects should cause the Response header values to remain in Gen0 as they are likely to be reset to a new value on each request. 

Request values are reset if they have been set

Streams are uninitialized and reinitialized with frame reference so as not to prolong its lifetime.

Also doesn't hold onto header collections or stream objects while the Frame is in a keep-alive wait.

Resolves #607
Resolves #628
Resolves https://github.com/aspnet/KestrelHttpServer/issues/629 when set > 0

Before:
![headers](http://aoa.blob.core.windows.net/aspnet/header-non-pooled.png)

With this change, setting
```
{
  "kestrel.maxPooledStreams": 128,
  "kestrel.maxPooledHeaders": 128
}
```
After memory is down by 1.4GB, headers have moved out of the top spots
![headers](http://aoa.blob.core.windows.net/aspnet/headers-pooled.png)
And instead appear quite far down
![headers](http://aoa.blob.core.windows.net/aspnet/headers-pooled-2.png)
