### PR TITLE
Don't reference facades in NuSpec

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/project.json
@@ -28,7 +28,7 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Threading.Tasks": ""
+        "System.Threading.Tasks": { "type": "build" }
       }
     },
     "netstandard1.3": {


### PR DESCRIPTION
These can be removed entirely after dotnet/cli#164