### PR TITLE
Init date values in ctor

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/DateHeaderValueManager.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/DateHeaderValueManager.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             _timeWithoutRequestsUntilIdle = timeWithoutRequestsUntilIdle;
             _timerInterval = timerInterval;
             _dateValueTimer = new Timer(TimerLoop, state: null, dueTime: Timeout.Infinite, period: Timeout.Infinite);
+            SetDateValues(systemClock.UtcNow);
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/DateHeaderValueManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/DateHeaderValueManagerTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             Assert.Equal(now.ToString(Constants.RFC1123DateFormat), result1);
             Assert.Equal(now.ToString(Constants.RFC1123DateFormat), result2);
-            Assert.Equal(1, systemClock.UtcNowCalled);
+            Assert.Equal(2, systemClock.UtcNowCalled);
         }
 
         [Fact]
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             Assert.Equal(now.ToString(Constants.RFC1123DateFormat), result1);
             Assert.Equal(future.ToString(Constants.RFC1123DateFormat), result2);
-            Assert.True(systemClock.UtcNowCalled >= 2);
+            Assert.True(systemClock.UtcNowCalled >= 3);
         }
 
         [Fact]


### PR DESCRIPTION
This change sets the object in the DateHeader .ctor rather than waiting for the timer tick to initialize it.

Start up race that seemed to work prior to https://github.com/aspnet/KestrelHttpServer/pull/810 by using an null array for the date header value which `FrameResponseHeaders.CopyToFast` [would skip](https://github.com/aspnet/KestrelHttpServer/blob/dev/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameHeaders.Generated.cs#L9038-L9050) therefore not outputting a date header. So an invalid response, however not a failure.

With the date bytes and date string now in a object; that object is null - which causes the null reference when resolving the bytes at start-up.

Resolves  #866

/cc @halter73 