### PR TITLE
React to HttpAbstractions namespace changes

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Https/HttpsConnectionFilter.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Https/HttpsConnectionFilter.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Net.Security;
-using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Features.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Filter;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Https

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/DummyApplication.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/DummyApplication.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests


### PR DESCRIPTION
- aspnet/HttpAbstractions#549 and aspnet/HttpAbstractions#592
- clean up `using`s