### PR TITLE
Consume chunked request fully

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Exceptions/BadHttpRequestException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Exceptions/BadHttpRequestException.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Exceptions
+{
+    public sealed class BadHttpRequestException : IOException
+    {
+        internal BadHttpRequestException(string message)
+            : base(message)
+        {
+
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/MessageBody.cs
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         /// </summary>
         private class ForChunkedEncoding : MessageBody
         {
-            private static Vector<byte> _vectorCRs = new Vector<byte>((byte)'\r');
+            private Vector<byte> _vectorCRs = new Vector<byte>((byte)'\r');
 
             private int _inputLength;
             private Mode _mode = Mode.Prefix;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/HttpComponentFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/HttpComponentFactory.cs
@@ -34,9 +34,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
             return streams;
         }
 
-        public void DisposeStreams(Streams streams, bool poolingPermitted)
+        public void DisposeStreams(Streams streams)
         {
-            if (poolingPermitted && _streamPool.Count < ServerInformation.PoolingParameters.MaxPooledStreams)
+            if (_streamPool.Count < ServerInformation.PoolingParameters.MaxPooledStreams)
             {
                 streams.Uninitialize();
 
@@ -58,9 +58,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
             return headers;
         }
 
-        public void DisposeHeaders(Headers headers, bool poolingPermitted)
+        public void DisposeHeaders(Headers headers)
         {
-            if (poolingPermitted && _headerPool.Count < ServerInformation.PoolingParameters.MaxPooledHeaders)
+            if (_headerPool.Count < ServerInformation.PoolingParameters.MaxPooledHeaders)
             {
                 headers.Uninitialize();
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/IHttpComponentFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/IHttpComponentFactory.cs
@@ -11,10 +11,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
 
         Streams CreateStreams(FrameContext owner);
 
-        void DisposeStreams(Streams streams, bool poolingPermitted);
+        void DisposeStreams(Streams streams);
 
         Headers CreateHeaders(DateHeaderValueManager dateValueManager);
 
-        void DisposeHeaders(Headers headers, bool poolingPermitted);
+        void DisposeHeaders(Headers headers);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/IKestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/IKestrelTrace.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Server.Kestrel.Exceptions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
 {
@@ -32,6 +33,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
         void ConnectionError(string connectionId, Exception ex);
 
         void ConnectionDisconnectedWrite(string connectionId, int count, Exception ex);
+
+        void ConnectionBadRequest(string connectionId, BadHttpRequestException ex);
 
         void NotAllConnectionsClosedGracefully();
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/KestrelTrace.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Exceptions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel
@@ -24,6 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         private static readonly Action<ILogger, string, Exception> _connectionError;
         private static readonly Action<ILogger, string, int, Exception> _connectionDisconnectedWrite;
         private static readonly Action<ILogger, Exception> _notAllConnectionsClosedGracefully;
+        private static readonly Action<ILogger, string, string, Exception> _connectionBadRequest;
 
         protected readonly ILogger _logger;
 
@@ -45,6 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             _connectionError = LoggerMessage.Define<string>(LogLevel.Information, 14, @"Connection id ""{ConnectionId}"" communication error");
             _connectionDisconnectedWrite = LoggerMessage.Define<string, int>(LogLevel.Debug, 15, @"Connection id ""{ConnectionId}"" write of ""{count}"" bytes to disconnected client.");
             _notAllConnectionsClosedGracefully = LoggerMessage.Define(LogLevel.Debug, 16, "Some connections failed to close gracefully during server shutdown.");
+            _connectionBadRequest = LoggerMessage.Define<string, string>(LogLevel.Information, 17, @"Connection id ""{ConnectionId}"" bad request data: ""{message}""");
         }
 
         public KestrelTrace(ILogger logger)
@@ -133,6 +136,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         public virtual void NotAllConnectionsClosedGracefully()
         {
             _notAllConnectionsClosedGracefully(_logger, null);
+        }
+
+        public void ConnectionBadRequest(string connectionId, BadHttpRequestException ex)
+        {
+            _connectionBadRequest(_logger, connectionId, ex.Message, ex);
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
@@ -185,7 +185,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 while (await request.Body.ReadAsync(buffer, 0, buffer.Length) != 0)
                 {
-                    // read to end
+                    ;// read to end
                 }
 
                 if (requestsReceived < requestCount)
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 while (await request.Body.ReadAsync(buffer, 0, buffer.Length) != 0)
                 {
-                    // read to end
+                    ;// read to end
                 }
 
                 if (requestsReceived < requestCount)
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        public async Task InvalidLengthResultsIn500(ServiceContext testContext)
+        public async Task InvalidLengthResultsIn400(ServiceContext testContext)
         {
             using (var server = new TestServer(async httpContext =>
             {
@@ -367,14 +367,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     "POST / HTTP/1.1",
                     "Transfer-Encoding: chunked",
                     "",
-                    "Cio",
-                    "HelloChunked",
-                    "0",
-                    "");
+                    "Cii");
 
-                    // Should really be a 40x as is bad request
                     await connection.Receive(
-                        "HTTP/1.1 500 Internal Server Error",
+                        "HTTP/1.1 400 Bad Request",
                         "");
                     await connection.ReceiveStartsWith("Date:");
                     await connection.ReceiveEnd(
@@ -388,7 +384,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        public async Task InvalidSizedDataResultsIn500(ServiceContext testContext)
+        public async Task InvalidSizedDataResultsIn400(ServiceContext testContext)
         {
             using (var server = new TestServer(async httpContext =>
             {
@@ -415,13 +411,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "Transfer-Encoding: chunked",
                         "",
                         "C",
-                        "HelloChunkedInvalid",
-                        "0",
-                        "");
+                        "HelloChunkedIn");
 
-                    // Should really be a 40x as is bad request
                     await connection.Receive(
-                        "HTTP/1.1 500 Internal Server Error",
+                        "HTTP/1.1 400 Bad Request",
                         "");
                     await connection.ReceiveStartsWith("Date:");
                     await connection.ReceiveEnd(

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
@@ -1,18 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel;
-using Microsoft.AspNetCore.Server.Kestrel.Filter;
-using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -435,41 +430,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "",
                         "");
                 }
-            }
-        }
-
-        private class TestApplicationErrorLogger : ILogger
-        {
-            // Application errors are logged using 13 as the eventId.
-            private const int ApplicationErrorEventId = 13;
-
-            public int ApplicationErrorsLogged { get; set; }
-
-            public IDisposable BeginScopeImpl(object state)
-            {
-                return new Disposable(() => { });
-            }
-
-            public bool IsEnabled(LogLevel logLevel)
-            {
-                return true;
-            }
-
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-            {
-                if (eventId.Id == ApplicationErrorEventId)
-                {
-                    ApplicationErrorsLogged++;
-                }
-            }
-        }
-
-        private class PassThroughConnectionFilter : IConnectionFilter
-        {
-            public Task OnConnectionAsync(ConnectionFilterContext context)
-            {
-                context.Connection = new LoggingStream(context.Connection, new TestApplicationErrorLogger());
-                return TaskUtilities.CompletedTask;
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
@@ -1,0 +1,288 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel;
+using Microsoft.AspNetCore.Server.Kestrel.Filter;
+using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
+using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.KestrelTests
+{
+    public class ChunkedRequestTests
+    {
+        public static TheoryData<ServiceContext> ConnectionFilterData
+        {
+            get
+            {
+                return new TheoryData<ServiceContext>
+                {
+                    {
+                        new TestServiceContext()
+                    },
+                    {
+                        new TestServiceContext(new PassThroughConnectionFilter())
+                    }
+                };
+            }
+        }
+
+        private async Task App(HttpContext httpContext)
+        {
+            var request = httpContext.Request;
+            var response = httpContext.Response;
+            response.Headers.Clear();
+            while (true)
+            {
+                var buffer = new byte[8192];
+                var count = await request.Body.ReadAsync(buffer, 0, buffer.Length);
+                if (count == 0)
+                {
+                    break;
+                }
+                await response.Body.WriteAsync(buffer, 0, count);
+            }
+        }
+
+        private async Task AppChunked(HttpContext httpContext)
+        {
+            var request = httpContext.Request;
+            var response = httpContext.Response;
+            var data = new MemoryStream();
+            await request.Body.CopyToAsync(data);
+            var bytes = data.ToArray();
+
+            response.Headers.Clear();
+            response.Headers["Content-Length"] = bytes.Length.ToString();
+            await response.Body.WriteAsync(bytes, 0, bytes.Length);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(ConnectionFilterData))]
+        public async Task Http10TransferEncoding(ServiceContext testContext)
+        {
+            using (var server = new TestServer(App, testContext))
+            {
+                using (var connection = new TestConnection(server.Port))
+                {
+                    await connection.SendEnd(
+                        "POST / HTTP/1.0",
+                        "Transfer-Encoding: chunked",
+                        "",
+                        "5", "Hello",
+                        "6", " World",
+                        "0",
+                         "");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.0 200 OK",
+                        "",
+                        "Hello World");
+                }
+            }
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(ConnectionFilterData))]
+        public async Task Http10KeepAliveTransferEncoding(ServiceContext testContext)
+        {
+            using (var server = new TestServer(AppChunked, testContext))
+            {
+                using (var connection = new TestConnection(server.Port))
+                {
+                    await connection.SendEnd(
+                        "POST / HTTP/1.0",
+                        "Transfer-Encoding: chunked",
+                        "Connection: keep-alive",
+                        "",
+                        "5", "Hello",
+                        "6", " World",
+                        "0",
+                         "",
+                        "POST / HTTP/1.0",
+                        "",
+                        "Goodbye");
+                    await connection.Receive(
+                        "HTTP/1.0 200 OK",
+                        "Connection: keep-alive",
+                        "Content-Length: 11",
+                        "",
+                        "Hello World");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.0 200 OK",
+                        "Content-Length: 7",
+                        "",
+                        "Goodbye");
+                }
+            }
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(ConnectionFilterData))]
+        public async Task RequestBodyIsConsumedAutomaticallyIfAppDoesntConsumeItFully(ServiceContext testContext)
+        {
+            using (var server = new TestServer(async httpContext =>
+            {
+                var response = httpContext.Response;
+                var request = httpContext.Request;
+
+                Assert.Equal("POST", request.Method);
+
+                response.Headers.Clear();
+                response.Headers["Content-Length"] = new[] { "11" };
+
+                await response.Body.WriteAsync(Encoding.ASCII.GetBytes("Hello World"), 0, 11);
+            }, testContext))
+            {
+                using (var connection = new TestConnection(server.Port))
+                {
+                    await connection.SendEnd(
+                        "POST / HTTP/1.1",
+                        "Content-Length: 5",
+                        "",
+                        "HelloPOST / HTTP/1.1",
+                        "Transfer-Encoding: chunked",
+                        "",
+                        "C", "HelloChunked",
+                        "0",
+                        "",
+                        "POST / HTTP/1.1",
+                        "Content-Length: 7",
+                        "",
+                        "Goodbye");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 200 OK",
+                        "Content-Length: 11",
+                        "",
+                        "Hello WorldHTTP/1.1 200 OK",
+                        "Content-Length: 11",
+                        "",
+                        "Hello WorldHTTP/1.1 200 OK",
+                        "Content-Length: 11",
+                        "",
+                        "Hello World");
+                }
+            }
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(ConnectionFilterData))]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        public async Task TrailingHeadersAreParsed(ServiceContext testContext)
+        {
+            var requestCount = 10;
+            var requestsReceived = 0;
+
+            using (var server = new TestServer(async httpContext =>
+            {
+                var response = httpContext.Response;
+                var request = httpContext.Request;
+
+                var buffer = new byte[200];
+
+                Assert.Equal(string.Empty, request.Headers["X-Trailer-Header"]);
+
+                while(await request.Body.ReadAsync(buffer, 0, buffer.Length) != 0)
+                {
+                    // read to end
+                }
+
+                if (requestsReceived < requestCount)
+                {
+                    Assert.Equal(new string('a', requestsReceived), request.Headers["X-Trailer-Header"]);
+                }
+                else
+                {
+                    Assert.Equal(string.Empty, request.Headers["X-Trailer-Header"]);
+                }
+
+                requestsReceived++;
+
+                response.Headers.Clear();
+                response.Headers["Content-Length"] = new[] { "11" };
+
+                await response.Body.WriteAsync(Encoding.ASCII.GetBytes("Hello World"), 0, 11);
+            }, testContext))
+            {
+                var response = string.Join("\r\n", new string[] {
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: 11",
+                    "",
+                    "Hello World"});
+
+                var expectedFullResponse = string.Join("", Enumerable.Repeat(response, requestCount + 1));
+
+                using (var connection = new TestConnection(server.Port))
+                {
+                    await connection.Send(
+                        "POST / HTTP/1.1",
+                        "Transfer-Encoding: chunked",
+                        "",
+                        "C", "HelloChunked",
+                        "0",
+                        "");
+
+                    for (var i = 1; i < requestCount; i++)
+                    {
+                        await connection.Send(
+                            "POST / HTTP/1.1",
+                            "Transfer-Encoding: chunked",
+                            "",
+                            "C", "HelloChunked",
+                            "0",
+                            string.Concat("X-Trailer-Header", new string('a', i)),
+                            "");
+                    }
+
+                    await connection.SendEnd(
+                        "POST / HTTP/1.1",
+                        "Content-Length: 7",
+                        "",
+                        "Goodbye");
+
+                    await connection.ReceiveEnd(expectedFullResponse);
+                }
+            }
+        }
+
+        private class TestApplicationErrorLogger : ILogger
+        {
+            public int ApplicationErrorsLogged { get; set; }
+
+            public IDisposable BeginScopeImpl(object state)
+            {
+                return new Disposable(() => { });
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                // Application errors are logged using 13 as the eventId.
+                if (eventId.Id == 13)
+                {
+                    ApplicationErrorsLogged++;
+                }
+            }
+        }
+
+        private class PassThroughConnectionFilter : IConnectionFilter
+        {
+            public Task OnConnectionAsync(ConnectionFilterContext context)
+            {
+                context.Connection = new LoggingStream(context.Connection, new TestApplicationErrorLogger());
+                return TaskUtilities.CompletedTask;
+            }
+        }
+    }
+}
+

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
@@ -290,11 +290,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = new TestConnection(server.Port))
                 {
-                    await connection.Send(
+                    await connection.SendEnd(
                         "POST / HTTP/1.0",
                         "Transfer-Encoding: chunked",
                         "",
-                        "5", "Hello", "6", " World", "0\r\n");
+                        "5", "Hello", 
+                        "6", " World",
+                        "0",
+                         "");
                     await connection.ReceiveEnd(
                         "HTTP/1.0 200 OK",
                         "",
@@ -406,7 +409,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "Transfer-Encoding: chunked",
                         "Connection: keep-alive",
                         "",
-                        "5", "Hello", "6", " World", "0",
+                        "5", "Hello", 
+                        "6", " World", 
+                        "0",
+                         "",
                         "POST / HTTP/1.0",
                         "",
                         "Goodbye");
@@ -969,7 +975,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "HelloPOST / HTTP/1.1",
                         "Transfer-Encoding: chunked",
                         "",
-                        "C", "HelloChunked", "0",
+                        "C", "HelloChunked", 
+                        "0",
+                        "",
                         "POST / HTTP/1.1",
                         "Content-Length: 7",
                         "",

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -12,11 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel;
-using Microsoft.AspNetCore.Server.Kestrel.Filter;
-using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
-using Microsoft.AspNetCore.Server.Kestrel.Networking;
-using Microsoft.AspNetCore.Testing.xunit;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -1022,39 +1016,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 await Assert.ThrowsAsync<TaskCanceledException>(async () => await writeTcs.Task);
                 // RequestAborted tripped
                 Assert.True(registrationWh.Wait(1000));
-            }
-        }
-
-        private class TestApplicationErrorLogger : ILogger
-        {
-            public int ApplicationErrorsLogged { get; set; }
-
-            public IDisposable BeginScopeImpl(object state)
-            {
-                return new Disposable(() => { });
-            }
-
-            public bool IsEnabled(LogLevel logLevel)
-            {
-                return true;
-            }
-
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-            {
-                // Application errors are logged using 13 as the eventId.
-                if (eventId.Id == 13)
-                {
-                    ApplicationErrorsLogged++;
-                }
-            }
-        }
-
-        private class PassThroughConnectionFilter : IConnectionFilter
-        {
-            public Task OnConnectionAsync(ConnectionFilterContext context)
-            {
-                context.Connection = new LoggingStream(context.Connection, new TestApplicationErrorLogger());
-                return TaskUtilities.CompletedTask;
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -29,12 +29,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool2())
             using (var socketInput = new SocketInput(pool, ltp))
             {
+                var connectionContext = new ConnectionContext()
+                {
+                    DateHeaderValueManager = new DateHeaderValueManager(),
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var frame = new Frame<object>(application: null, context: connectionContext);
                 var headerCollection = new FrameRequestHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
                 socketInput.IncomingData(headerArray, 0, headerArray.Length);
 
-                var success = Frame.TakeMessageHeaders(socketInput, headerCollection);
+                var success = frame.TakeMessageHeaders(socketInput, headerCollection);
 
                 Assert.True(success);
                 Assert.Equal(numHeaders, headerCollection.Count());

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/PassThroughConnectionFilter.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/PassThroughConnectionFilter.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Filter;
+using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
+
+namespace Microsoft.AspNetCore.Server.KestrelTests
+{
+
+    public class PassThroughConnectionFilter : IConnectionFilter
+    {
+        public Task OnConnectionAsync(ConnectionFilterContext context)
+        {
+            context.Connection = new LoggingStream(context.Connection, new TestApplicationErrorLogger());
+            return TaskUtilities.CompletedTask;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/TestApplicationErrorLogger.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/TestApplicationErrorLogger.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Server.Kestrel;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.KestrelTests
+{
+    public class TestApplicationErrorLogger : ILogger
+    {
+        // Application errors are logged using 13 as the eventId.
+        private const int ApplicationErrorEventId = 13;
+
+        public int ApplicationErrorsLogged { get; set; }
+
+        public IDisposable BeginScopeImpl(object state)
+        {
+            return new Disposable(() => { });
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (eventId.Id == ApplicationErrorEventId)
+            {
+                ApplicationErrorsLogged++;
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
@@ -18,17 +18,20 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var trace = new KestrelTrace(new TestKestrelTrace());
             var ltp = new LoggingThreadPool(trace);
-            FrameContext = new FrameContext
+            var context = new FrameContext()
             {
+                DateHeaderValueManager = new DateHeaderValueManager(),
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                 ConnectionControl = this,
                 FrameControl = this
             };
+            FrameContext = new Frame<object>(null, context);
 
             _memoryPool = new MemoryPool2();
             FrameContext.SocketInput = new SocketInput(_memoryPool, ltp);
         }
 
-        public FrameContext FrameContext { get; set; }
+        public Frame FrameContext { get; set; }
 
         public void Add(string text, bool fin = false)
         {


### PR DESCRIPTION
Chunked requests have an extra `\r\n` at end

```
5\r\n
Hello\r\n
6\r\n
World\r\n
0\r\n
... Trailer headers ...
\r\n
```

Resolves #617

@Tratcher is this correct?

/cc @cesarbs @halter73 

Please note changes in tests