### PR TITLE
Reduce calls to uv_async_send when loop active

### DIFF
--- a/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
@@ -688,7 +688,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 // Write isn't called twice after the thread is unblocked
                 Assert.False(writeWh.Wait(1000));
                 Assert.Equal(1, writeCount);
-                // One call to ScheduleWrite + One call to Post to block the thread
+
+                // One call to post which blocked thread
+                // So writes were posted while thread was active and don't trigger a repost
+                Assert.Equal(1, mockLibuv.PostCount);
+
+                kestrelThread.Post(_ => { }, state: null);
+
+                // Second call to Post triggers new post as thread not active
                 Assert.Equal(2, mockLibuv.PostCount);
 
                 // Cleanup

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockLibuv.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockLibuv.cs
@@ -76,6 +76,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
             _uv_strerror = errno => IntPtr.Zero;
             _uv_read_start = UvReadStart;
             _uv_read_stop = handle => 0;
+            _uv_unsafe_async_send = handle => 0;
         }
 
         public Func<UvStreamHandle, int, Action<int>, int> OnWrite { get; set; }


### PR DESCRIPTION
Fixes #865 

Before
![async-send-before](https://aoa.blob.core.windows.net/aspnet/async-send-before.png)

After
![async-send-after](https://aoa.blob.core.windows.net/aspnet/async-send-after.png)

Still need needs RPS measuring, don't have access to a network that isn't noisy enough to measure