### PR TITLE
Don't reset connection info via interface

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.FeatureCollection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.FeatureCollection.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Http
@@ -265,15 +264,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 
         int IFeatureCollection.Revision => _featureRevision;
 
-        IPAddress IHttpConnectionFeature.RemoteIpAddress { get; set; }
+        IPAddress IHttpConnectionFeature.RemoteIpAddress
+        {
+            get { return RemoteIpAddress; }
+            set { RemoteIpAddress = value; }
+        }
 
-        IPAddress IHttpConnectionFeature.LocalIpAddress { get; set; }
+        IPAddress IHttpConnectionFeature.LocalIpAddress
+        {
+            get { return LocalIpAddress; }
+            set { LocalIpAddress = value; }
+        }
 
-        int IHttpConnectionFeature.RemotePort { get; set; }
+        int IHttpConnectionFeature.RemotePort
+        {
+            get { return RemotePort; }
+            set { RemotePort = value; }
+        }
 
-        int IHttpConnectionFeature.LocalPort { get; set; }
+        int IHttpConnectionFeature.LocalPort
+        {
+            get { return LocalPort; }
+            set { LocalPort = value; }
+        }
 
-        string IHttpConnectionFeature.ConnectionId { get; set; }
+        string IHttpConnectionFeature.ConnectionId
+        {
+            get { return ConnectionIdFeature; }
+            set { ConnectionIdFeature = value; }
+        }
 
         object IFeatureCollection.this[Type key]
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Numerics;
 using System.Text;
 using System.Threading;
@@ -74,6 +75,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             Reset();
         }
 
+        public string ConnectionIdFeature { get; set; }
+        public IPAddress RemoteIpAddress { get; set; }
+        public int RemotePort { get; set; }
+        public IPAddress LocalIpAddress { get; set; }
+        public int LocalPort { get; set; }
         public string Scheme { get; set; }
         public string Method { get; set; }
         public string RequestUri { get; set; }
@@ -241,14 +247,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             StatusCode = 200;
             ReasonPhrase = null;
 
-            var httpConnectionFeature = this as IHttpConnectionFeature;
-            httpConnectionFeature.RemoteIpAddress = RemoteEndPoint?.Address;
-            httpConnectionFeature.RemotePort = RemoteEndPoint?.Port ?? 0;
+            RemoteIpAddress = RemoteEndPoint?.Address;
+            RemotePort = RemoteEndPoint?.Port ?? 0;
 
-            httpConnectionFeature.LocalIpAddress = LocalEndPoint?.Address;
-            httpConnectionFeature.LocalPort = LocalEndPoint?.Port ?? 0;
-
-            httpConnectionFeature.ConnectionId = ConnectionId;
+            LocalIpAddress = LocalEndPoint?.Address;
+            LocalPort = LocalEndPoint?.Port ?? 0;
+            ConnectionIdFeature = ConnectionId;
 
             PrepareRequest?.Invoke(this);
 


### PR DESCRIPTION
A not insignificant time in frame reset is spent resetting the connection addresses via interface when in all likelyhood they have not changed.

![reset connection info](http://aoa.blob.core.windows.net/aspnet/reset.png)

This resets them via class variable and only does the reset if they have changed

![reset connection after](http://aoa.blob.core.windows.net/aspnet/reset-1.png)

Resolves https://github.com/aspnet/KestrelHttpServer/issues/819