### PR TITLE
Remove unused dependency on TraceSource

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/project.json
@@ -36,8 +36,6 @@
       "dependencies": {
         "System.Collections": "4.0.11-*",
         "System.Diagnostics.Debug": "4.0.11-*",
-        "System.Diagnostics.TraceSource": "4.0.0-*",
-        "System.Diagnostics.Tracing": "4.1.0-*",
         "System.Globalization": "4.0.11-*",
         "System.IO": "4.1.0-*",
         "System.Linq": "4.1.0-*",


### PR DESCRIPTION
- TraceSource is RID specific (see https://github.com/dotnet/corefx/issues/7480) and it
causes 2 dlls to end up in the output of every ASP.NET application. We don't even
use it anymore.

I want to get this in RC2. It reduces the output size by `109kb`

/cc @danroth27 @Eilon 