### PR TITLE
Allocate things per KestrelThread instead of per listener

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -52,8 +52,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 _bufferSizeControl = new BufferSizeControl(ServerOptions.MaxRequestBufferSize.Value, this, Thread);
             }
 
-            SocketInput = new SocketInput(Memory, ThreadPool, _bufferSizeControl);
-            SocketOutput = new SocketOutput(Thread, _socket, Memory, this, ConnectionId, Log, ThreadPool, WriteReqPool);
+            SocketInput = new SocketInput(Thread.Memory, ThreadPool, _bufferSizeControl);
+            SocketOutput = new SocketOutput(Thread, _socket, this, ConnectionId, Log, ThreadPool);
 
             var tcpHandle = _socket as UvTcpHandle;
             if (tcpHandle != null)
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             if (_filterContext.Connection != _libuvStream)
             {
-                _filteredStreamAdapter = new FilteredStreamAdapter(ConnectionId, _filterContext.Connection, Memory, Log, ThreadPool, _bufferSizeControl);
+                _filteredStreamAdapter = new FilteredStreamAdapter(ConnectionId, _filterContext.Connection, Thread.Memory, Log, ThreadPool, _bufferSizeControl);
 
                 _frame.SocketInput = _filteredStreamAdapter.SocketInput;
                 _frame.SocketOutput = _filteredStreamAdapter.SocketOutput;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Listener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Listener.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
     {
         private bool _closed;
 
-        protected Listener(ServiceContext serviceContext) 
+        protected Listener(ServiceContext serviceContext)
             : base(serviceContext)
         {
         }
@@ -28,7 +28,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             ServerAddress = address;
             Thread = thread;
-            ConnectionManager = new ConnectionManager(thread);
 
             var tcs = new TaskCompletionSource<int>(this);
 
@@ -57,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         protected static void ConnectionCallback(UvStreamHandle stream, int status, Exception error, object state)
         {
-            var listener = (Listener) state;
+            var listener = (Listener)state;
 
             if (error != null)
             {
@@ -97,22 +96,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     listener._closed = true;
 
-                    listener.ConnectionManager.WalkConnectionsAndClose();
-                }, this).ConfigureAwait(false);
-
-                await ConnectionManager.WaitForConnectionCloseAsync().ConfigureAwait(false);
-
-                await Thread.PostAsync(state =>
-                {
-                    var writeReqPool = ((Listener)state).WriteReqPool;
-                    while (writeReqPool.Count > 0)
-                    {
-                        writeReqPool.Dequeue().Dispose();
-                    }
                 }, this).ConfigureAwait(false);
             }
 
-            Memory.Dispose();
             ListenSocket = null;
         }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerContext.cs
@@ -16,8 +16,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         public ListenerContext(ServiceContext serviceContext) 
             : base(serviceContext)
         {
-            Memory = new MemoryPool();
-            WriteReqPool = new Queue<UvWriteReq>(SocketOutput.MaxPooledWriteReqs);
         }
 
         public ListenerContext(ListenerContext listenerContext)
@@ -25,20 +23,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             ServerAddress = listenerContext.ServerAddress;
             Thread = listenerContext.Thread;
-            Memory = listenerContext.Memory;
-            ConnectionManager = listenerContext.ConnectionManager;
-            WriteReqPool = listenerContext.WriteReqPool;
-            Log = listenerContext.Log;
         }
 
         public ServerAddress ServerAddress { get; set; }
 
         public KestrelThread Thread { get; set; }
-
-        public MemoryPool Memory { get; set; }
-
-        public ConnectionManager ConnectionManager { get; set; }
-
-        public Queue<UvWriteReq> WriteReqPool { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerSecondary.cs
@@ -39,8 +39,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             ServerAddress = address;
             Thread = thread;
-            ConnectionManager = new ConnectionManager(thread);
-
             DispatchPipe = new UvPipeHandle(Log);
 
             var tcs = new TaskCompletionSource<int>(this);
@@ -180,27 +178,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     listener._closed = true;
 
-                    listener.ConnectionManager.WalkConnectionsAndClose();
-                }, this).ConfigureAwait(false);
-
-                await ConnectionManager.WaitForConnectionCloseAsync().ConfigureAwait(false);
-
-                await Thread.PostAsync(state =>
-                {
-                    var listener = (ListenerSecondary)state;
-                    var writeReqPool = listener.WriteReqPool;
-                    while (writeReqPool.Count > 0)
-                    {
-                        writeReqPool.Dequeue().Dispose();
-                    }
                 }, this).ConfigureAwait(false);
             }
             else
             {
                 FreeBuffer();
             }
-
-            Memory.Dispose();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/WriteReqPool.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/WriteReqPool.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
+{
+    public class WriteReqPool
+    {
+        private const int _maxPooledWriteReqs = 1024;
+
+        private readonly KestrelThread _thread;
+        private readonly Queue<UvWriteReq> _pool = new Queue<UvWriteReq>(_maxPooledWriteReqs);
+        private readonly IKestrelTrace _log;
+        private bool _disposed;
+
+        public WriteReqPool(KestrelThread thread, IKestrelTrace log)
+        {
+            _thread = thread;
+            _log = log;
+        }
+
+        public UvWriteReq Allocate()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+
+            UvWriteReq req;
+            if (_pool.Count > 0)
+            {
+                req = _pool.Dequeue();
+            }
+            else
+            {
+                req = new UvWriteReq(_log);
+                req.Init(_thread.Loop);
+            }
+
+            return req;
+        }
+
+        public void Return(UvWriteReq req)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+
+            if (_pool.Count < _maxPooledWriteReqs)
+            {
+                _pool.Enqueue(req);
+            }
+            else
+            {
+                req.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                while (_pool.Count > 0)
+                {
+                    _pool.Dequeue().Dispose();
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var mockLibuv = new MockLibuv();
 
-            using (var memory = new MemoryPool())
             using (var engine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 engine.Start(count: 1);
@@ -27,7 +26,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     FrameFactory = connectionContext => new Frame<HttpContext>(
                         new DummyApplication(httpContext => TaskUtilities.CompletedTask), connectionContext),
-                    Memory = memory,
                     ServerAddress = ServerAddress.FromUrl("http://127.0.0.1:0"),
                     Thread = engine.Threads[0]
                 };

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
@@ -26,8 +26,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             // Arrange
             var mockLibuv = new MockLibuv();
-
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -36,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(mockLibuv, kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, new MockConnection(), "0", trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, new MockConnection(), "0", trace, ltp);
 
                 // I doubt _maxBytesPreCompleted will ever be over a MB. If it is, we should change this test.
                 var bufferSize = 1048576;
@@ -78,7 +76,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 }
             };
 
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -88,7 +85,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
                 var mockConnection = new MockConnection();
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, mockConnection, "0", trace, ltp);
 
                 var bufferSize = maxBytesPreCompleted;
                 var buffer = new ArraySegment<byte>(new byte[bufferSize], 0, bufferSize);
@@ -152,7 +149,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 }
             };
 
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -162,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
                 var mockConnection = new MockConnection();
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, mockConnection, "0", trace, ltp);
 
                 var bufferSize = maxBytesPreCompleted / 2;
                 var data = new byte[bufferSize];
@@ -231,7 +227,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 }
             };
 
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -240,10 +235,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(mockLibuv, kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                
+
                 using (var mockConnection = new MockConnection())
                 {
-                    ISocketOutput socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
+                    ISocketOutput socketOutput = new SocketOutput(kestrelThread, socket, mockConnection, "0", trace, ltp);
 
                     var bufferSize = maxBytesPreCompleted;
 
@@ -348,7 +343,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 }
             };
 
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -361,7 +355,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 using (var mockConnection = new MockConnection())
                 {
                     var abortedSource = mockConnection.RequestAbortedSource;
-                    ISocketOutput socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
+                    ISocketOutput socketOutput = new SocketOutput(kestrelThread, socket, mockConnection, "0", trace, ltp);
 
                     var bufferSize = maxBytesPreCompleted;
 
@@ -441,7 +435,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 }
             };
 
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -451,7 +444,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
                 var mockConnection = new MockConnection();
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, mockConnection, "0", trace, ltp);
 
                 var bufferSize = maxBytesPreCompleted;
                 var buffer = new ArraySegment<byte>(new byte[bufferSize], 0, bufferSize);
@@ -534,7 +527,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 }
             };
 
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -543,14 +535,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(mockLibuv, kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, new MockConnection(), "0", trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, new MockConnection(), "0", trace, ltp);
 
                 // block 1
                 var start = socketOutput.ProducingStart();
                 start.Block.End = start.Block.Data.Offset + start.Block.Data.Count;
 
                 // block 2
-                var block2 = memory.Lease();
+                var block2 = kestrelThread.Memory.Lease();
                 block2.End = block2.Data.Offset + block2.Data.Count;
                 start.Block.Next = block2;
 
@@ -586,7 +578,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 }
             };
 
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -596,7 +587,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
                 var mockConnection = new MockConnection();
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, mockConnection, "0", trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, mockConnection, "0", trace, ltp);
 
                 var buffer = new ArraySegment<byte>(new byte[1]);
 
@@ -656,7 +647,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 }
             };
 
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -665,7 +655,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var socket = new MockSocket(mockLibuv, kestrelThread.Loop.ThreadId, new TestKestrelTrace());
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, new MockConnection(), "0", trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, new MockConnection(), "0", trace, ltp);
 
                 var blockThreadWh = new ManualResetEventSlim();
                 kestrelThread.Post(_ =>
@@ -702,7 +692,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var mockLibuv = new MockLibuv();
 
-            using (var memory = new MemoryPool())
             using (var kestrelEngine = new KestrelEngine(mockLibuv, new TestServiceContext()))
             {
                 kestrelEngine.Start(count: 1);
@@ -712,7 +701,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var trace = new KestrelTrace(new TestKestrelTrace());
                 var ltp = new LoggingThreadPool(trace);
                 var connection = new MockConnection();
-                var socketOutput = new SocketOutput(kestrelThread, socket, memory, connection, "0", trace, ltp, new Queue<UvWriteReq>());
+                var socketOutput = new SocketOutput(kestrelThread, socket, connection, "0", trace, ltp);
 
                 // Close SocketOutput
                 var cleanupTask = socketOutput.WriteAsync(


### PR DESCRIPTION
- Moved things that have loop affinity to KestrelThread like
WriteReqPool, MemoryPool and the ConnectionManager
- Changed on the listeners to only kill the ListenSocket, not the
connections on dispose
- Moved connection disposal to KestrelThread.Stop
- Simplify the connection manager logic so it's possible to walk and
wait in a single call