### PR TITLE
Remove uses of ValueTask<T>'s implicit casts

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/MessageBody.cs
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 var limit = buffer.Array == null ? inputLengthLimit : Math.Min(buffer.Count, inputLengthLimit);
                 if (limit == 0)
                 {
-                    return 0;
+                    return new ValueTask<int>(0);
                 }
 
                 var task = _context.SocketInput.ReadAsync(buffer.Array, buffer.Offset, limit);
@@ -189,11 +189,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                     {
                         _context.RejectRequest("Unexpected end of request content");
                     }
-                    return actual;
+                    return new ValueTask<int>(actual);
                 }
                 else
                 {
-                    return ReadAsyncAwaited(task.AsTask());
+                    return new ValueTask<int>(ReadAsyncAwaited(task.AsTask()));
                 }
             }
 
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 
             public override ValueTask<int> ReadAsyncImplementation(ArraySegment<byte> buffer, CancellationToken cancellationToken)
             {
-                return ReadStateMachineAsync(_context.SocketInput, buffer, cancellationToken);
+                return new ValueTask<int>(ReadStateMachineAsync(_context.SocketInput, buffer, cancellationToken));
             }
 
             private async Task<int> ReadStateMachineAsync(SocketInput input, ArraySegment<byte> buffer, CancellationToken cancellationToken)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/SocketInputExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/SocketInputExtensions.cs
@@ -21,15 +21,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 
                 if (actual != 0)
                 {
-                    return actual;
+                    return new ValueTask<int>(actual);
                 }
                 else if (fin)
                 {
-                    return 0;
+                    return new ValueTask<int>(0);
                 }
             }
 
-            return input.ReadAsyncAwaited(buffer, offset, count);
+            return new ValueTask<int>(input.ReadAsyncAwaited(buffer, offset, count));
         }
 
         private static async Task<int> ReadAsyncAwaited(this SocketInput input, byte[] buffer, int offset, int count)


### PR DESCRIPTION
These are likely being removed :frowning:.  See https://github.com/dotnet/corefx/pull/8914 for more details.

cc: @benaadams, @davidfowl, @ljw1004, @MadsTorgersen