### PR TITLE
Minor Stream improvements

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Filter/LibuvStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Filter/LibuvStream.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Filter
 {
@@ -119,6 +120,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Filter
         public override void Flush()
         {
             // No-op since writes are immediate.
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            // No-op since writes are immediate.
+            return TaskUtilities.CompletedTask;
         }
 
         private ValueTask<int> ReadAsync(ArraySegment<byte> buffer)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameRequestStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameRequestStream.cs
@@ -19,35 +19,51 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             _state = FrameStreamState.Closed;
         }
 
-        public override bool CanRead { get { return true; } }
+        public override bool CanRead => true;
 
-        public override bool CanSeek { get { return false; } }
+        public override bool CanSeek => false;
 
-        public override bool CanWrite { get { return false; } }
+        public override bool CanWrite => false;
 
         public override long Length
         {
             get
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
         }
 
-        public override long Position { get; set; }
+        public override long Position
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
 
         public override void Flush()
         {
-            throw new NotImplementedException();
+            // No-op.
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            // No-op.
+            return TaskUtilities.CompletedTask;
         }
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public override void SetLength(long value)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -113,7 +129,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public Stream StartAcceptingReads(MessageBody body)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameResponseStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameResponseStream.cs
@@ -29,11 +29,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
         {
             get
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
         }
 
-        public override long Position { get; set; }
+        public override long Position
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
 
         public override void Flush()
         {
@@ -54,17 +64,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public override void SetLength(long value)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameRequestStreamTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameRequestStreamTests.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Http;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.KestrelTests
+{
+    public class FrameRequestStreamTests
+    {
+        [Fact]
+        public void CanReadReturnsTrue()
+        {
+            var stream = new FrameRequestStream();
+            Assert.True(stream.CanRead);
+        }
+
+        [Fact]
+        public void CanSeekReturnsFalse()
+        {
+            var stream = new FrameRequestStream();
+            Assert.False(stream.CanSeek);
+        }
+
+        [Fact]
+        public void CanWriteReturnsFalse()
+        {
+            var stream = new FrameRequestStream();
+            Assert.False(stream.CanWrite);
+        }
+
+        [Fact]
+        public void SeekThrows()
+        {
+            var stream = new FrameRequestStream();
+            Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
+        }
+
+        [Fact]
+        public void LengthThrows()
+        {
+            var stream = new FrameRequestStream();
+            Assert.Throws<NotSupportedException>(() => stream.Length);
+        }
+
+        [Fact]
+        public void SetLengthThrows()
+        {
+            var stream = new FrameRequestStream();
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(0));
+        }
+
+        [Fact]
+        public void PositionThrows()
+        {
+            var stream = new FrameRequestStream();
+            Assert.Throws<NotSupportedException>(() => stream.Position);
+            Assert.Throws<NotSupportedException>(() => stream.Position = 0);
+        }
+
+        [Fact]
+        public void WriteThrows()
+        {
+            var stream = new FrameRequestStream();
+            Assert.Throws<NotSupportedException>(() => stream.Write(new byte[1], 0, 1));
+        }
+
+        [Fact]
+        public void WriteByteThrows()
+        {
+            var stream = new FrameRequestStream();
+            Assert.Throws<NotSupportedException>(() => stream.WriteByte(0));
+        }
+
+        [Fact]
+        public async Task WriteAsyncThrows()
+        {
+            var stream = new FrameRequestStream();
+            await Assert.ThrowsAsync<NotSupportedException>(() => stream.WriteAsync(new byte[1], 0, 1));
+        }
+
+#if NET451
+        [Fact]
+        public void BeginWriteThrows()
+        {
+            var stream = new FrameRequestStream();
+            Assert.Throws<NotSupportedException>(() => stream.BeginWrite(new byte[1], 0, 1, null, null));
+        }
+#endif
+
+        [Fact]
+        public void FlushDoesNotThrow()
+        {
+            var stream = new FrameRequestStream();
+            stream.Flush();
+        }
+
+        [Fact]
+        public async Task FlushAsyncDoesNotThrow()
+        {
+            var stream = new FrameRequestStream();
+            await stream.FlushAsync();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseStreamTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseStreamTests.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Http;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.KestrelTests
+{
+    public class FrameResponseStreamTests
+    {
+        [Fact]
+        public void CanReadReturnsFalse()
+        {
+            var stream = new FrameResponseStream();
+            Assert.False(stream.CanRead);
+        }
+
+        [Fact]
+        public void CanSeekReturnsFalse()
+        {
+            var stream = new FrameResponseStream();
+            Assert.False(stream.CanSeek);
+        }
+
+        [Fact]
+        public void CanWriteReturnsTrue()
+        {
+            var stream = new FrameResponseStream();
+            Assert.True(stream.CanWrite);
+        }
+
+        [Fact]
+        public void ReadThrows()
+        {
+            var stream = new FrameResponseStream();
+            Assert.Throws<NotSupportedException>(() => stream.Read(new byte[1], 0, 1));
+        }
+
+        [Fact]
+        public void ReadByteThrows()
+        {
+            var stream = new FrameResponseStream();
+            Assert.Throws<NotSupportedException>(() => stream.ReadByte());
+        }
+
+        [Fact]
+        public async Task ReadAsyncThrows()
+        {
+            var stream = new FrameResponseStream();
+            await Assert.ThrowsAsync<NotSupportedException>(() => stream.ReadAsync(new byte[1], 0, 1));
+        }
+
+#if NET451
+        [Fact]
+        public void BeginReadThrows()
+        {
+            var stream = new FrameResponseStream();
+            Assert.Throws<NotSupportedException>(() => stream.BeginRead(new byte[1], 0, 1, null, null));
+        }
+#endif
+
+        [Fact]
+        public void SeekThrows()
+        {
+            var stream = new FrameResponseStream();
+            Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
+        }
+
+        [Fact]
+        public void LengthThrows()
+        {
+            var stream = new FrameResponseStream();
+            Assert.Throws<NotSupportedException>(() => stream.Length);
+        }
+
+        [Fact]
+        public void SetLengthThrows()
+        {
+            var stream = new FrameResponseStream();
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(0));
+        }
+
+        [Fact]
+        public void PositionThrows()
+        {
+            var stream = new FrameResponseStream();
+            Assert.Throws<NotSupportedException>(() => stream.Position);
+            Assert.Throws<NotSupportedException>(() => stream.Position = 0);
+        }
+    }
+}


### PR DESCRIPTION
- Unsupported members should throw `NotSupportedException` instead of
`NotImplementedException` per MSDN docs for [`CanRead`](https://msdn.microsoft.com/en-us/library/system.io.stream.canread(v=vs.110).aspx)/[`CanSeek`](https://msdn.microsoft.com/en-us/library/system.io.stream.canseek(v=vs.110).aspx)/[`CanWrite`](https://msdn.microsoft.com/en-us/library/system.io.stream.canwrite(v=vs.110).aspx).

- Position should throw `NotSupportedException` when `CanSeek` is false.

- `FrameRequestStream.Flush` and `FlushAsync` should not throw
`NotImplementedException`.

- Use expression-bodied members for `CanRead`/`CanSeek`/`CanWrite` on
`FrameRequestStream` to match `FrameResponseStream`.

- Provide no-op override of `LibuvStream.FlushAsync` to match `Flush`.