### PR TITLE
Use Task.FromCanceled<TResult>() on NETSTANDARD1_3

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameRequestStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameRequestStream.cs
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 case FrameStreamState.Open:
                     if (cancellationToken.IsCancellationRequested)
                     {
-                        return TaskUtilities.GetCancelledZeroTask();
+                        return TaskUtilities.GetCancelledZeroTask(cancellationToken);
                     }
                     break;
                 case FrameStreamState.Closed:

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/TaskUtilities.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/TaskUtilities.cs
@@ -26,12 +26,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
 #endif
         }
 
-        public static Task<int> GetCancelledZeroTask()
+        public static Task<int> GetCancelledZeroTask(CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Task<int>.FromCanceled doesn't return Task<int>
+#if NETSTANDARD1_3
+            return Task.FromCanceled<int>(cancellationToken);
+#else
             var tcs = new TaskCompletionSource<int>();
             tcs.TrySetCanceled();
             return tcs.Task;
+#endif
         }
     }
 }


### PR DESCRIPTION
`Task.FromCanceled<int>(cancellationToken)` can be used on `NETSTANDARD1_3` in `TaskUtilities.GetCancelledZeroTask()`.