### PR TITLE
Make Bad Request tests more reliable

### DIFF
--- a/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllEnd(request);
+                    await connection.SendAllTryEnd(request);
                     await ReceiveBadRequestResponse(connection);
                 }
             }
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.Send(request);
+                    await connection.SendAll(request);
                     await ReceiveBadRequestResponse(connection);
                 }
             }
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllEnd($"GET / HTTP/1.1\r\n{rawHeaders}");
+                    await connection.SendAllTryEnd($"GET / HTTP/1.1\r\n{rawHeaders}");
                     await ReceiveBadRequestResponse(connection);
                 }
             }
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.SendAllTryEnd(
                         "GET / HTTP/1.1",
                         "H\u00eb\u00e4d\u00ebr: value",
                         "",
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd($"GET {path} HTTP/1.1\r\n");
+                    await connection.SendAllTryEnd($"GET {path} HTTP/1.1\r\n");
                     await ReceiveBadRequestResponse(connection);
                 }
             }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -365,7 +364,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.Send(
+                    await connection.SendAll(
                         "POST / HTTP/1.1",
                         "Transfer-Encoding: chunked",
                         "",
@@ -407,7 +406,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.Send(
+                    await connection.SendAll(
                         "POST / HTTP/1.1",
                         "Transfer-Encoding: chunked",
                         "",

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestConnection.cs
@@ -46,16 +46,26 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public async Task SendAll(params string[] lines)
         {
             var text = String.Join("\r\n", lines);
-            var writer = new StreamWriter(_stream, Encoding.ASCII);
+            var writer = new StreamWriter(_stream, Encoding.GetEncoding("iso-8859-1"));
             await writer.WriteAsync(text);
             writer.Flush();
             _stream.Flush();
         }
 
-        public async Task SendAllEnd(params string[] lines)
+        public async Task SendAllTryEnd(params string[] lines)
         {
             await SendAll(lines);
-            _socket.Shutdown(SocketShutdown.Send);
+
+            try
+            {
+                _socket.Shutdown(SocketShutdown.Send);
+            }
+            catch (IOException)
+            {
+                // The server may forcefully close the connection (usually due to a bad request),
+                // so an IOException: "An existing connection was forcibly closed by the remote host"
+                // isn't guaranteed but not unexpected.
+            }
         }
 
         public async Task Send(params string[] lines)


### PR DESCRIPTION
- Avoid calling write again after the request is already rejected

This avoids sporadic failures like the following:

    Microsoft.AspNetCore.Server.KestrelTests.BadHttpRequestTests.BadRequestIfPathContainsNullCharacters(path: "/%F3%85%82%00") [FAIL]
      System.IO.IOException : Unable to write data to the transport connection: An established connection was aborted by the software in your host machine.
      ---- System.Net.Sockets.SocketException : An established connection was aborted by the software in your host machine
      Stack Trace:
           at System.Net.Sockets.NetworkStream.BeginWrite(Byte[] buffer, Int32 offset, Int32 size, AsyncCallback callback, Object state)
           at System.Net.Sockets.NetworkStream.<>c.<WriteAsync>b__59_0(Byte[] bufferArg, Int32 offsetArg, Int32 sizeArg, AsyncCallback callback, Object state)
           at System.Threading.Tasks.TaskFactory`1.FromAsyncImpl[TArg1,TArg2,TArg3](Func`6 beginMethod, Func`2 endFunction, Action`1 endAction, TArg1 arg1, TArg2 arg2, TArg3 arg3, Object state, TaskCreationOptions creationOptions)
           at System.Threading.Tasks.TaskFactory.FromAsync[TArg1,TArg2,TArg3](Func`6 beginMethod, Action`1 endMethod, TArg1 arg1, TArg2 arg2, TArg3 arg3, Object state)
           at System.Net.Sockets.NetworkStream.WriteAsync(Byte[] buffer, Int32 offset, Int32 size, CancellationToken cancellationToken)
           at System.IO.StreamWriter.<FlushAsyncInternal>d__67.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
        C:\Users\shalter\dev\Universe\KestrelHttpServer\test\Microsoft.AspNetCore.Server.KestrelTests\TestConnection.cs(69,0): at Microsoft.AspNetCore.Server.KestrelTests.TestConnection.<Send>d__11.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
        C:\Users\shalter\dev\Universe\KestrelHttpServer\test\Microsoft.AspNetCore.Server.KestrelTests\TestConnection.cs(79,0): at Microsoft.AspNetCore.Server.KestrelTests.TestConnection.<SendEnd>d__12.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
        C:\Users\shalter\dev\Universe\KestrelHttpServer\test\Microsoft.AspNetCore.Server.KestrelTests\BadHttpRequestTests.cs(213,0): at Microsoft.AspNetCore.Server.KestrelTests.BadHttpRequestTests.<BadRequestIfPathContainsNullCharacters>d__4.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        ----- Inner Stack Trace -----
           at System.Net.Sockets.Socket.BeginSend(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags, AsyncCallback callback, Object state)
           at System.Net.Sockets.NetworkStream.BeginWrite(Byte[] buffer, Int32 offset, Int32 size, AsyncCallback callback, Object state)
  Finished:    Microsoft.AspNetCore.Server.KestrelTests

@cesarbs @moozzyk 