### PR TITLE
ServerAddress.FromUrl() should throw for invalid url (#875)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/ServerAddress.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/ServerAddress.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             int schemeDelimiterStart = url.IndexOf("://", StringComparison.Ordinal);
             if (schemeDelimiterStart < 0)
             {
-                return null;
+                throw new FormatException($"Invalid URL: {url}");
             }
             int schemeDelimiterEnd = schemeDelimiterStart + "://".Length;
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             var exception = Assert.Throws<FormatException>(() => StartDummyApplication(server));
 
-            Assert.Contains("Unrecognized listening address", exception.Message);
+            Assert.Contains("Invalid URL", exception.Message);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ServerAddressTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ServerAddressTests.cs
@@ -14,9 +14,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [InlineData("")]
         [InlineData("5000")]
         [InlineData("//noscheme")]
-        public void FromUriReturnsNullForSchemelessUrls(string url)
+        public void FromUriThrowsForSchemelessUrls(string url)
         {
-            Assert.Null(ServerAddress.FromUrl(url));
+            Assert.Throws<FormatException>(() => ServerAddress.FromUrl(url));
         }
 
         [Theory]


### PR DESCRIPTION
When viewing this diff, append `w=1` to the query string to ignore whitespace changes.  Many lines had one level of indent removed.

@halter73, @cesarbs 