### PR TITLE
Allow a maximum of 3 concurrent uv_write operations per connection

### DIFF
--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockLibuv.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockLibuv.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
 
             _uv_async_send = postHandle =>
             {
+                PostCount++;
                 _loopWh.Set();
 
                 return 0;
@@ -94,6 +95,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
         public uv_alloc_cb AllocCallback { get; set; }
 
         public uv_read_cb ReadCallback { get; set; }
+
+        public int PostCount { get; set; }
 
         private int UvReadStart(UvStreamHandle handle, uv_alloc_cb allocCallback, uv_read_cb readCallback)
         {


### PR DESCRIPTION
- Keep logic to prevent unnecessary calls to KestrelThread.Post
- This partially reverts commit 4809964.

#691

    > dotnet run -- -n plaintext -s http://adx-3u-perfsvr:5001 -c http://adx-3u-svr02:5002 -o KestrelHttpServer@dev
    [03:12:40.868] Starting scenario Plaintext on benchmark server...
    [03:13:07.830] Warmup
    [03:13:07.841] Starting scenario Plaintext on benchmark client...
    [03:13:19.066] Scenario Plaintext completed on benchmark client
    [03:13:19.067] RPS: 1138723.54
    [03:13:19.069] Stopping scenario Plaintext on benchmark client...
    [03:13:19.074] Benchmark
    [03:13:19.075] Starting scenario Plaintext on benchmark client...
    [03:13:30.142] Scenario Plaintext completed on benchmark client
    [03:13:30.144] RPS: 1226353.61
    [03:13:30.145] Stopping scenario Plaintext on benchmark client...
    [03:13:30.150] Stopping scenario Plaintext on benchmark server...
    > dotnet run -- -n plaintext -s http://adx-3u-perfsvr:5001 -c http://adx-3u-svr02:5002 -o KestrelHttpServer@halter73/three-writes
    Project Repository (.NETStandard,Version=v1.0) was previously compiled. Skipping compilation.
    Project Benchmarks.ClientJob (.NETStandard,Version=v1.0) was previously compiled. Skipping compilation.
    Project Benchmarks.ServerJob (.NETStandard,Version=v1.0) was previously compiled. Skipping compilation.
    Project BenchmarksDriver (.NETCoreApp,Version=v1.0) was previously compiled. Skipping compilation.
    [03:13:57.339] Starting scenario Plaintext on benchmark server...
    [03:14:24.077] Warmup
    [03:14:24.108] Starting scenario Plaintext on benchmark client...
    [03:14:35.298] Scenario Plaintext completed on benchmark client
    [03:14:35.298] RPS: 1160654.74
    [03:14:35.298] Stopping scenario Plaintext on benchmark client...
    [03:14:35.302] Benchmark
    [03:14:35.302] Starting scenario Plaintext on benchmark client...
    [03:14:46.369] Scenario Plaintext completed on benchmark client
    [03:14:46.369] RPS: 1203719.31
    [03:14:46.369] Stopping scenario Plaintext on benchmark client...
    [03:14:46.372] Stopping scenario Plaintext on benchmark server...
    > dotnet run -- -n plaintext -s http://adx-3u-perfsvr:5001 -c http://adx-3u-svr02:5002 -o KestrelHttpServer@dev
    Project Repository (.NETStandard,Version=v1.0) was previously compiled. Skipping compilation.
    Project Benchmarks.ClientJob (.NETStandard,Version=v1.0) was previously compiled. Skipping compilation.
    Project Benchmarks.ServerJob (.NETStandard,Version=v1.0) was previously compiled. Skipping compilation.
    Project BenchmarksDriver (.NETCoreApp,Version=v1.0) was previously compiled. Skipping compilation.
    [03:15:03.186] Starting scenario Plaintext on benchmark server...
    [03:15:55.823] Warmup
    [03:15:55.855] Starting scenario Plaintext on benchmark client...
    [03:16:06.374] Scenario Plaintext completed on benchmark client
    [03:16:06.376] RPS: 1131070.46
    [03:16:06.379] Stopping scenario Plaintext on benchmark client...
    [03:16:06.384] Benchmark
    [03:16:06.385] Starting scenario Plaintext on benchmark client...
    [03:16:17.446] Scenario Plaintext completed on benchmark client
    [03:16:17.446] RPS: 1221381.6
    [03:16:17.447] Stopping scenario Plaintext on benchmark client...
    [03:16:17.450] Stopping scenario Plaintext on benchmark server...
    > dotnet run -- -n plaintext -s http://adx-3u-perfsvr:5001 -c http://adx-3u-svr02:5002 -o KestrelHttpServer@halter73/three-writes
    Project Repository (.NETStandard,Version=v1.0) was previously compiled. Skipping compilation.
    Project Benchmarks.ClientJob (.NETStandard,Version=v1.0) was previously compiled. Skipping compilation.
    Project Benchmarks.ServerJob (.NETStandard,Version=v1.0) was previously compiled. Skipping compilation.
    Project BenchmarksDriver (.NETCoreApp,Version=v1.0) was previously compiled. Skipping compilation.
    [03:16:34.935] Starting scenario Plaintext on benchmark server...
    [03:17:26.145] Warmup
    [03:17:26.165] Starting scenario Plaintext on benchmark client...
    [03:17:37.281] Scenario Plaintext completed on benchmark client
    [03:17:37.281] RPS: 1192650.87
    [03:17:37.284] Stopping scenario Plaintext on benchmark client...
    [03:17:37.287] Benchmark
    [03:17:37.288] Starting scenario Plaintext on benchmark client...
    [03:17:48.349] Scenario Plaintext completed on benchmark client
    [03:17:48.350] RPS: 1228639.49
    [03:17:48.350] Stopping scenario Plaintext on benchmark client...
    [03:17:48.353] Stopping scenario Plaintext on benchmark server...

