### PR TITLE
AddressRegistrationTests should get local IPs from System.Net.NetworkInformation (#796)

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -166,7 +167,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 dataset.Add("http://127.0.0.1:0/", GetTestUrls);
                 dataset.Add($"http://{Dns.GetHostName()}:0/", GetTestUrls);
 
-                var ipv4Addresses = Dns.GetHostAddressesAsync(Dns.GetHostName()).Result
+                var ipv4Addresses = GetIPAddresses()
                     .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork);
                 foreach (var ip in ipv4Addresses)
                 {
@@ -224,7 +225,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 dataset.Add($"http://[::1]:{port1}/base/path", _ => new[] { $"http://[::1]:{port1}/base/path" });
 
                 // Dynamic port and non-loopback addresses
-                var ipv6Addresses = Dns.GetHostAddressesAsync(Dns.GetHostName()).Result
+                var ipv6Addresses = GetIPAddresses()
                     .Where(ip => ip.AddressFamily == AddressFamily.InterNetworkV6)
                     .Where(ip => ip.ScopeId == 0);
                 foreach (var ip in ipv6Addresses)
@@ -258,7 +259,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 var dataset = new TheoryData<string, Func<IServerAddressesFeature, string[]>>();
 
                 // Dynamic port
-                var ipv6Addresses = Dns.GetHostAddressesAsync(Dns.GetHostName()).Result
+                var ipv6Addresses = GetIPAddresses()
                     .Where(ip => ip.AddressFamily == AddressFamily.InterNetworkV6)
                     .Where(ip => ip.ScopeId != 0);
                 foreach (var ip in ipv6Addresses)
@@ -268,6 +269,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 return dataset;
             }
+        }
+
+        private static IEnumerable<IPAddress> GetIPAddresses()
+        {
+            return NetworkInterface.GetAllNetworkInterfaces()
+                .SelectMany(i => i.GetIPProperties().UnicastAddresses)
+                .Select(a => a.Address);
         }
 
         private static string[] GetTestUrls(IServerAddressesFeature addressesFeature)

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
@@ -19,6 +19,7 @@
         },
         "System.Net.Http": "4.1.0-*",
         "System.Net.Http.WinHttpHandler": "4.0.0-*",
+        "System.Net.NetworkInformation": "4.1.0-*",
         "System.Runtime.Serialization.Primitives": "4.1.1-*"
       }
     },


### PR DESCRIPTION
@cesarbs, @halter73 

#796