### PR TITLE
Fixing a test failing on Mac and Linux

### DIFF
--- a/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
-                        "Hëädër: value",
+                        "H\u00eb\u00e4d\u00ebr: value",
                         "",
                         "");
                     await ReceiveBadRequestResponse(connection);


### PR DESCRIPTION
Replacing non-ASCII character with equivalent Unicode character escape sequences