### PR TITLE
Prevent NullReferenceException in KestrelThread.OnStopRude

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/KestrelThread.cs
@@ -132,7 +132,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 var handle = UvMemory.FromIntPtr<UvHandle>(ptr);
                 if (handle != _post)
                 {
-                    handle.Dispose();
+                    // handle can be null because UvMemory.FromIntPtr looks up a weak reference
+                    handle?.Dispose();
                 }
             });
 


### PR DESCRIPTION
- UvMemory.FromIntPtr looks up a weak reference so we need to null check.

#827