### PR TITLE
ServerAddress.FromUrl("http://") throws ArgumentOutOfRangeException (#860)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/ServerAddress.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/ServerAddress.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             }
 
             // Path should not end with a / since it will be used as PathBase later
-            if (url[url.Length - 1] == '/')
+            if (url[url.Length - 1] == '/' && url.Length > pathDelimiterEnd)
             {
                 serverAddress.PathBase = url.Substring(pathDelimiterEnd, url.Length - pathDelimiterEnd - 1);
             }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/ServerAddress.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/ServerAddress.cs
@@ -141,8 +141,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 serverAddress.Host = url.Substring(schemeDelimiterEnd, pathDelimiterStart - schemeDelimiterEnd);
             }
 
+            if (string.IsNullOrEmpty(serverAddress.Host))
+            {
+                throw new FormatException($"Invalid URL: {url}");
+            }
+
             // Path should not end with a / since it will be used as PathBase later
-            if (url[url.Length - 1] == '/' && url.Length > pathDelimiterEnd)
+            if (url[url.Length - 1] == '/')
             {
                 serverAddress.PathBase = url.Substring(pathDelimiterEnd, url.Length - pathDelimiterEnd - 1);
             }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ServerAddressTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ServerAddressTests.cs
@@ -20,7 +20,13 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
         [Theory]
+        [InlineData("://", "", "", 0, "", "://:0")]
+        [InlineData("http://", "http", "", 80, "", "http://:80")]
+        [InlineData("http:///", "http", "", 80, "", "http://:80")]
+        [InlineData("http:////", "http", "", 80, "/", "http://:80/")]
         [InlineData("://emptyscheme", "", "emptyscheme", 0, "", "://emptyscheme:0")]
+        [InlineData("http://+", "http", "+", 80, "", "http://+:80")]
+        [InlineData("http://*", "http", "*", 80, "", "http://*:80")]
         [InlineData("http://localhost", "http", "localhost", 80, "", "http://localhost:80")]
         [InlineData("http://www.example.com", "http", "www.example.com", 80, "", "http://www.example.com:80")]
         [InlineData("https://www.example.com", "https", "www.example.com", 443, "", "https://www.example.com:443")]

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ServerAddressTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ServerAddressTests.cs
@@ -21,9 +21,13 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         [Theory]
         [InlineData("://", "", "", 0, "", "://:0")]
+        [InlineData("://:5000", "", "", 5000, "", "://:5000")]
         [InlineData("http://", "http", "", 80, "", "http://:80")]
+        [InlineData("http://:5000", "http", "", 5000, "", "http://:5000")]
         [InlineData("http:///", "http", "", 80, "", "http://:80")]
+        [InlineData("http:///:5000", "http", "", 80, "/:5000", "http://:80/:5000")]
         [InlineData("http:////", "http", "", 80, "/", "http://:80/")]
+        [InlineData("http:////:5000", "http", "", 80, "//:5000", "http://:80//:5000")]
         [InlineData("://emptyscheme", "", "emptyscheme", 0, "", "://emptyscheme:0")]
         [InlineData("http://+", "http", "+", 80, "", "http://+:80")]
         [InlineData("http://*", "http", "*", 80, "", "http://*:80")]

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ServerAddressTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ServerAddressTests.cs
@@ -14,20 +14,26 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [InlineData("")]
         [InlineData("5000")]
         [InlineData("//noscheme")]
-        public void FromUriThrowsForSchemelessUrls(string url)
+        public void FromUriThrowsForUrlsWithoutSchemeDelimiter(string url)
         {
             Assert.Throws<FormatException>(() => ServerAddress.FromUrl(url));
         }
 
         [Theory]
-        [InlineData("://", "", "", 0, "", "://:0")]
-        [InlineData("://:5000", "", "", 5000, "", "://:5000")]
-        [InlineData("http://", "http", "", 80, "", "http://:80")]
-        [InlineData("http://:5000", "http", "", 5000, "", "http://:5000")]
-        [InlineData("http:///", "http", "", 80, "", "http://:80")]
-        [InlineData("http:///:5000", "http", "", 80, "/:5000", "http://:80/:5000")]
-        [InlineData("http:////", "http", "", 80, "/", "http://:80/")]
-        [InlineData("http:////:5000", "http", "", 80, "//:5000", "http://:80//:5000")]
+        [InlineData("://")]
+        [InlineData("://:5000")]
+        [InlineData("http://")]
+        [InlineData("http://:5000")]
+        [InlineData("http:///")]
+        [InlineData("http:///:5000")]
+        [InlineData("http:////")]
+        [InlineData("http:////:5000")]
+        public void FromUriThrowsForUrlsWithoutHost(string url)
+        {
+            Assert.Throws<FormatException>(() => ServerAddress.FromUrl(url));
+        }
+
+        [Theory]
         [InlineData("://emptyscheme", "", "emptyscheme", 0, "", "://emptyscheme:0")]
         [InlineData("http://+", "http", "+", 80, "", "http://+:80")]
         [InlineData("http://*", "http", "*", 80, "", "http://*:80")]


### PR DESCRIPTION
- Code change in `ServerAddress.cs` prevents the `ArgumentOutOfRangeException`, and causes `FromUrl("http://")` to return a `ServerAddress` with `Host=""`.
- I considered throwing `FormatException` if `String.IsNullOrEmpty(Host)`, but this raises further questions of what we consider a valid `Host`:
 - Is whitespace a valid host?
 - Is a special character like `!` or `.` a valid host?
 - Is a string containing whitespace (like `foo bar`) a valid host?
- So I think we should allow any host until we decide to start actually validating the host per the RFCs.

@halter73, @cesarbs, @davidfowl, @Tratcher 