### PR TITLE
Avoid Null ReferenceException in Frame.RequestAbortedSource

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Http/FrameOfT.cs
@@ -87,9 +87,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
 
                         InitializeStreams(messageBody);
 
-                        _abortedCts = null;
-                        _manuallySetRequestAbortToken = null;
-
                         var context = _application.CreateContext(this);
                         try
                         {
@@ -163,8 +160,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Http
                 try
                 {
                     await TryProduceInvalidRequestResponse();
-
-                    _abortedCts = null;
 
                     // If _requestAborted is set, the connection has already been closed.
                     if (Volatile.Read(ref _requestAborted) == 0)


### PR DESCRIPTION
- Avoid unneeded resetting of _abortedCts and _manuallySetRequestAbortToken