### PR TITLE
Fix race preventing handling of the last request sent over a connection

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameOfT.cs
@@ -37,8 +37,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                     {
                         if (SocketInput.RemoteIntakeFin)
                         {
+                            if (TakeStartLine(SocketInput))
+                            {
+                                break;
+                            }
+
                             return;
                         }
+
                         await SocketInput;
                     }
 
@@ -48,8 +54,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                     {
                         if (SocketInput.RemoteIntakeFin)
                         {
+                            if (TakeMessageHeaders(SocketInput, FrameRequestHeaders))
+                            {
+                                break;
+                            }
+
                             return;
                         }
+
                         await SocketInput;
                     }
 


### PR DESCRIPTION
We need to attempt to consume start lines and headers even after
SocketInput.RemoteIntakeFin is set to true to ensure we don't close a
connection without giving the application a chance to respond to a request
sent immediately before the a FIN from the client.

Fixes #704