### PR TITLE
Allocate things per KestrelThread instead of per listener

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
 
             var normalRead = status > 0;
-            var normalDone = status == Constants.ECONNRESET || status == Constants.EOF;
+            var normalDone = status == Constants.EOF;
             var errorDone = !(normalDone || normalRead);
             var readCount = normalRead ? status : 0;
 
@@ -293,13 +293,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             else
             {
                 _socket.ReadStop();
-                Log.ConnectionReadFin(ConnectionId);
+
+                if (normalDone)
+                {
+                    Log.ConnectionReadFin(ConnectionId);
+                }
             }
 
             Exception error = null;
             if (errorDone)
             {
                 handle.Libuv.Check(status, out error);
+                Log.ConnectionError(ConnectionId, error);
             }
 
             _rawSocketInput.IncomingComplete(readCount, error);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -51,8 +51,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 _bufferSizeControl = new BufferSizeControl(ServerOptions.MaxRequestBufferSize.Value, this, Thread);
             }
 
-            SocketInput = new SocketInput(Memory, ThreadPool, _bufferSizeControl);
-            SocketOutput = new SocketOutput(Thread, _socket, Memory, this, ConnectionId, Log, ThreadPool, WriteReqPool);
+            SocketInput = new SocketInput(Thread.Memory, ThreadPool, _bufferSizeControl);
+            SocketOutput = new SocketOutput(Thread, _socket, this, ConnectionId, Log, ThreadPool);
 
             var tcpHandle = _socket as UvTcpHandle;
             if (tcpHandle != null)
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             if (_filterContext.Connection != _libuvStream)
             {
-                _filteredStreamAdapter = new FilteredStreamAdapter(ConnectionId, _filterContext.Connection, Memory, Log, ThreadPool, _bufferSizeControl);
+                _filteredStreamAdapter = new FilteredStreamAdapter(ConnectionId, _filterContext.Connection, Thread.Memory, Log, ThreadPool, _bufferSizeControl);
 
                 _frame.SocketInput = _filteredStreamAdapter.SocketInput;
                 _frame.SocketOutput = _filteredStreamAdapter.SocketOutput;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private static long _lastConnectionId = DateTime.UtcNow.Ticks;
 
         private readonly UvStreamHandle _socket;
-        private Frame _frame;
+        private readonly Frame _frame;
         private ConnectionFilterContext _filterContext;
         private LibuvStream _libuvStream;
         private FilteredStreamAdapter _filteredStreamAdapter;
@@ -83,7 +83,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 _frame.SocketOutput = SocketOutput;
 
                 _frame.Start();
-
             }
             else
             {
@@ -139,8 +138,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             // called from a libuv thread.
             ThreadPool.Run(() =>
             {
-                var connection = this;
-                connection._frame.Abort();
+                _frame.Abort();
             });
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private FilteredStreamAdapter _filteredStreamAdapter;
         private Task _readInputTask;
 
-        private TaskCompletionSource<object> _socketClosedTcs;
+        private TaskCompletionSource<object> _socketClosedTcs = new TaskCompletionSource<object>();
         private BufferSizeControl _bufferSizeControl;
 
         public Connection(ListenerContext context, UvStreamHandle socket) : base(context)
@@ -127,13 +127,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         public Task StopAsync()
         {
-            if (_socketClosedTcs == null)
-            {
-                _socketClosedTcs = new TaskCompletionSource<object>();
-
-                _frame.Stop();
-                _frame.SocketInput.CompleteAwaiting();
-            }
+            _frame.Stop();
+            _frame.SocketInput.CompleteAwaiting();
 
             return _socketClosedTcs.Task;
         }
@@ -168,7 +163,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 SocketInput.Dispose();
             }
 
-            _socketClosedTcs?.TrySetResult(null);
+            _socketClosedTcs.TrySetResult(null);
         }
 
         private void ApplyConnectionFilter()

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private FilteredStreamAdapter _filteredStreamAdapter;
         private Task _readInputTask;
 
-        private TaskCompletionSource<object> _socketClosedTcs = new TaskCompletionSource<object>();
+         private TaskCompletionSource<object> _socketClosedTcs = new TaskCompletionSource<object>();
         private BufferSizeControl _bufferSizeControl;
 
         public Connection(ListenerContext context, UvStreamHandle socket) : base(context)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ConnectionManager.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ConnectionManager.cs
@@ -3,30 +3,34 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
     public class ConnectionManager
     {
-        private KestrelThread _thread;
-        private List<Task> _connectionStopTasks;
+        private readonly KestrelThread _thread;
+        private readonly IThreadPool _threadPool;
 
-        public ConnectionManager(KestrelThread thread)
+        public ConnectionManager(KestrelThread thread, IThreadPool threadPool)
         {
             _thread = thread;
+            _threadPool = threadPool;
         }
 
-        // This must be called on the libuv event loop
         public void WalkConnectionsAndClose()
         {
-            if (_connectionStopTasks != null)
-            {
-                throw new InvalidOperationException($"{nameof(WalkConnectionsAndClose)} cannot be called twice.");
-            }
+            var wh = new ManualResetEventSlim();
+            _thread.Post(state => ((ConnectionManager)state).WalkConnectionsAndCloseCore(wh), this);
+            wh.Wait();
+        }
 
-            _connectionStopTasks = new List<Task>();
+        private void WalkConnectionsAndCloseCore(ManualResetEventSlim wh)
+        {
+            var connectionStopTasks = new List<Task>();
 
             _thread.Walk(ptr =>
             {
@@ -35,19 +39,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                 if (connection != null)
                 {
-                    _connectionStopTasks.Add(connection.StopAsync());
+                    connectionStopTasks.Add(connection.StopAsync());
                 }
             });
-        }
 
-        public Task WaitForConnectionCloseAsync()
-        {
-            if (_connectionStopTasks == null)
+            _threadPool.Run(() =>
             {
-                throw new InvalidOperationException($"{nameof(WalkConnectionsAndClose)} must be called first.");
-            }
-
-            return Task.WhenAll(_connectionStopTasks);
+                Task.WaitAll(connectionStopTasks.ToArray());
+                wh.Set();
+            });
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 {
                     while (!_requestProcessingStopping && TakeStartLine(SocketInput) != RequestLineStatus.Done)
                     {
-                        if (SocketInput.RemoteIntakeFin)
+                        if (SocketInput.CheckFinOrThrow())
                         {
                             // We need to attempt to consume start lines and headers even after
                             // SocketInput.RemoteIntakeFin is set to true to ensure we don't close a
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     while (!_requestProcessingStopping && !TakeMessageHeaders(SocketInput, FrameRequestHeaders))
                     {
-                        if (SocketInput.RemoteIntakeFin)
+                        if (SocketInput.CheckFinOrThrow())
                         {
                             // We need to attempt to consume start lines and headers even after
                             // SocketInput.RemoteIntakeFin is set to true to ensure we don't close a

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Listener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Listener.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
     {
         private bool _closed;
 
-        protected Listener(ServiceContext serviceContext) 
+        protected Listener(ServiceContext serviceContext)
             : base(serviceContext)
         {
         }
@@ -28,7 +28,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             ServerAddress = address;
             Thread = thread;
-            ConnectionManager = new ConnectionManager(thread);
 
             var tcs = new TaskCompletionSource<int>(this);
 
@@ -57,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         protected static void ConnectionCallback(UvStreamHandle stream, int status, Exception error, object state)
         {
-            var listener = (Listener) state;
+            var listener = (Listener)state;
 
             if (error != null)
             {
@@ -97,22 +96,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     listener._closed = true;
 
-                    listener.ConnectionManager.WalkConnectionsAndClose();
-                }, this).ConfigureAwait(false);
-
-                await ConnectionManager.WaitForConnectionCloseAsync().ConfigureAwait(false);
-
-                await Thread.PostAsync(state =>
-                {
-                    var writeReqPool = ((Listener)state).WriteReqPool;
-                    while (writeReqPool.Count > 0)
-                    {
-                        writeReqPool.Dequeue().Dispose();
-                    }
                 }, this).ConfigureAwait(false);
             }
 
-            Memory.Dispose();
             ListenSocket = null;
         }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerContext.cs
@@ -16,8 +16,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         public ListenerContext(ServiceContext serviceContext) 
             : base(serviceContext)
         {
-            Memory = new MemoryPool();
-            WriteReqPool = new Queue<UvWriteReq>(SocketOutput.MaxPooledWriteReqs);
         }
 
         public ListenerContext(ListenerContext listenerContext)
@@ -25,20 +23,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             ServerAddress = listenerContext.ServerAddress;
             Thread = listenerContext.Thread;
-            Memory = listenerContext.Memory;
-            ConnectionManager = listenerContext.ConnectionManager;
-            WriteReqPool = listenerContext.WriteReqPool;
-            Log = listenerContext.Log;
         }
 
         public ServerAddress ServerAddress { get; set; }
 
         public KestrelThread Thread { get; set; }
-
-        public MemoryPool Memory { get; set; }
-
-        public ConnectionManager ConnectionManager { get; set; }
-
-        public Queue<UvWriteReq> WriteReqPool { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerSecondary.cs
@@ -39,8 +39,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             ServerAddress = address;
             Thread = thread;
-            ConnectionManager = new ConnectionManager(thread);
-
             DispatchPipe = new UvPipeHandle(Log);
 
             var tcs = new TaskCompletionSource<int>(this);
@@ -180,27 +178,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     listener._closed = true;
 
-                    listener.ConnectionManager.WalkConnectionsAndClose();
-                }, this).ConfigureAwait(false);
-
-                await ConnectionManager.WaitForConnectionCloseAsync().ConfigureAwait(false);
-
-                await Thread.PostAsync(state =>
-                {
-                    var listener = (ListenerSecondary)state;
-                    var writeReqPool = listener.WriteReqPool;
-                    while (writeReqPool.Count > 0)
-                    {
-                        writeReqPool.Dequeue().Dispose();
-                    }
                 }, this).ConfigureAwait(false);
             }
             else
             {
                 FreeBuffer();
             }
-
-            Memory.Dispose();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 {
                     while (_mode == Mode.Prefix)
                     {
-                        var fin = input.RemoteIntakeFin;
+                        var fin = input.CheckFinOrThrow();
 
                         ParseChunkedPrefix(input);
 
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     while (_mode == Mode.Extension)
                     {
-                        var fin = input.RemoteIntakeFin;
+                        var fin = input.CheckFinOrThrow();
 
                         ParseExtension(input);
 
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     while (_mode == Mode.Data)
                     {
-                        var fin = input.RemoteIntakeFin;
+                        var fin = input.CheckFinOrThrow();
 
                         int actual = ReadChunkedData(input, buffer.Array, buffer.Offset, buffer.Count);
 
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     while (_mode == Mode.Suffix)
                     {
-                        var fin = input.RemoteIntakeFin;
+                        var fin = input.CheckFinOrThrow();
 
                         ParseChunkedSuffix(input);
 
@@ -317,7 +317,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 // Chunks finished, parse trailers
                 while (_mode == Mode.Trailer)
                 {
-                    var fin = input.RemoteIntakeFin;
+                    var fin = input.CheckFinOrThrow();
 
                     ParseChunkedTrailer(input);
 
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 {
                     while (!_context.TakeMessageHeaders(input, _requestHeaders))
                     {
-                        if (input.RemoteIntakeFin)
+                        if (input.CheckFinOrThrow())
                         {
                             if (_context.TakeMessageHeaders(input, _requestHeaders))
                             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketInputExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketInputExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             while (input.IsCompleted)
             {
-                var fin = input.RemoteIntakeFin;
+                var fin = input.CheckFinOrThrow();
 
                 var begin = input.ConsumingStart();
                 int actual;
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             {
                 await input;
 
-                var fin = input.RemoteIntakeFin;
+                var fin = input.CheckFinOrThrow();
 
                 var begin = input.ConsumingStart();
                 int actual;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/Constants.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/Constants.cs
@@ -10,7 +10,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         public const int ListenBacklog = 128;
 
         public const int EOF = -4095;
-        public static readonly int? ECONNRESET = GetECONNRESET();
         public static readonly int? EADDRINUSE = GetEADDRINUSE();
 
         /// <summary>
@@ -25,23 +24,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         public const string RFC1123DateFormat = "r";
 
         public const string ServerName = "Kestrel";
-
-        private static int? GetECONNRESET()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-               return -4077;
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return -104;
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return -54;
-            }
-            return null;
-        }
 
         private static int? GetEADDRINUSE()
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
@@ -92,10 +92,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                         "ThreadCount must be positive.");
                 }
 
-                if (!Constants.ECONNRESET.HasValue)
-                {
-                    _logger.LogWarning("Unable to determine ECONNRESET value on this platform.");
-                }
                 if (!Constants.EADDRINUSE.HasValue)
                 {
                     _logger.LogWarning("Unable to determine EADDRINUSE value on this platform.");

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
@@ -6,7 +6,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.1.0-*",
     "Microsoft.AspNetCore.Server.Kestrel.Https": "1.1.0-*",
     "Microsoft.AspNetCore.Testing": "1.1.0-*",
-    "Microsoft.Extensions.Logging.Console": "1.1.0-*",
+    "Microsoft.Extensions.Logging.Testing": "1.1.0-*",
     "Newtonsoft.Json": "9.0.1",
     "xunit": "2.2.0-*"
   },

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var mockLibuv = new MockLibuv();
 
-            using (var memory = new MemoryPool())
             using (var engine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 engine.Start(count: 1);
@@ -27,7 +26,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     FrameFactory = connectionContext => new Frame<HttpContext>(
                         new DummyApplication(httpContext => TaskUtilities.CompletedTask), connectionContext),
-                    Memory = memory,
                     ServerAddress = ServerAddress.FromUrl("http://127.0.0.1:0"),
                     Thread = engine.Threads[0]
                 };

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 Libuv.uv_buf_t ignored;
                 mockLibuv.AllocCallback(socket.InternalGetHandle(), 2048, out ignored);
                 mockLibuv.ReadCallback(socket.InternalGetHandle(), 0, ref ignored);
-                Assert.False(connection.SocketInput.RemoteIntakeFin);
+                Assert.False(connection.SocketInput.CheckFinOrThrow());
 
                 connection.ConnectionControl.End(ProduceEndType.SocketDisconnect);
             }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             // This should match _maxBytesPreCompleted in SocketOutput
             var maxBytesPreCompleted = 65536;
-            var completeQueue = new Queue<Action<int>>();
+            var completeQueue = new ConcurrentQueue<Action<int>>();
 
             // Arrange
             var mockLibuv = new MockLibuv
@@ -87,7 +87,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(mockLibuv, kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, new MockConnection(), "0", trace, ltp, new Queue<UvWriteReq>());
+                var mockConnection = new MockConnection();
+                var socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
 
                 var bufferSize = maxBytesPreCompleted;
                 var buffer = new ArraySegment<byte>(new byte[bufferSize], 0, bufferSize);
@@ -111,7 +112,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 // Too many bytes are already pre-completed for the second write to pre-complete.
                 Assert.False(completedWh.Wait(1000));
                 // Act
-                completeQueue.Dequeue()(0);
+                Action<int> triggerNextCompleted;
+                Assert.True(completeQueue.TryDequeue(out triggerNextCompleted));
+                triggerNextCompleted(0);
                 // Assert
                 // Finishing the first write should allow the second write to pre-complete.
                 Assert.True(completedWh.Wait(1000));
@@ -119,6 +122,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 // Cleanup
                 var cleanupTask = socketOutput.WriteAsync(
                     default(ArraySegment<byte>), default(CancellationToken), socketDisconnect: true);
+
+                // Wait for all writes to complete so the completeQueue isn't modified during enumeration.
+                Assert.True(mockConnection.SocketClosed.Wait(1000));
 
                 foreach (var triggerCompleted in completeQueue)
                 {
@@ -132,7 +138,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             // This should match _maxBytesPreCompleted in SocketOutput
             var maxBytesPreCompleted = 65536;
-            var completeQueue = new Queue<Action<int>>();
+            var completeQueue = new ConcurrentQueue<Action<int>>();
             var writeRequestedWh = new ManualResetEventSlim();
 
             // Arrange
@@ -155,7 +161,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(mockLibuv, kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, new MockConnection(), "0", trace, ltp, new Queue<UvWriteReq>());
+                var mockConnection = new MockConnection();
+                var socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
 
                 var bufferSize = maxBytesPreCompleted / 2;
                 var data = new byte[bufferSize];
@@ -185,7 +192,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 Assert.Equal(2, completeQueue.Count);
 
                 // Act
-                completeQueue.Dequeue()(0);
+                Action<int> triggerNextCompleted;
+                Assert.True(completeQueue.TryDequeue(out triggerNextCompleted));
+                triggerNextCompleted(0);
 
                 // Assert
                 // Finishing the first write should allow the second write to pre-complete.
@@ -194,6 +203,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 // Cleanup
                 var cleanupTask = socketOutput.WriteAsync(
                     default(ArraySegment<byte>), default(CancellationToken), socketDisconnect: true);
+
+                // Wait for all writes to complete so the completeQueue isn't modified during enumeration.
+                Assert.True(mockConnection.SocketClosed.Wait(1000));
 
                 foreach (var triggerCompleted in completeQueue)
                 {
@@ -207,7 +219,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             // This should match _maxBytesPreCompleted in SocketOutput
             var maxBytesPreCompleted = 65536;
-            var completeQueue = new Queue<Action<int>>();
+            var completeQueue = new ConcurrentQueue<Action<int>>();
 
             // Arrange
             var mockLibuv = new MockLibuv
@@ -298,11 +310,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     Assert.False(task6Success.IsCanceled);
                     Assert.False(task6Success.IsFaulted);
 
-                    Assert.True(true);
-
                     // Cleanup
                     var cleanupTask = ((SocketOutput)socketOutput).WriteAsync(
                         default(ArraySegment<byte>), default(CancellationToken), socketDisconnect: true);
+
+                    // Allow for the socketDisconnect command to get posted to the libuv thread.
+                    // Right now, the up to three pending writes are holding it up.
+                    Action<int> triggerNextCompleted;
+                    Assert.True(completeQueue.TryDequeue(out triggerNextCompleted));
+                    triggerNextCompleted(0);
+
+                    // Wait for all writes to complete so the completeQueue isn't modified during enumeration.
+                    Assert.True(mockConnection.SocketClosed.Wait(1000));
 
                     foreach (var triggerCompleted in completeQueue)
                     {
@@ -317,7 +336,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             // This should match _maxBytesPreCompleted in SocketOutput
             var maxBytesPreCompleted = 65536;
-            var completeQueue = new Queue<Action<int>>();
+            var completeQueue = new ConcurrentQueue<Action<int>>();
 
             // Arrange
             var mockLibuv = new MockLibuv
@@ -376,7 +395,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     Assert.False(task3Canceled.IsFaulted);
 
                     // Cause the first write to fail.
-                    completeQueue.Dequeue()(-1);
+                    Action<int> triggerNextCompleted;
+                    Assert.True(completeQueue.TryDequeue(out triggerNextCompleted));
+                    triggerNextCompleted(-1);
 
                     // Second task is now completed
                     await task2Success;
@@ -388,6 +409,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     // Cleanup
                     var cleanupTask = ((SocketOutput)socketOutput).WriteAsync(
                         default(ArraySegment<byte>), default(CancellationToken), socketDisconnect: true);
+
+                    // Wait for all writes to complete so the completeQueue isn't modified during enumeration.
+                    Assert.True(mockConnection.SocketClosed.Wait(1000));
 
                     foreach (var triggerCompleted in completeQueue)
                     {
@@ -402,7 +426,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             // This should match _maxBytesPreCompleted in SocketOutput
             var maxBytesPreCompleted = 65536;
-            var completeQueue = new Queue<Action<int>>();
+            var completeQueue = new ConcurrentQueue<Action<int>>();
             var onWriteWh = new ManualResetEventSlim();
 
             // Arrange
@@ -426,7 +450,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(mockLibuv, kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, new MockConnection(), "0", trace, ltp, new Queue<UvWriteReq>());
+                var mockConnection = new MockConnection();
+                var socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
 
                 var bufferSize = maxBytesPreCompleted;
                 var buffer = new ArraySegment<byte>(new byte[bufferSize], 0, bufferSize);
@@ -460,7 +485,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 socketOutput.WriteAsync(buffer, default(CancellationToken)).ContinueWith(onCompleted2);
 
                 Assert.True(onWriteWh.Wait(1000));
-                completeQueue.Dequeue()(0);
+                Action<int> triggerNextCompleted;
+                Assert.True(completeQueue.TryDequeue(out triggerNextCompleted));
+                triggerNextCompleted(0);
 
                 // Assert 
                 // Too many bytes are already pre-completed for the third but not the second write to pre-complete.
@@ -469,7 +496,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 Assert.False(completedWh2.Wait(1000));
 
                 // Act
-                completeQueue.Dequeue()(0);
+                Assert.True(completeQueue.TryDequeue(out triggerNextCompleted));
+                triggerNextCompleted(0);
 
                 // Assert
                 // Finishing the first write should allow the second write to pre-complete.
@@ -478,6 +506,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 // Cleanup
                 var cleanupTask = ((SocketOutput)socketOutput).WriteAsync(
                     default(ArraySegment<byte>), default(CancellationToken), socketDisconnect: true);
+
+                // Wait for all writes to complete so the completeQueue isn't modified during enumeration.
+                Assert.True(mockConnection.SocketClosed.Wait(1000));
 
                 foreach (var triggerCompleted in completeQueue)
                 {
@@ -543,7 +574,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void OnlyAllowsUpToThreeConcurrentWrites()
         {
             var writeWh = new ManualResetEventSlim();
-            var completeQueue = new Queue<Action<int>>();
+            var completeQueue = new ConcurrentQueue<Action<int>>();
 
             var mockLibuv = new MockLibuv
             {
@@ -564,7 +595,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(mockLibuv, kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, new MockConnection(), "0", trace, ltp, new Queue<UvWriteReq>());
+                var mockConnection = new MockConnection();
+                var socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
 
                 var buffer = new ArraySegment<byte>(new byte[1]);
 
@@ -584,12 +616,21 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 Assert.False(writeWh.Wait(1000));
 
                 // Complete 1st write allowing uv_write to be triggered again
-                completeQueue.Dequeue()(0);
+                Action<int> triggerNextCompleted;
+                Assert.True(completeQueue.TryDequeue(out triggerNextCompleted));
+                triggerNextCompleted(0);
                 Assert.True(writeWh.Wait(1000));
 
                 // Cleanup
                 var cleanupTask = socketOutput.WriteAsync(
                     default(ArraySegment<byte>), default(CancellationToken), socketDisconnect: true);
+
+                // Allow for the socketDisconnect command to get posted to the libuv thread.
+                // Right now, the three pending writes are holding it up.
+                Assert.True(completeQueue.TryDequeue(out triggerNextCompleted));
+                triggerNextCompleted(0);
+                // Wait for all writes to complete so the completeQueue isn't modified during enumeration.
+                Assert.True(mockConnection.SocketClosed.Wait(1000));
 
                 foreach (var triggerCompleted in completeQueue)
                 {

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             FrameContext.SocketInput.IncomingData(data, 0, data.Length);
             if (fin)
             {
-                FrameContext.SocketInput.RemoteIntakeFin = true;
+                FrameContext.SocketInput.IncomingFin();
             }
         }
 


### PR DESCRIPTION
- Moved things that have loop affinity to KestrelThread like
WriteReqPool, MemoryPool and the ConnectionManager
- Changed on the listeners to only kill the ListenSocket, not the
connections on dispose
- Moved connection disposal to KestrelThread.Stop
- Simplify the connection manager logic so it's possible to walk and
wait in a single call

(Note: Builds on no-connection-locks but that doesn't really matter)