### PR TITLE
Downtarget Kestrel to NETStandard 1.3

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Https/HttpsConnectionFilter.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Https/HttpsConnectionFilter.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
                 return certificate2;
             }
 
-#if NETSTANDARD1_5
+#if NETSTANDARD1_3
             // conversion X509Certificate to X509Certificate2 not supported
             // https://github.com/dotnet/corefx/issues/4510
             return null;

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Https/project.json
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Https/project.json
@@ -23,7 +23,7 @@
   },
   "frameworks": {
     "net451": {},
-    "netstandard1.5": {
+    "netstandard1.3": {
       "dependencies": {
         "System.Net.Security": "4.0.0-*"
       },

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/TaskUtilities.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/TaskUtilities.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 {
     public static class TaskUtilities
     {
-#if NETSTANDARD1_5
+#if NETSTANDARD1_3
         public static Task CompletedTask = Task.CompletedTask;
 #else
         public static Task CompletedTask = Task.FromResult<object>(null);
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
         public static Task GetCancelledTask(CancellationToken cancellationToken)
         {
-#if NETSTANDARD1_5
+#if NETSTANDARD1_3
             return Task.FromCanceled(cancellationToken);
 #else
             var tcs = new TaskCompletionSource<object>();
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
         public static Task<int> GetCancelledZeroTask(CancellationToken cancellationToken = default(CancellationToken))
         {
-#if NETSTANDARD1_5
+#if NETSTANDARD1_3
             // Make sure cancellationToken is cancelled before passing to Task.FromCanceled
             if (!cancellationToken.IsCancellationRequested)
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/project.json
@@ -31,7 +31,7 @@
         }
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "dependencies": {
         "System.Collections": "4.0.11-*",
         "System.Diagnostics.Debug": "4.0.11-*",


### PR DESCRIPTION
Kestrel doesn't need any functionality beyond NS1.3 so down targeting helps more scenarios, including moving more aspnet projects to be down targeted. 