### PR TITLE
[Do not merge] CI Test

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
+    <add key="DotNetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="DotNetCli" value="https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json" />
+    <add key="AspNetVolatile" value="https://www.myget.org/F/aspnetvolatiledev/api/v3/index.json" />
     <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,5 +5,3 @@ build_script:
 clone_depth: 1
 test: off
 deploy: off
-environment:
-  NO_PARALLEL_TEST_PROJECTS: Microsoft.AspNetCore.Server.Kestrel.FunctionalTests

--- a/src/Microsoft.AspNetCore.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/project.json
@@ -35,7 +35,7 @@
         "System.Diagnostics.Tracing": "4.1.0-*",
         "System.Globalization": "4.0.11-*",
         "System.IO": "4.1.0-*",
-        "System.Linq": "4.0.2-*",
+        "System.Linq": "4.1.0-*",
         "System.Net.Primitives": "4.0.11-*",
         "System.Runtime.Extensions": "4.1.0-*",
         "System.Runtime.InteropServices": "4.1.0-*",

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -16,15 +16,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class AddressRegistrationTests
     {
-        [ConditionalTheory, MemberData(nameof(AddressRegistrationDataIPv4))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Theory, MemberData(nameof(AddressRegistrationDataIPv4))]
         public async Task RegisterAddresses_IPv4_Success(string addressInput, string[] testUrls)
         {
             await RegisterAddresses_Success(addressInput, testUrls);
         }
 
         [ConditionalTheory, MemberData(nameof(AddressRegistrationDataIPv6))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         [IPv6SupportedCondition]
         public async Task RegisterAddresses_IPv6_Success(string addressInput, string[] testUrls)
         {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/PathBaseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/PathBaseTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class PathBaseTests
     {
-        [ConditionalTheory]
+        [Theory]
         [InlineData("/base", "/base", "/base", "")]
         [InlineData("/base", "/base/", "/base", "/")]
         [InlineData("/base", "/base/something", "/base", "/something")]
@@ -25,13 +24,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [InlineData("/base/more", "/base/more", "/base/more", "")]
         [InlineData("/base/more", "/base/more/something", "/base/more", "/something")]
         [InlineData("/base/more", "/base/more/something/", "/base/more", "/something/")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public Task RequestPathBaseIsServerPathBase(string registerPathBase, string requestPath, string expectedPathBase, string expectedPath)
         {
             return TestPathBase(registerPathBase, requestPath, expectedPathBase, expectedPath);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [InlineData("", "/", "", "/")]
         [InlineData("", "/something", "", "/something")]
         [InlineData("/", "/", "", "/")]
@@ -40,33 +38,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [InlineData("/base", "/baseandsomething", "", "/baseandsomething")]
         [InlineData("/base", "/ba", "", "/ba")]
         [InlineData("/base", "/ba/se", "", "/ba/se")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public Task DefaultPathBaseIsEmpty(string registerPathBase, string requestPath, string expectedPathBase, string expectedPath)
         {
             return TestPathBase(registerPathBase, requestPath, expectedPathBase, expectedPath);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [InlineData("", "/", "", "/")]
         [InlineData("/", "/", "", "/")]
         [InlineData("/base", "/base/", "/base", "/")]
         [InlineData("/base/", "/base", "/base", "")]
         [InlineData("/base/", "/base/", "/base", "/")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public Task PathBaseNeverEndsWithSlash(string registerPathBase, string requestPath, string expectedPathBase, string expectedPath)
         {
             return TestPathBase(registerPathBase, requestPath, expectedPathBase, expectedPath);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public Task PathBaseAndPathPreserveRequestCasing()
         {
             return TestPathBase("/base", "/Base/Something", "/Base", "/Something");
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public Task PathBaseCanHaveUTF8Characters()
         {
             return TestPathBase("/b♫se", "/b♫se/something", "/b♫se", "/something");

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
-        public async Task RequestPathIsNormalized()
+        public void RequestPathIsNormalized()
         {
             var port = PortManager.GetPort();
             var config = new ConfigurationBuilder().AddInMemoryCollection(

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -21,8 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class RequestTests
     {
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task LargeUpload()
         {
             var port = PortManager.GetPort();
@@ -78,25 +77,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [InlineData("127.0.0.1", "127.0.0.1")]
         [InlineData("localhost", "127.0.0.1")]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public Task RemoteIPv4Address(string requestAddress, string expectAddress)
         {
             return TestRemoteIPAddress("localhost", requestAddress, expectAddress);
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         [IPv6SupportedCondition]
         public Task RemoteIPv6Address()
         {
             return TestRemoteIPAddress("[::1]", "[::1]", "::1");
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task DoesNotHangOnConnectionCloseRequest()
         {
             var port = PortManager.GetPort();
@@ -130,8 +126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public void RequestPathIsNormalized()
         {
             var port = PortManager.GetPort();

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -19,8 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class ResponseTests
     {
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on mono.")]
+        [Fact]
         public async Task LargeDownload()
         {
             var port = PortManager.GetPort();
@@ -80,8 +79,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [ConditionalTheory, MemberData(nameof(NullHeaderData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on mono.")]
+        [Theory, MemberData(nameof(NullHeaderData))]
         public async Task IgnoreNullHeaderValues(string headerName, StringValues headerValue, string expectedValue)
         {
             var port = PortManager.GetPort();
@@ -129,8 +127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on mono.")]
+        [Fact]
         public async Task OnCompleteCalledEvenWhenOnStartingNotCalled()
         {
             var port = PortManager.GetPort();

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
@@ -5,19 +5,22 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Testing": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*",
-    "System.Net.Http": "4.0.1-*",
     "xunit": "2.1.0"
   },
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-dev-*",
+        "System.Net.Http": "4.0.1-*"
       },
       "imports": "portable-net451+win8"
     },
     "dnx451": {
       "dependencies": {
         "xunit.runner.console": "2.1.0"
+      },
+      "frameworkAssemblies": {
+        "System.Net.Http": "4.0.0.0"
       }
     }
   },

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedResponseTests.cs
@@ -5,15 +5,13 @@ using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
 {
     public class ChunkedResponseTests
     {
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task ResponsesAreChunkedAutomatically()
         {
             using (var server = new TestServer(async httpContext =>
@@ -45,8 +43,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task ZeroLengthWritesAreIgnored()
         {
             using (var server = new TestServer(async httpContext =>
@@ -79,8 +76,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task EmptyResponseBodyHandledCorrectlyWithZeroLengthWrite()
         {
             using (var server = new TestServer(async httpContext =>
@@ -107,8 +103,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task ConnectionClosedIfExeptionThrownAfterWrite()
         {
             using (var server = new TestServer(async httpContext =>
@@ -138,8 +133,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task ConnectionClosedIfExeptionThrownAfterZeroLengthWrite()
         {
             using (var server = new TestServer(async httpContext =>
@@ -168,8 +162,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task WritesAreFlushedPriorToResponseCompletion()
         {
             var flushWh = new ManualResetEventSlim();

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionFilterTests.cs
@@ -5,9 +5,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Filter;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -31,8 +29,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task CanReadAndWriteWithRewritingConnectionFilter()
         {
             var filter = new RewritingConnectionFilter();
@@ -58,8 +55,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Assert.Equal(sendString.Length, filter.BytesRead);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task CanReadAndWriteWithAsyncConnectionFilter()
         {
             var serviceContext = new TestServiceContext()
@@ -83,8 +79,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
+        [Fact]
         public async Task ThrowingSynchronousConnectionFilterDoesNotCrashServer()
         {
             var serviceContext = new TestServiceContext()

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Filter;
 using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
-using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -80,9 +79,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             return Task.FromResult<object>(null);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public void EngineCanStartAndStop(ServiceContext testContext)
         {
             var engine = new KestrelEngine(testContext);
@@ -90,9 +88,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             engine.Dispose();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public void ListenerCanCreateAndDispose(TestServiceContext testContext)
         {
             testContext.App = App;
@@ -104,9 +101,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             engine.Dispose();
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public void ConnectionCanReadAndWrite(TestServiceContext testContext)
         {
             var port = TestServer.GetNextPort();
@@ -133,9 +129,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -155,9 +150,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http11(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -184,7 +178,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
         public async Task ReuseStreamsOn(ServiceContext testContext)
         {
@@ -227,7 +221,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
         public async Task ReuseStreamsOff(ServiceContext testContext)
         {
@@ -270,9 +264,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10ContentLength(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -292,9 +285,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10TransferEncoding(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -314,9 +306,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10KeepAlive(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -344,9 +335,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10KeepAliveNotUsedIfResponseContentLengthNotSet(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -375,9 +365,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10KeepAliveContentLength(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -407,9 +396,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Http10KeepAliveTransferEncoding(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -440,9 +428,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task Expect100ContinueForBody(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -467,9 +454,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task DisconnectingClient(ServiceContext testContext)
         {
             using (var server = new TestServer(App, testContext))
@@ -492,9 +478,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ZeroContentLengthSetAutomaticallyAfterNoWrites(ServiceContext testContext)
         {
             using (var server = new TestServer(EmptyApp, testContext))
@@ -521,9 +506,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ZeroContentLengthNotSetAutomaticallyForNonKeepAliveRequests(ServiceContext testContext)
         {
             using (var server = new TestServer(EmptyApp, testContext))
@@ -556,9 +540,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ZeroContentLengthNotSetAutomaticallyForHeadRequests(ServiceContext testContext)
         {
             using (var server = new TestServer(EmptyApp, testContext))
@@ -577,9 +560,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ZeroContentLengthNotSetAutomaticallyForCertainStatusCodes(ServiceContext testContext)
         {
             using (var server = new TestServer(async httpContext =>
@@ -631,9 +613,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingResultsIn500Response(ServiceContext testContext)
         {
             bool onStartingCalled = false;
@@ -690,9 +671,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingAfterWritingKillsConnection(ServiceContext testContext)
         {
             bool onStartingCalled = false;
@@ -733,9 +713,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingAfterPartialWriteKillsConnection(ServiceContext testContext)
         {
             bool onStartingCalled = false;
@@ -776,9 +755,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ConnectionClosesWhenFinReceived(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -804,9 +782,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ConnectionClosesWhenFinReceivedBeforeRequestCompletes(ServiceContext testContext)
         {
             using (var server = new TestServer(AppChunked, testContext))
@@ -847,9 +824,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingInOnStartingResultsInFailedWritesAnd500Response(ServiceContext testContext)
         {
             var onStartingCallCount1 = 0;
@@ -921,9 +897,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task ThrowingInOnCompletedIsLoggedAndClosesConnection(ServiceContext testContext)
         {
             var onCompletedCalled1 = false;
@@ -972,9 +947,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task RequestBodyIsConsumedAutomaticallyIfAppDoesntConsumeItFully(ServiceContext testContext)
         {
             using (var server = new TestServer(async httpContext =>
@@ -1019,9 +993,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task RequestsCanBeAbortedMidRead(ServiceContext testContext)
         {
             var readTcs = new TaskCompletionSource<object>();
@@ -1092,9 +1065,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Assert.Equal(2, abortedRequestId);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Test hangs after execution on Mono.")]
         public async Task FailedWritesResultInAbortedRequest(ServiceContext testContext)
         {
             // This should match _maxBytesPreCompleted in SocketOutput

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/project.json
@@ -5,7 +5,6 @@
     "Microsoft.AspNetCore.Server.Kestrel.Https": "1.0.0-*",
     "Microsoft.AspNetCore.Testing": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*",
-    "System.Net.Http": "4.0.1-*",
     "xunit": "2.1.0"
   },
   "frameworks": {
@@ -17,13 +16,17 @@
         "System.Net.Http.WinHttpHandler": "4.0.0-*",
         "System.Net.Sockets": "4.1.0-*",
         "System.Runtime.Handles": "4.0.1-*",
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-dev-*",
+        "System.Net.Http": "4.0.1-*"
       },
       "imports": "portable-net451+win8"
     },
     "dnx451": {
       "dependencies": {
         "xunit.runner.console": "2.1.0"
+      },
+      "frameworkAssemblies": {
+        "System.Net.Http": "4.0.0.0"
       }
     }
   },


### PR DESCRIPTION
This is #635 with updated feeds

3 out of 4 runs fails with `Exit Code 139` on linux  https://github.com/dotnet/coreclr/issues/3101
Generates `warning NU1006: Dependencies in project.json were modified`

Otherwise its green and no hangs, even enabled the disabled mono tests! (though should use #635)

/cc @cesarbs @halter73 