### PR TITLE
NonCovariant array based data stuctures

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Listener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Listener.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                             var writeReqPool = socket.WriteReqPool;
                             while (writeReqPool.Count > 0)
                             {
-                                writeReqPool.Dequeue().Dispose();
+                                writeReqPool.Dequeue().Reference.Dispose();
                             }
 
                             tcs2.SetResult(0);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/ListenerContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/ListenerContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             : base(serviceContext)
         {
             Memory2 = new MemoryPool2();
-            WriteReqPool = new Queue<UvWriteReq>(SocketOutput.MaxPooledWriteReqs);
+            WriteReqPool = new Queue<NonCovariant<UvWriteReq>>(SocketOutput.MaxPooledWriteReqs);
         }
 
         public ListenerContext(ListenerContext listenerContext)
@@ -37,6 +37,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 
         public MemoryPool2 Memory2 { get; set; }
 
-        public Queue<UvWriteReq> WriteReqPool { get; set; }
+        public Queue<NonCovariant<UvWriteReq>> WriteReqPool { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/SocketOutput.cs
@@ -50,8 +50,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         private Exception _lastWriteError;
         private WriteContext _nextWriteContext;
         private readonly Queue<WaitingTask> _tasksPending;
-        private readonly Queue<WriteContext> _writeContextPool;
-        private readonly Queue<UvWriteReq> _writeReqPool;
+        private readonly Queue<NonCovariant<WriteContext>> _writeContextPool;
+        private readonly Queue<NonCovariant<UvWriteReq>> _writeReqPool;
 
         public SocketOutput(
             KestrelThread thread,
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             long connectionId,
             IKestrelTrace log,
             IThreadPool threadPool,
-            Queue<UvWriteReq> writeReqPool)
+            Queue<NonCovariant<UvWriteReq>> writeReqPool)
         {
             _thread = thread;
             _socket = socket;
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             _log = log;
             _threadPool = threadPool;
             _tasksPending = new Queue<WaitingTask>(_initialTaskQueues);
-            _writeContextPool = new Queue<WriteContext>(_maxPooledWriteContexts);
+            _writeContextPool = new Queue<NonCovariant<WriteContext>>(_maxPooledWriteContexts);
             _writeReqPool = writeReqPool;
 
             _head = memory.Lease();

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/MemoryPool2.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/MemoryPool2.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
         /// Thread-safe collection of blocks which are currently in the pool. A slab will pre-allocate all of the block tracking objects
         /// and add them to this collection. When memory is requested it is taken from here first, and when it is returned it is re-added.
         /// </summary>
-        private readonly ConcurrentQueue<MemoryPoolBlock2> _blocks = new ConcurrentQueue<MemoryPoolBlock2>();
+        private readonly ConcurrentQueue<NonCovariant<MemoryPoolBlock2>> _blocks = new ConcurrentQueue<NonCovariant<MemoryPoolBlock2>>();
 
         /// <summary>
         /// Thread-safe collection of slabs which have been allocated by this pool. As long as a slab is in this collection and slab.IsActive, 
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
                     slab: null);
             }
 
-            MemoryPoolBlock2 block;
+            NonCovariant<MemoryPoolBlock2> block;
             if (_blocks.TryDequeue(out block))
             {
                 // block successfully taken from the stack - return it

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/NonCovariant.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/NonCovariant.cs
@@ -1,0 +1,31 @@
+﻿
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
+{
+    /// <summary>
+    /// A simple struct to wrap reference types inside when storing in arrays 
+    /// or data structures based on arrays to bypass the CLR's covariant checks when writing to arrays.
+    /// See http://codeblog.jonskeet.uk/2013/06/22/array-covariance-not-just-ugly-but-slow-too/
+    /// Uses https://github.com/dotnet/corefx/blob/master/src/System.Collections.Immutable/src/System/Collections/Immutable/RefAsValueType.cs
+    /// and https://github.com/dotnet/corefxlab/issues/614#issuecomment-184892677
+    /// </summary>
+    public struct NonCovariant<T> where T : class
+    {
+        public readonly T Reference;
+
+        private NonCovariant(T value)
+        {
+            this.Reference = value;
+        }
+
+        public static implicit operator NonCovariant<T>(T value)
+        {
+            return new NonCovariant<T>(value);
+        }
+
+        public static implicit operator T(NonCovariant<T> value)
+        {
+            return value.Reference;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<NonCovariant<UvWriteReq>>());
 
                 // I doubt _maxBytesPreCompleted will ever be over a MB. If it is, we should change this test.
                 var bufferSize = 1048576;
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<NonCovariant<UvWriteReq>>());
 
                 var bufferSize = maxBytesPreCompleted;
                 var buffer = new ArraySegment<byte>(new byte[bufferSize], 0, bufferSize);
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<NonCovariant<UvWriteReq>>());
 
                 var bufferSize = maxBytesPreCompleted / 2;
                 var data = new byte[bufferSize];
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                ISocketOutput socketOutput = new SocketOutput(kestrelThread, socket, memory, new MockConnection(socket), 0, trace, ltp, new Queue<UvWriteReq>());
+                ISocketOutput socketOutput = new SocketOutput(kestrelThread, socket, memory, new MockConnection(socket), 0, trace, ltp, new Queue<NonCovariant<UvWriteReq>>());
 
                 var bufferSize = maxBytesPreCompleted;
 
@@ -313,7 +313,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 var mockConnection = new MockConnection(socket);
                 mockConnection.RequestAbortedSource = abortedSource;
-                ISocketOutput socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, 0, trace, ltp, new Queue<UvWriteReq>());
+                ISocketOutput socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, 0, trace, ltp, new Queue<NonCovariant<UvWriteReq>>());
 
                 var bufferSize = maxBytesPreCompleted;
 
@@ -387,7 +387,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<NonCovariant<UvWriteReq>>());
 
                 var bufferSize = maxBytesPreCompleted;
                 var buffer = new ArraySegment<byte>(new byte[bufferSize], 0, bufferSize);
@@ -464,7 +464,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, memory, null, 0, trace, ltp, new Queue<NonCovariant<UvWriteReq>>());
 
                 // block 1
                 var start = socketOutput.ProducingStart();


### PR DESCRIPTION
Arrays of ref types slower than arrays of structs

Use structs for array-based datastuctures, List, Queue, ConcurrentQueue in hot paths

See http://codeblog.jonskeet.uk/2013/06/22/array-covariance-not-just-ugly-but-slow-too/

Corefx use https://github.com/dotnet/corefx/blob/master/src/System.Collections.Immutable/src/System/Collections/Immutable/RefAsValueType.cs

Some places already use structs like KestrelThread

Comment https://github.com/dotnet/corefxlab/issues/614#issuecomment-184892677