### PR TITLE
Enable all tests in HttpsConnectionFilterTests to run on all platforms

### DIFF
--- a/KestrelHttpServer.sln
+++ b/KestrelHttpServer.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Server.Kestrel", "src\Microsoft.AspNetCore.Server.Kestrel\Microsoft.AspNetCore.Server.Kestrel.xproj", "{F510611A-3BEE-4B88-A613-5F4A74ED82A1}"
 EndProject
@@ -31,6 +31,11 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Server.Kestrel.Https", "src\Microsoft.AspNetCore.Server.Kestrel.Https\Microsoft.AspNetCore.Server.Kestrel.Https.xproj", "{5F64B3C3-0C2E-431A-B820-A81BBFC863DA}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Server.Kestrel.FunctionalTests", "test\Microsoft.AspNetCore.Server.Kestrel.FunctionalTests\Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.xproj", "{9559A5F1-080C-4909-B6CF-7E4B3DC55748}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{0EF2ACDF-012F-4472-A13A-4272419E2903}"
+	ProjectSection(SolutionItems) = preProject
+		test\shared\HttpClientSlim.cs = test\shared\HttpClientSlim.cs
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -78,5 +83,6 @@ Global
 		{BD2D4D29-1BD9-40D0-BB31-337D5416B63C} = {327F7880-D9AF-46BD-B45C-3B7E34A01DFD}
 		{5F64B3C3-0C2E-431A-B820-A81BBFC863DA} = {2D5D5227-4DBD-499A-96B1-76A36B03B750}
 		{9559A5F1-080C-4909-B6CF-7E4B3DC55748} = {D3273454-EA07-41D2-BF0B-FCC3675C2483}
+		{0EF2ACDF-012F-4472-A13A-4272419E2903} = {D3273454-EA07-41D2-BF0B-FCC3675C2483}
 	EndGlobalSection
 EndGlobal

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
@@ -85,10 +86,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 host.Start();
 
-                var client = new HttpClientSlim() { ValidateCertificate = false };
                 foreach (var testUrl in testUrls(host.ServerFeatures.Get<IServerAddressesFeature>()))
                 {
-                    var response = await client.GetStringAsync(testUrl);
+                    var response = await HttpClientSlim.GetStringAsync(testUrl, validateCertificate: false);
 
                     // Compare the response with Uri.ToString(), rather than testUrl directly.
                     // Required to handle IPv6 addresses with zone index, like "fe80::3%1"

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpClientSlimTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpClientSlimTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
+{
+    public class HttpClientSlimTests
+    {
+        [Fact]
+        public async Task GetStringAsyncHttp()
+        {
+            using (var host = StartHost())
+            {
+                Assert.Equal("test", await HttpClientSlim.GetStringAsync(host.GetUris().First()));
+            }
+        }
+
+        [Fact]
+        public async Task GetStringAsyncHttps()
+        {
+            using (var host = StartHost(protocol: "https"))
+            {
+                Assert.Equal("test", await HttpClientSlim.GetStringAsync(host.GetUris().First(), validateCertificate: false));
+            }
+        }
+
+        private IWebHost StartHost(string protocol = "http", int statusCode = 200)
+        {
+            var host = new WebHostBuilder()
+                .UseUrls($"{protocol}://127.0.0.1:0")
+                .UseKestrel(options =>
+                {
+                    options.UseHttps(@"TestResources/testCert.pfx", "testPassword");
+                })
+                .Configure((app) =>
+                {
+                    app.Run(context =>
+                    {
+                        return context.Response.WriteAsync("test");
+                    });
+                })
+                .Build();
+
+            host.Start();
+            return host;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpClientSlimTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpClientSlimTests.cs
@@ -53,6 +53,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
+        [Fact]
+        public async Task PostAsyncHttps()
+        {
+            using (var host = StartHost(protocol: "https",
+                handler: (context) => context.Request.Body.CopyToAsync(context.Response.Body)))
+            {
+                Assert.Equal("test post", await HttpClientSlim.PostAsync(host.GetUri(),
+                    new StringContent("test post"), validateCertificate: false));
+            }
+        }
+
+        [Fact]
+        public async Task PostAsyncThrowsForErrorResponse()
+        {
+            using (var host = StartHost(statusCode: 500))
+            {
+                await Assert.ThrowsAnyAsync<HttpRequestException>(
+                    () => HttpClientSlim.PostAsync(host.GetUri(), new StringContent("")));
+            }
+        }
+
         private IWebHost StartHost(string protocol = "http", int statusCode = 200, Func<HttpContext, Task> handler = null)
         {
             var host = new WebHostBuilder()

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/IWebHostPortExtensions.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/IWebHostPortExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Hosting
     {
         public static string GetHost(this IWebHost host)
         {
-            return host.GetUris().First().Host;
+            return host.GetUri().Host;
         }
 
         public static int GetPort(this IWebHost host)
@@ -39,6 +39,11 @@ namespace Microsoft.AspNetCore.Hosting
             return host.ServerFeatures.Get<IServerAddressesFeature>().Addresses
                 .Select(a => a.Replace("://+", "://localhost"))
                 .Select(a => new Uri(a));
+        }
+
+        public static Uri GetUri(this IWebHost host)
+        {
+            return host.GetUris().First();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
@@ -31,6 +31,11 @@
   },
   "buildOptions": {
     "allowUnsafe": true,
+    "compile": {
+      "include": [
+        "../shared/**/*.cs"
+      ]
+    },
     "copyToOutput": {
       "include": "TestResources/testCert.pfx"
     }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
@@ -198,9 +198,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "WinHttpHandler not available on non-Windows.")]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "WinHttpHandler not available on non-Windows.")]
+        [Fact]
         public async Task HttpsSchemePassedToRequestFeature()
         {
             var serviceContext = new TestServiceContext(
@@ -214,12 +212,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             using (var server = new TestServer(context => context.Response.WriteAsync(context.Request.Scheme), serviceContext, _serverAddress))
             {
-                using (var client = new HttpClient(GetHandler()))
-                {
-                    var result = await client.GetAsync($"https://localhost:{server.Port}/");
-
-                    Assert.Equal("https", await result.Content.ReadAsStringAsync());
-                }
+                var result = await HttpClientSlim.GetStringAsync($"https://localhost:{server.Port}/", validateCertificate: false);
+                Assert.Equal("https", result);
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Filter;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
@@ -103,9 +104,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "WinHttpHandler not available on non-Windows.")]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "WinHttpHandler not available on non-Windows.")]
+        [Fact]
         public async Task AllowCertificateContinuesWhenNoCertificate()
         {
             var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
@@ -124,12 +123,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 },
                 serviceContext, _serverAddress))
             {
-                using (var client = new HttpClient(GetHandler()))
-                {
-                    var result = await client.GetAsync($"https://localhost:{server.Port}/");
-
-                    Assert.Equal("hello world", await result.Content.ReadAsStringAsync());
-                }
+                var result = await HttpClientSlim.GetStringAsync($"https://localhost:{server.Port}/", validateCertificate: false);
+                Assert.Equal("hello world", result);
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
@@ -56,9 +56,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         // https://github.com/aspnet/KestrelHttpServer/issues/240
         // This test currently fails on mono because of an issue with SslStream.
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "WinHttpHandler not available on non-Windows.")]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "WinHttpHandler not available on non-Windows.")]
+        [Fact]
         public async Task CanReadAndWriteWithHttpsConnectionFilter()
         {
             var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
@@ -69,14 +67,13 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             using (var server = new TestServer(App, serviceContext, _serverAddress))
             {
-                using (var client = new HttpClient(GetHandler()))
-                {
-                    var result = await client.PostAsync($"https://localhost:{server.Port}/", new FormUrlEncodedContent(new[] {
-                            new KeyValuePair<string, string>("content", "Hello World?")
-                        }));
+                var result = await HttpClientSlim.PostAsync($"https://localhost:{server.Port}/",
+                    new FormUrlEncodedContent(new[] {
+                        new KeyValuePair<string, string>("content", "Hello World?")
+                    }),
+                    validateCertificate: false);
 
-                    Assert.Equal("content=Hello+World%3F", await result.Content.ReadAsStringAsync());
-                }
+                Assert.Equal("content=Hello+World%3F", result);
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -18,41 +17,14 @@ using Microsoft.AspNetCore.Server.Kestrel.Filter;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
 {
-    public class HttpsConnectionFilterTests : IDisposable
+    public class HttpsConnectionFilterTests
     {
         private static string _serverAddress = "https://127.0.0.1:0/";
-        private static RemoteCertificateValidationCallback _alwaysValidCallback =
-                    (sender, cert, chain, sslPolicyErrors) => true;
         private static X509Certificate2 _x509Certificate2 = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword");
-
-#if NET451
-        static HttpsConnectionFilterTests()
-        {
-            // SecurityProtocolType values below not available in Mono < 4.3
-            const int SecurityProtocolTypeTls11 = 768;
-            const int SecurityProtocolTypeTls12 = 3072;
-            ServicePointManager.SecurityProtocol |= (SecurityProtocolType)(SecurityProtocolTypeTls12 | SecurityProtocolTypeTls11);
-        }
-#endif
-
-        public HttpsConnectionFilterTests()
-        {
-#if NET451
-            ServicePointManager.ServerCertificateValidationCallback += _alwaysValidCallback;
-#endif
-        }
-
-        public void Dispose()
-        {
-#if NET451
-            ServicePointManager.ServerCertificateValidationCallback -= _alwaysValidCallback;
-#endif
-        }
 
         // https://github.com/aspnet/KestrelHttpServer/issues/240
         // This test currently fails on mono because of an issue with SslStream.
@@ -403,17 +375,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 catch (IOException) { }
                 Assert.Null(line);
             }
-        }
-
-        private HttpMessageHandler GetHandler()
-        {
-#if NET451
-            return new HttpClientHandler();
-#else
-            var handler = new WinHttpHandler();
-            handler.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
-            return handler;
-#endif
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
@@ -80,9 +80,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "WinHttpHandler not available on non-Windows.")]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "WinHttpHandler not available on non-Windows.")]
+        [Fact]
         public async Task RequireCertificateFailsWhenNoCertificate()
         {
             var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
@@ -96,11 +94,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             using (var server = new TestServer(App, serviceContext, _serverAddress))
             {
-                using (var client = new HttpClient(GetHandler()))
-                {
-                    await Assert.ThrowsAnyAsync<Exception>(
-                        () => client.GetAsync($"https://localhost:{server.Port}/"));
-                }
+                await Assert.ThrowsAnyAsync<Exception>(
+                    () => HttpClientSlim.GetStringAsync($"https://localhost:{server.Port}/"));
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/project.json
@@ -33,6 +33,11 @@
   },
   "buildOptions": {
     "allowUnsafe": true,
+    "compile": {
+      "include": [
+        "../shared/**/*.cs"
+      ]
+    },
     "keyFile": "../../tools/Key.snk",
     "copyToOutput": {
       "include": "TestResources/testCert.pfx"

--- a/test/shared/HttpClientSlim.cs
+++ b/test/shared/HttpClientSlim.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
@@ -32,10 +33,25 @@ namespace Microsoft.AspNetCore.Testing
                 using (var reader = new StreamReader(stream, Encoding.ASCII))
                 {
                     var response = await reader.ReadToEndAsync();
+
+                    var status = GetStatus(response);
+
+                    Console.WriteLine(status);
+
+                    new HttpResponseMessage(status).EnsureSuccessStatusCode();
+
                     var body = response.Substring(response.IndexOf("\r\n\r\n") + 4);
                     return body;
                 }
             }
+        }
+
+        private static HttpStatusCode GetStatus(string response)
+        {
+            var statusStart = response.IndexOf(' ') + 1;
+            var statusEnd = response.IndexOf(' ', statusStart) - 1;
+            var statusLength = statusEnd - statusStart + 1;
+            return (HttpStatusCode)int.Parse(response.Substring(statusStart, statusLength));
         }
 
         private static async Task<Stream> GetStream(Uri requestUri, bool validateCertificate)

--- a/test/shared/HttpClientSlim.cs
+++ b/test/shared/HttpClientSlim.cs
@@ -64,9 +64,6 @@ namespace Microsoft.AspNetCore.Testing
                 var response = await reader.ReadToEndAsync();
 
                 var status = GetStatus(response);
-
-                Console.WriteLine(status);
-
                 new HttpResponseMessage(status).EnsureSuccessStatusCode();
 
                 var body = response.Substring(response.IndexOf("\r\n\r\n") + 4);


### PR DESCRIPTION
- Move `HttpClientSlim.cs` to `test\shared`
- Change `HttpClientSlim` to static class to simplify calling code
- Add `HttpClientSlim.PostAsync()`

@halter73, @cesarbs 