### PR TITLE
No longer build libuv in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,7 @@ dist: trusty
 addons:
   apt:
     packages:
-    - gettext
-    - libcurl4-openssl-dev
-    - libicu-dev
-    - libssl-dev
     - libunwind8
-    - zlib1g
-env:
-  - KOREBUILD_TEST_SKIPMONO=true
-install:
-  - curl -sSL https://github.com/libuv/libuv/archive/v1.4.2.tar.gz | tar zxfv - -C /tmp && cd /tmp/libuv-1.4.2/
-  - sh autogen.sh
-  - ./configure --prefix=$HOME/libuvinstall
-  - make
-  - make install
-  - export LD_LIBRARY_PATH="$HOME/libuvinstall/lib"
-  - cd $OLDPWD
 mono:
   - 4.0.5
 os:

--- a/samples/LargeResponseApp/project.json
+++ b/samples/LargeResponseApp/project.json
@@ -5,6 +5,10 @@
       "version": "1.0.0-*",
       "type": "build"
     },
+    "Microsoft.AspNetCore.Internal.libuv-Linux": {
+      "version": "1.0.0-*",
+      "type": "build"
+    },
     "Microsoft.AspNetCore.Internal.libuv-Windows": {
       "version": "1.0.0-*",
       "type": "build"

--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -5,6 +5,10 @@
       "version": "1.0.0-*",
       "type": "build"
     },
+    "Microsoft.AspNetCore.Internal.libuv-Linux": {
+      "version": "1.0.0-*",
+      "type": "build"
+    },
     "Microsoft.AspNetCore.Internal.libuv-Windows": {
       "version": "1.0.0-*",
       "type": "build"

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
@@ -10,6 +10,10 @@
       "version": "1.0.0-*",
       "type": "build"
     },
+    "Microsoft.AspNetCore.Internal.libuv-Linux": {
+      "version": "1.0.0-*",
+      "type": "build"
+    },
     "Microsoft.AspNetCore.Internal.libuv-Windows": {
       "version": "1.0.0-*",
       "type": "build"

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/project.json
@@ -10,6 +10,10 @@
       "version": "1.0.0-*",
       "type": "build"
     },
+    "Microsoft.AspNetCore.Internal.libuv-Linux": {
+      "version": "1.0.0-*",
+      "type": "build"
+    },
     "Microsoft.AspNetCore.Internal.libuv-Windows": {
       "version": "1.0.0-*",
       "type": "build"


### PR DESCRIPTION
The Ubuntu libuv build should now be taken from http://github.com/aspnet/libuv-build

@moozzyk 