### PR TITLE
Make ECONNRESET value platform-specific (#649).

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Connection.cs
@@ -40,6 +40,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         private ConnectionState _connectionState;
         private TaskCompletionSource<object> _socketClosedTcs;
 
+        bool _eConnResetChecked = false;
+
         public Connection(ListenerContext context, UvStreamHandle socket) : base(context)
         {
             _socket = socket;
@@ -270,6 +272,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 // We need to clean up whatever was allocated by OnAlloc.
                 _rawSocketInput.IncomingDeferred();
                 return;
+            }
+
+            if (!_eConnResetChecked && !Constants.ECONNRESET.HasValue)
+            {
+                Log.LogWarning("Unable to determine ECONNRESET value on this platform.");
+                _eConnResetChecked = true;
             }
 
             var normalRead = status > 0;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/Constants.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/Constants.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using Microsoft.Extensions.PlatformAbstractions;
+
 namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
 {
     internal class Constants
@@ -8,7 +11,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
         public const int ListenBacklog = 128;
 
         public const int EOF = -4095;
-        public const int ECONNRESET = -4077;
+        public static readonly int? ECONNRESET = GetECONNRESET();
 
         /// <summary>
         /// Prefix of host name used to specify Unix sockets in the configuration.
@@ -20,5 +23,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
         /// for info on the format.
         /// </summary>
         public const string RFC1123DateFormat = "r";
+
+        private static int? GetECONNRESET()
+        {
+            switch (PlatformServices.Default.Runtime.OperatingSystemPlatform)
+            {
+                case Platform.Windows:
+                    return -4077;
+                case Platform.Linux:
+                    return -104;
+                case Platform.Darwin:
+                    return -54;
+                default:
+                    return null;
+            }
+        }
     }
 }


### PR DESCRIPTION
Gross, but we don't have platform-specific `#define`s.

#649 

cc @halter73 @mikeharder @davidfowl 