### PR TITLE
Add KestrelServerOptionsSetup before KestrelServerOptions (#755)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/WebHostBuilderKestrelExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/WebHostBuilderKestrelExtensions.cs
@@ -44,12 +44,10 @@ namespace Microsoft.AspNetCore.Hosting
         /// </returns>
         public static IWebHostBuilder UseKestrel(this IWebHostBuilder hostBuilder, Action<KestrelServerOptions> options)
         {
-            hostBuilder.ConfigureServices(services =>
+            return hostBuilder.UseKestrel().ConfigureServices(services =>
             {
                 services.Configure(options);
             });
-
-            return hostBuilder.UseKestrel();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/WebHostBuilderKestrelExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/WebHostBuilderKestrelExtensionsTests.cs
@@ -29,7 +29,23 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             });
 
             // Act
-            var host = hostBuilder.Build();
+            hostBuilder.Build();
+        }
+
+        [Fact]
+        public void ApplicationServicesNotNullDuringUseKestrelWithOptions()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .UseKestrel(options =>
+                {
+                    // Assert
+                    Assert.NotNull(options.ApplicationServices);
+                })
+                .Configure(app => { });
+
+            // Act
+            hostBuilder.Build();
         }
     }
 }


### PR DESCRIPTION
- Required to ensure that options.ApplicationServices is available after during UseKestrel(options)

@davidfowl, @halter73, @Tratcher, @cesarbs 