### PR TITLE
Improve response generation perf by emitting known strings directly, instead of using Buffer.BlockCopy etc

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -593,9 +595,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 
             _requestProcessingStatus = RequestProcessingStatus.ResponseStarted;
 
-            var statusBytes = ReasonPhrases.ToStatusBytes(StatusCode, ReasonPhrase);
-
-            CreateResponseHeader(statusBytes, appCompleted);
+            CreateResponseHeader(appCompleted);
         }
 
         protected Task TryProduceInvalidRequestResponse()
@@ -696,8 +696,129 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void EmitHttp11(ref MemoryPoolIterator end)
+        {
+            byte* b;
+            
+            if (end.GetRawBuffer(9, out b))
+            {
+                 // Emit directly
+                *(long*)b = 0x312E312F50545448;
+                *(b + 8) = 0x20;
+                
+                end.UpdateEnd(9);
+            }
+            else
+            {
+                end.CopyFrom(_bytesHttpVersion11);
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void Emit200OK(ref MemoryPoolIterator end)
+        {
+            byte* b;
+            
+            if (end.GetRawBuffer(6, out b))
+            {
+                 // Emit directly
+                *(int*)b = 0x20303032;
+                *(short*)(b + 4) = 0x4B4F;
+
+                end.UpdateEnd(6);
+            }
+            else
+            {
+                end.CopyFrom(ReasonPhrases.ToStatusBytes(200, null));
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void EmitServerKestrel(ref MemoryPoolIterator end)
+        {
+            byte* b;
+            
+            if (end.GetRawBuffer(17, out b))
+            {
+                // Emit directly
+                *(long*)b = 0x7265767265530A0D;
+                *(long*)(b + 8) = 0x65727473654B203A;
+                *(b + 16) = 0x6C;
+                
+                end.UpdateEnd(17);
+            }
+            else
+            {
+                end.CopyFrom(_bytesServer);
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void EmitHeaderEnd(ref MemoryPoolIterator end)
+        {
+            byte* b;
+                        
+            if (end.GetRawBuffer(4, out b))
+            {
+                 // Emit directly
+                *(int*)b = 0x0A0D0A0D;
+                
+                end.UpdateEnd(4);
+            }
+            else
+            {
+                end.CopyFrom(_bytesEndHeaders);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteStatus(ref MemoryPoolIterator end)
+        {
+            // Fast path for 200 OK
+            if (StatusCode == 200 && ReasonPhrase == null)
+            {
+                Emit200OK(ref end);
+            }
+            else
+            {
+                var statusBytes = ReasonPhrases.ToStatusBytes(StatusCode, ReasonPhrase);
+                end.CopyFrom(statusBytes);
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void WriteDate(ref MemoryPoolIterator end, byte[] dateHeaderBytes)
+        {
+            // Auto-generated date header should always be exactly the same length.
+            Debug.Assert(dateHeaderBytes.Length == 37);
+            
+            byte* b;
+            
+            if (end.GetRawBuffer(37, out b))
+            {
+                 // Copy directly
+                fixed (byte * pDateBytes = dateHeaderBytes)
+                {
+                    byte * d = pDateBytes;
+                    
+                    *(long*)b = *(long*)d;
+                    *(long*)(b + 8) = *(long*)(d + 8);
+                    *(long*)(b + 16) = *(long*)(d + 16);
+                    *(long*)(b + 24) = *(long*)(d + 24);
+                    *(int*)(b + 32) = *(int*)(d + 32);
+                    *(b + 36) = *(d + 36);
+                }
+                
+                end.UpdateEnd(37);
+            }
+            else
+            {
+                end.CopyFrom(dateHeaderBytes);
+            }
+        }
+
         private void CreateResponseHeader(
-            byte[] statusBytes,
             bool appCompleted)
         {
             var responseHeaders = FrameResponseHeaders;
@@ -766,21 +887,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 responseHeaders.SetRawConnection("keep-alive", _bytesConnectionKeepAlive);
             }
 
-            if (ServerOptions.AddServerHeader && !responseHeaders.HasServer)
-            {
-                responseHeaders.SetRawServer(Constants.ServerName, _bytesServer);
-            }
+            EmitHttp11(ref end);
+            WriteStatus(ref end);
+            responseHeaders.CopyTo(ref end);
 
             if (!responseHeaders.HasDate)
             {
                 var dateHeaderValues = DateHeaderValueManager.GetDateHeaderValues();
                 responseHeaders.SetRawDate(dateHeaderValues.String, dateHeaderValues.Bytes);
+                
+                WriteDate(ref end, dateHeaderValues.Bytes);
             }
 
-            end.CopyFrom(_bytesHttpVersion11);
-            end.CopyFrom(statusBytes);
-            responseHeaders.CopyTo(ref end);
-            end.CopyFrom(_bytesEndHeaders, 0, _bytesEndHeaders.Length);
+            if (ServerOptions.AddServerHeader && !responseHeaders.HasServer)
+            {
+                responseHeaders.SetRawServer(Constants.ServerName, _bytesServer);
+                
+                EmitServerKestrel(ref end);
+            }
+            
+            EmitHeaderEnd(ref end);
 
             SocketOutput.ProducingComplete(end);
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/Frame.cs
@@ -706,6 +706,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             var hasConnection = responseHeaders.HasConnection;
 
             var end = SocketOutput.ProducingStart();
+            if (end.IsDefault)
+            { 
+                return;
+            }
+            
             if (_keepAlive && hasConnection)
             {
                 foreach (var connectionValue in responseHeaders.HeaderConnection)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameHeaders.Generated.cs
@@ -9001,7 +9001,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             ((ICollection<KeyValuePair<string, StringValues>>)MaybeUnknown)?.CopyTo(array, arrayIndex);
         }
         
-        protected void CopyToFast(ref MemoryPoolIterator output)
+        protected unsafe void CopyToFast(ref MemoryPoolIterator output)
         {
             
                 if (((_bits & 1L) != 0)) 
@@ -9010,7 +9010,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 0, 17);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(17, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x2D65686361430A0D;
+*(long*)(b + 8) = 0x3A6C6F72746E6F43;
+*(short*)(b + 16) = 0x20;
+
+                output.UpdateEnd(17);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 0, 17);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9027,7 +9043,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 17, 14);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(14, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x63656E6E6F430A0D;
+*(int*)(b + 8) = 0x6E6F6974;
+*(short*)(b + 12) = 0x203A;
+
+                output.UpdateEnd(14);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 17, 14);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9044,7 +9076,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 31, 8);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(8, out b))
+            {
+                 // Emit directly
+*(int*)(b + 0) = 0x61440A0D;
+*(short*)(b + 4) = 0x6574;
+*(short*)(b + 6) = 0x3A;
+
+                output.UpdateEnd(8);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 31, 8);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9056,7 +9104,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 39, 14);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(14, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x412D7065654B0A0D;
+*(int*)(b + 8) = 0x6576696C;
+*(short*)(b + 12) = 0x203A;
+
+                output.UpdateEnd(14);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 39, 14);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9068,7 +9132,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 53, 10);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(10, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x616D676172500A0D;
+*(short*)(b + 8) = 0x203A;
+
+                output.UpdateEnd(10);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 53, 10);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9080,7 +9159,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 63, 11);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(11, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x656C696172540A0D;
+*(short*)(b + 8) = 0x3A72;
+*(short*)(b + 10) = 0x20;
+
+                output.UpdateEnd(11);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 63, 11);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9097,7 +9192,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 74, 21);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(21, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x66736E6172540A0D;
+*(long*)(b + 8) = 0x646F636E452D7265;
+*(int*)(b + 16) = 0x3A676E69;
+*(short*)(b + 20) = 0x20;
+
+                output.UpdateEnd(21);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 74, 21);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9109,7 +9221,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 95, 11);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(11, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6461726770550A0D;
+*(short*)(b + 8) = 0x3A65;
+*(short*)(b + 10) = 0x20;
+
+                output.UpdateEnd(11);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 95, 11);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9121,7 +9249,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 106, 7);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(7, out b))
+            {
+                 // Emit directly
+*(int*)(b + 0) = 0x69560A0D;
+*(short*)(b + 4) = 0x3A61;
+*(short*)(b + 6) = 0x20;
+
+                output.UpdateEnd(7);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 106, 7);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9133,7 +9277,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 113, 11);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(11, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6E696E7261570A0D;
+*(short*)(b + 8) = 0x3A67;
+*(short*)(b + 10) = 0x20;
+
+                output.UpdateEnd(11);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 113, 11);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9145,7 +9305,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 124, 9);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(9, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x3A776F6C6C410A0D;
+*(short*)(b + 8) = 0x20;
+
+                output.UpdateEnd(9);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 124, 9);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9162,7 +9337,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 133, 18);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(18, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6E65746E6F430A0D;
+*(long*)(b + 8) = 0x6874676E654C2D74;
+*(short*)(b + 16) = 0x203A;
+
+                output.UpdateEnd(18);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 133, 18);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9174,7 +9365,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 151, 16);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(16, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6E65746E6F430A0D;
+*(int*)(b + 8) = 0x79542D74;
+*(short*)(b + 12) = 0x6570;
+*(short*)(b + 14) = 0x3A;
+
+                output.UpdateEnd(16);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 151, 16);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9186,7 +9394,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 167, 20);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(20, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6E65746E6F430A0D;
+*(long*)(b + 8) = 0x69646F636E452D74;
+*(int*)(b + 16) = 0x203A676E;
+
+                output.UpdateEnd(20);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 167, 20);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9198,7 +9422,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 187, 20);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(20, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6E65746E6F430A0D;
+*(long*)(b + 8) = 0x6175676E614C2D74;
+*(int*)(b + 16) = 0x203A6567;
+
+                output.UpdateEnd(20);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 187, 20);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9210,7 +9450,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 207, 20);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(20, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6E65746E6F430A0D;
+*(long*)(b + 8) = 0x697461636F4C2D74;
+*(int*)(b + 16) = 0x203A6E6F;
+
+                output.UpdateEnd(20);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 207, 20);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9222,7 +9478,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 227, 15);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(15, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6E65746E6F430A0D;
+*(int*)(b + 8) = 0x444D2D74;
+*(short*)(b + 12) = 0x3A35;
+*(short*)(b + 14) = 0x20;
+
+                output.UpdateEnd(15);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 227, 15);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9234,7 +9507,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 242, 17);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(17, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6E65746E6F430A0D;
+*(long*)(b + 8) = 0x3A65676E61522D74;
+*(short*)(b + 16) = 0x20;
+
+                output.UpdateEnd(17);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 242, 17);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9246,7 +9535,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 259, 11);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(11, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6572697078450A0D;
+*(short*)(b + 8) = 0x3A73;
+*(short*)(b + 10) = 0x20;
+
+                output.UpdateEnd(11);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 259, 11);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9258,7 +9563,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 270, 17);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(17, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x4D2D7473614C0A0D;
+*(long*)(b + 8) = 0x3A6465696669646F;
+*(short*)(b + 16) = 0x20;
+
+                output.UpdateEnd(17);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 270, 17);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9270,7 +9591,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 287, 17);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(17, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x7470656363410A0D;
+*(long*)(b + 8) = 0x3A7365676E61522D;
+*(short*)(b + 16) = 0x20;
+
+                output.UpdateEnd(17);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 287, 17);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9282,7 +9619,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 304, 7);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(7, out b))
+            {
+                 // Emit directly
+*(int*)(b + 0) = 0x67410A0D;
+*(short*)(b + 4) = 0x3A65;
+*(short*)(b + 6) = 0x20;
+
+                output.UpdateEnd(7);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 304, 7);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9294,7 +9647,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 311, 8);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(8, out b))
+            {
+                 // Emit directly
+*(int*)(b + 0) = 0x54450A0D;
+*(short*)(b + 4) = 0x6761;
+*(short*)(b + 6) = 0x3A;
+
+                output.UpdateEnd(8);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 311, 8);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9306,7 +9675,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 319, 12);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(12, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x697461636F4C0A0D;
+*(int*)(b + 8) = 0x203A6E6F;
+
+                output.UpdateEnd(12);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 319, 12);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9318,7 +9702,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 331, 21);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(21, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x2D79786F72500A0D;
+*(long*)(b + 8) = 0x6369746568747541;
+*(int*)(b + 16) = 0x3A657461;
+*(short*)(b + 20) = 0x20;
+
+                output.UpdateEnd(21);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 331, 21);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9330,7 +9731,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 352, 15);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(15, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x2D79727465520A0D;
+*(int*)(b + 8) = 0x65746641;
+*(short*)(b + 12) = 0x3A72;
+*(short*)(b + 14) = 0x20;
+
+                output.UpdateEnd(15);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 352, 15);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9347,7 +9765,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 367, 10);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(10, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x7265767265530A0D;
+*(short*)(b + 8) = 0x203A;
+
+                output.UpdateEnd(10);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 367, 10);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9359,7 +9792,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 377, 14);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(14, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x6F432D7465530A0D;
+*(int*)(b + 8) = 0x65696B6F;
+*(short*)(b + 12) = 0x203A;
+
+                output.UpdateEnd(14);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 377, 14);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9371,7 +9820,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 391, 8);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(8, out b))
+            {
+                 // Emit directly
+*(int*)(b + 0) = 0x61560A0D;
+*(short*)(b + 4) = 0x7972;
+*(short*)(b + 6) = 0x3A;
+
+                output.UpdateEnd(8);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 391, 8);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9383,7 +9848,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 399, 20);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(20, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x75412D5757570A0D;
+*(long*)(b + 8) = 0x616369746E656874;
+*(int*)(b + 16) = 0x203A6574;
+
+                output.UpdateEnd(20);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 399, 20);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9395,7 +9876,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 419, 36);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(36, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x7373656363410A0D;
+*(long*)(b + 8) = 0x6C6F72746E6F432D;
+*(long*)(b + 16) = 0x432D776F6C6C412D;
+*(long*)(b + 24) = 0x6169746E65646572;
+*(int*)(b + 32) = 0x203A736C;
+
+                output.UpdateEnd(36);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 419, 36);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9407,7 +9906,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 455, 32);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(32, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x7373656363410A0D;
+*(long*)(b + 8) = 0x6C6F72746E6F432D;
+*(long*)(b + 16) = 0x482D776F6C6C412D;
+*(int*)(b + 24) = 0x65646165;
+*(short*)(b + 28) = 0x7372;
+*(short*)(b + 30) = 0x3A;
+
+                output.UpdateEnd(32);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 455, 32);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9419,7 +9937,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 487, 32);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(32, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x7373656363410A0D;
+*(long*)(b + 8) = 0x6C6F72746E6F432D;
+*(long*)(b + 16) = 0x4D2D776F6C6C412D;
+*(int*)(b + 24) = 0x6F687465;
+*(short*)(b + 28) = 0x7364;
+*(short*)(b + 30) = 0x3A;
+
+                output.UpdateEnd(32);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 487, 32);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9431,7 +9968,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 519, 31);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(31, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x7373656363410A0D;
+*(long*)(b + 8) = 0x6C6F72746E6F432D;
+*(long*)(b + 16) = 0x4F2D776F6C6C412D;
+*(int*)(b + 24) = 0x69676972;
+*(short*)(b + 28) = 0x3A6E;
+*(short*)(b + 30) = 0x20;
+
+                output.UpdateEnd(31);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 519, 31);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9443,7 +9999,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 550, 33);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(33, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x7373656363410A0D;
+*(long*)(b + 8) = 0x6C6F72746E6F432D;
+*(long*)(b + 16) = 0x2D65736F7078452D;
+*(long*)(b + 24) = 0x3A73726564616548;
+*(short*)(b + 32) = 0x20;
+
+                output.UpdateEnd(33);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 550, 33);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }
@@ -9455,7 +10029,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {
                             if (value != null)
                             {
-                                output.CopyFrom(_headerBytes, 583, 26);
+                                 
+            byte* b;
+            
+            if (output.GetRawBuffer(26, out b))
+            {
+                 // Emit directly
+*(long*)(b + 0) = 0x7373656363410A0D;
+*(long*)(b + 8) = 0x6C6F72746E6F432D;
+*(long*)(b + 16) = 0x6567412D78614D2D;
+*(short*)(b + 24) = 0x203A;
+
+                output.UpdateEnd(26);
+            }
+            else
+            {
+                output.CopyFrom(_headerBytes, 583, 26);
+            }
+
                                 output.CopyFromAscii(value);
                             }
                         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/MemoryPoolIterator.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/MemoryPoolIterator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Numerics;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
 {
@@ -822,6 +823,45 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
                 }
             }
 
+            block.End = blockIndex;
+            _block = block;
+            _index = blockIndex;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe bool GetRawBuffer(int bytesRequired, out byte* rawBuffer)
+        {
+            Debug.Assert(_block != null);
+            Debug.Assert(_block.Next == null);
+            Debug.Assert(_block.End == _index);
+
+            var block = _block;
+            var blockIndex = _index;
+
+            var bytesLeftInBlock = block.Data.Offset + block.Data.Count - blockIndex;
+            
+            if (bytesLeftInBlock >= bytesRequired)
+            {
+                rawBuffer = block.DataFixedPtr + blockIndex;
+                return true;
+            }
+
+            rawBuffer = null;            
+            return false;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void UpdateEnd(int bytesWritten)
+        {
+            Debug.Assert(_block != null);
+            Debug.Assert(_block.Next == null);
+            Debug.Assert(_block.End == _index);
+
+            var block = _block;
+            var blockIndex = _index + bytesWritten;
+
+            Debug.Assert(blockIndex <= block.Data.Offset + block.Data.Count);
+            
             block.End = blockIndex;
             _block = block;
             _index = blockIndex;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/MemoryPoolIterator.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Infrastructure/MemoryPoolIterator.cs
@@ -726,11 +726,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
 
         public void CopyFrom(byte[] data, int offset, int count)
         {
-            if (IsDefault)
-            {
-                return;
-            }
-
             Debug.Assert(_block != null);
             Debug.Assert(_block.Next == null);
             Debug.Assert(_block.End == _index);
@@ -773,11 +768,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Infrastructure
 
         public unsafe void CopyFromAscii(string data)
         {
-            if (IsDefault)
-            {
-                return;
-            }
-
             Debug.Assert(_block != null);
             Debug.Assert(_block.Next == null);
             Debug.Assert(_block.End == _index);

--- a/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
+++ b/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
@@ -27,6 +27,49 @@ namespace Microsoft.AspNetCore.Server.Kestrel.GeneratedCode
             public string TestBit() => $"((_bits & {1L << Index}L) != 0)";
             public string SetBit() => $"_bits |= {1L << Index}L";
             public string ClearBit() => $"_bits &= ~{1L << Index}L";
+            public string EmitCode()
+            {
+                string s = $@" 
+            byte* b;
+            
+            if (output.GetRawBuffer({BytesCount}, out b))
+            {{
+                 // Emit directly
+";
+
+                int i = 0;
+                while (BytesCount - i > 8)
+                {
+                    s += $"*(long*)(b + {i}) = 0x{Bytes[i+7]:X2}{Bytes[i+6]:X2}{Bytes[i+5]:X2}{Bytes[i+4]:X2}{Bytes[i+3]:X2}{Bytes[i+2]:X2}{Bytes[i+1]:X2}{Bytes[i]:X2};\r\n";
+                    i += 8;
+                }
+                if (BytesCount - i >= 4)
+                {
+                    s += $"*(int*)(b + {i}) = 0x{Bytes[i+3]:X2}{Bytes[i+2]:X2}{Bytes[i+1]:X2}{Bytes[i]:X2};\r\n";
+                    i += 4;
+                }
+                if (BytesCount - i >= 2)
+                {
+                    s += $"*(short*)(b + {i}) = 0x{Bytes[i+1]:X2}{Bytes[i]:X2};\r\n";
+                    i += 2;
+                }
+                if (BytesCount - i >= 1)
+                {
+                    s += $"*(short*)(b + {i}) = 0x{Bytes[i]:X2};\r\n";
+                    i += 1;
+                }
+                
+                s += $@"
+                output.UpdateEnd({BytesCount});
+            }}
+            else
+            {{
+                output.CopyFrom(_headerBytes, {BytesOffset}, {BytesCount});
+            }}
+";                
+                return s;
+            }
+            
             public string EqualIgnoreCaseBytes()
             {
                 var result = "";
@@ -394,7 +437,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
             ((ICollection<KeyValuePair<string, StringValues>>)MaybeUnknown)?.CopyTo(array, arrayIndex);
         }}
         {(loop.ClassName == "FrameResponseHeaders" ? $@"
-        protected void CopyToFast(ref MemoryPoolIterator output)
+        protected unsafe void CopyToFast(ref MemoryPoolIterator output)
         {{
             {Each(loop.Headers, header => $@"
                 if ({header.TestBit()}) 
@@ -408,7 +451,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                         {{
                             if (value != null)
                             {{
-                                output.CopyFrom(_headerBytes, {header.BytesOffset}, {header.BytesCount});
+                                {header.EmitCode()}
                                 output.CopyFromAscii(value);
                             }}
                         }}


### PR DESCRIPTION
There are a lot of small, known strings we emit into response output (e.g. "HTTP/1.1", "Content-Type", etc).

Optimize these by adding or generating code that emits them directly into the buffers, when possible.

This change would supersede #853, since it greatly reduces the reliance on small copies via BlockCopy.

The win on TechEmpower is around 5%.

Note there are tests that need to be fixed before we can merge this...
