### PR TITLE
Never call Thread.Abort

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -104,9 +104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                         Post(t => t.OnStopImmediate());
                         if (!_thread.Join(stepTimeout))
                         {
-#if NET451
-                            _thread.Abort();
-#endif
+                            _log.LogError(0, null, "KestrelThread.Stop failed to terminate libuv thread.");
                         }
                     }
                 }
@@ -116,9 +114,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     // Until we rework this logic, ODEs are bound to happen sometimes.
                     if (!_thread.Join(stepTimeout))
                     {
-#if NET451
-                        _thread.Abort();
-#endif
+                        _log.LogError(0, null, "KestrelThread.Stop failed to terminate libuv thread.");
                     }
                 }
             }


### PR DESCRIPTION
- This API isn't available on .NET Core so we should rely entirely on
  our other methods of terminating the libuv threads.

#725