### PR TITLE
Enabling Kestrel on OSx Mono when not running with dnx

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Networking/Libuv.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Networking/Libuv.cs
@@ -12,9 +12,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Networking
         {
             IsWindows = PlatformApis.IsWindows;
 
-            var isDarwinMono = PlatformApis.IsDarwin && PlatformApis.IsMono;
+            var isDnxDarwinMono =
+#if NET451
+                PlatformApis.IsDarwin && PlatformApis.IsMono && AppDomain.CurrentDomain.GetData("DNX_SERVICEPROVIDER") != null;
+#else
+                false;
+#endif
 
-            if (isDarwinMono)
+            if (isDnxDarwinMono)
             {
                 _uv_loop_init = NativeDarwinMonoMethods.uv_loop_init;
                 _uv_loop_close = NativeDarwinMonoMethods.uv_loop_close;


### PR DESCRIPTION
Before moving to dotnet dnx on OSx on Mono would load libuv.dll into the process and Kestrel would use DllImport with __Internal to import functions from the native libraries loaded into the Mono process. With the move to dotnet nothing is preloading libuv to the process so Kestrel must no longer use DllImports with __Internal but the regular ones. Mono seems to load native libraries from the app folder so, the user won't have to install libuv on their own since libuv.dylib is published with the app.