### PR TITLE
Use type's namespace instead of assembly FullName

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
 
             Options = options.Value ?? new KestrelServerOptions();
             _applicationLifetime = applicationLifetime;
-            _logger = loggerFactory.CreateLogger(typeof(KestrelServer).GetTypeInfo().Assembly.FullName);
+            _logger = loggerFactory.CreateLogger(typeof(KestrelServer).GetTypeInfo().Namespace);
             Features = new FeatureCollection();
             var componentFactory = new HttpComponentFactory(Options);
             Features.Set<IHttpComponentFactory>(componentFactory);


### PR DESCRIPTION
Same as #776, but targeting release. Fixes #775