### PR TITLE
Add UseKestrel() extension method to IWebHostBuilder (#713)

### DIFF
--- a/samples/LargeResponseApp/Startup.cs
+++ b/samples/LargeResponseApp/Startup.cs
@@ -41,6 +41,8 @@ namespace LargeResponseApp
         {
             var host = new WebHostBuilder()
                 .UseDefaultHostingConfiguration(args)
+                .UseKestrel()
+                .UseUrls("http://localhost:5001/")
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>()
                 .Build();

--- a/samples/LargeResponseApp/hosting.json
+++ b/samples/LargeResponseApp/hosting.json
@@ -1,4 +1,0 @@
-{
-  "server": "Microsoft.AspNetCore.Server.Kestrel",
-  "server.urls": "http://localhost:5001/"
-}

--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -63,6 +63,8 @@ namespace SampleApp
         {
             var host = new WebHostBuilder()
                 .UseDefaultHostingConfiguration(args)
+                .UseKestrel()
+                .UseUrls("http://localhost:5000", "https://localhost:5001")
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>()
                 .Build();

--- a/samples/SampleApp/hosting.json
+++ b/samples/SampleApp/hosting.json
@@ -1,4 +1,0 @@
-{
-  "server": "Microsoft.AspNetCore.Server.Kestrel",
-  "server.urls": "http://localhost:5000;https://localhost:5001"
-}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelWebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelWebHostBuilderExtensions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Server.Kestrel;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    public static class KestrelWebHostBuilderExtensions
+    {
+        public static IWebHostBuilder UseKestrel(this IWebHostBuilder hostBuilder)
+        {
+            return hostBuilder.UseServer(typeof(KestrelServer).GetTypeInfo().Assembly.FullName);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             var hostBuilder = new WebHostBuilder()
                 .UseConfiguration(config)
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .Configure(ConfigureEchoAddress);
 
             using (var host = hostBuilder.Build())

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/PathBaseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/PathBaseTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             var builder = new WebHostBuilder()
                 .UseConfiguration(config)
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .Configure(app =>
                 {
                     app.Run(async context =>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             var port = PortManager.GetPort();
             var builder = new WebHostBuilder()
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .UseUrls($"http://localhost:{port}/")
                 .Configure(app =>
                 {
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             var port = PortManager.GetPort();
             var builder = new WebHostBuilder()
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .UseUrls($"http://localhost:{port}/")
                 .Configure(app =>
                 {
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             var port = PortManager.GetPort();
             var builder = new WebHostBuilder()
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .UseUrls($"http://localhost:{port}")
                 .Configure(app =>
                 {
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             var port = PortManager.GetPort();
             var builder = new WebHostBuilder()
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .UseUrls($"http://localhost:{port}/\u0041\u030A")
                 .Configure(app =>
                 {
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             var port = PortManager.GetPort();
             var builder = new WebHostBuilder()
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .UseUrls($"http://{registerAddress}:{port}")
                 .Configure(app =>
                 {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             var hostBuilder = new WebHostBuilder()
                 .UseConfiguration(config)
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .Configure(app =>
                 {
                     app.Run(async context =>
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             var hostBuilder = new WebHostBuilder()
                 .UseConfiguration(config)
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .Configure(app =>
                 {
                     app.Run(async context =>
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             var hostBuilder = new WebHostBuilder()
                 .UseConfiguration(config)
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .Configure(app =>
                 {
                     app.Run(context =>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ThreadCountTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ThreadCountTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             var hostBuilder = new WebHostBuilder()
                 .UseConfiguration(config)
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel()
                 .Configure(app =>
                 {
                     var serverInfo = app.ServerFeatures.Get<IKestrelServerInformation>();


### PR DESCRIPTION
Implements UseKestrel() extension method with no arguments.  Additional overload to specify options will be added later.

@halter73 @cesarbs @davidfowl @lodejard 