### PR TITLE
[Blocked] Use faster Unsafe.Read/CopyBlock methods

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/project.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "System.Buffers": "4.0.0-*",
+    "System.Runtime.CompilerServices.Unsafe": "4.0.0-*",
     "System.Numerics.Vectors": "4.1.1-*",
     "System.Threading.Tasks.Extensions": "4.0.0-*",
     "Libuv": "1.9.0-*",


### PR DESCRIPTION
Needs `System.Runtime.CompilerServices.Unsafe` added to feed

Supersedes #804

Blocked on https://github.com/aspnet/Home/issues/1428