### PR TITLE
Prevent crash when aborting connection before Frame is created (#738).

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Connection.cs
@@ -154,9 +154,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         {
             // Frame.Abort calls user code while this method is always
             // called from a libuv thread.
-            System.Threading.ThreadPool.QueueUserWorkItem(state =>
+            ThreadPool.Run(() =>
             {
-                var connection = (Connection)state;
+                var connection = this;
 
                 lock (connection._stateLock)
                 {
@@ -166,10 +166,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                     }
                     else
                     {
-                        connection._frame.Abort();
+                        connection._frame?.Abort();
                     }
                 }
-            }, this);
+            });
         }
 
         // Called on Libuv thread


### PR DESCRIPTION
- Check that `_frame` is not null
- Queue work item via `LoggingThreadPool` to isolate future potential exceptions and prevent new crashes

#738

cc @halter73 @benaadams @yuwaMSFT 