### PR TITLE
Fix connection termination issues when using connection filters (#737, #747).

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Filter/SocketInputStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Filter/SocketInputStream.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Filter
         protected override void Dispose(bool disposing)
         {
             // Close _socketInput with a fake zero-length write that will result in a zero-length read.
-            _socketInput.IncomingData(null, 0, 0);
+            _socketInput.IncomingFin();
             base.Dispose(disposing);
         }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/SocketInput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/SocketInput.cs
@@ -140,6 +140,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             }
         }
 
+        public void IncomingFin()
+        {
+            // Force a FIN
+            IncomingData(null, 0, 0);
+        }
+
         private void Complete()
         {
             var awaitableState = Interlocked.Exchange(

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/StreamSocketOutputTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/StreamSocketOutputTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             // As it calls ProduceStart with write immediate == true
             // This happens in WebSocket Upgrade over SSL
 
-            ISocketOutput socketOutput = new StreamSocketOutput(new ThrowsOnNullWriteStream(), null);
+            ISocketOutput socketOutput = new StreamSocketOutput("id", new ThrowsOnNullWriteStream(), null, new TestKestrelTrace());
 
             // Should not throw
             socketOutput.Write(default(ArraySegment<byte>), true);

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/TestApplicationErrorLogger.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/TestApplicationErrorLogger.cs
@@ -32,11 +32,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Console.WriteLine($"Log {logLevel}[{eventId}]: {formatter(state, exception)} {exception?.Message}");
 #endif
 
-            TotalErrorsLogged++;
-
             if (eventId.Id == ApplicationErrorEventId)
             {
                 ApplicationErrorsLogged++;
+            }
+
+            if (logLevel == LogLevel.Error)
+            {
+                TotalErrorsLogged++;
             }
         }
     }


### PR DESCRIPTION
This PR addresses two issues that surface when using connection filters (namely our https connection filter):

#747) If the client closes the connection while we're still writing a response, we see exceptions in the log because we're trying to write to a diposed streams. Specifically with https, if a client sends an https request and closes the connection while we're still writing output, we get an exception from `SslStream.Write()` because the stream has already been disposed.

Not capturing that exception is undesired because we end up leaking memory blocks and leaving them up to be collected by the GC, while ideally we should properly return all of them to the memory pool.

This is not a completely unexpected situation, so the fix is just to log that it happened and prevent further attempts to write to the disposed stream.

#737) If a client takes too long to send a FIN and in the mean time we've already consumed all input and written a response, we get an exception when trying to close the connection because we still have code awaiting socket input. This is what is happening in this issue: for whatever reason nginx takes too long to send a FIN and we attempt to close the connection before receiving it. However, the task started by `FilteredStreamAdapter.ReadInput()` is still running and awaiting for input (which given enough time would be the FIN). Since we close the connection before receiving the FIN we see the reported stack trace because `Connection._rawSocketInput` is disposed and aborts any consumers awaiting on it.

The fix is to force a FIN into `Connection._rawSocketInput` an `Abort()` method in `FilteredStreamAdapter` that sets a flag that we check after the task that copies data from the wrapped stream to the outer `SocketInput` finishes. The previous call to `IncomingData()` on `_rawSocketInput` causes the `CopyToAsync` task to end gracefully and by calling `FilteredStreamAdapter.Abort()` we ensure the continuation for the `CopyToAsync` task will just attempt to abort awaiting consumers but not log any errors.

Another change is to return the continuation Task from `FilteredStreamAdapter.ReadInput()` so we can set another continuation on it to dispose other `Connection` members. By disposing those objects on that second continuation we ensure the disposal is really happening after the `CopyToAsync` task has finished AND any awaiters on `SocketInput` have been aborted.

cc @halter73 @yuwaMSFT @Eilon 