### PR TITLE
Ensure libuv handles get disposed properly after binding errors

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Listener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Listener.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.Extensions.Logging;
 
@@ -38,6 +39,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 {
                     var listener = ((Listener)tcs2.Task.AsyncState);
                     listener.ListenSocket = listener.CreateListenSocket();
+                    ListenSocket.Listen(Constants.ListenBacklog, ConnectionCallback, this);
                     tcs2.SetResult(0);
                 }
                 catch (Exception ex)
@@ -54,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         /// </summary>
         protected abstract UvStreamHandle CreateListenSocket();
 
-        protected static void ConnectionCallback(UvStreamHandle stream, int status, Exception error, object state)
+        private static void ConnectionCallback(UvStreamHandle stream, int status, Exception error, object state)
         {
             var listener = (Listener)state;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerPrimary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerPrimary.cs
@@ -70,10 +70,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
 
             var dispatchPipe = new UvPipeHandle(Log);
-            dispatchPipe.Init(Thread.Loop, Thread.QueueCloseHandle, true);
 
             try
             {
+                dispatchPipe.Init(Thread.Loop, Thread.QueueCloseHandle, true);
                 pipe.Accept(dispatchPipe);
             }
             catch (UvException ex)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/PipeListener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/PipeListener.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.Extensions.Logging;
 
@@ -22,9 +21,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         protected override UvStreamHandle CreateListenSocket()
         {
             var socket = new UvPipeHandle(Log);
-            socket.Init(Thread.Loop, Thread.QueueCloseHandle, false);
-            socket.Bind(ServerAddress.UnixPipePath);
-            socket.Listen(Constants.ListenBacklog, (stream, status, error, state) => ConnectionCallback(stream, status, error, state), this);
+
+            try
+            {
+                socket.Init(Thread.Loop, Thread.QueueCloseHandle, false);
+                socket.Bind(ServerAddress.UnixPipePath);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+
             return socket;
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/PipeListenerPrimary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/PipeListenerPrimary.cs
@@ -22,9 +22,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         protected override UvStreamHandle CreateListenSocket()
         {
             var socket = new UvPipeHandle(Log);
-            socket.Init(Thread.Loop, Thread.QueueCloseHandle, false);
-            socket.Bind(ServerAddress.UnixPipePath);
-            socket.Listen(Constants.ListenBacklog, (stream, status, error, state) => ConnectionCallback(stream, status, error, state), this);
+
+            try
+            {
+                socket.Init(Thread.Loop, Thread.QueueCloseHandle, false);
+                socket.Bind(ServerAddress.UnixPipePath);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+
             return socket;
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
@@ -583,7 +583,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                 _writeReq = Self._writeReqPool.Allocate();
 
-                _writeReq.Write(Self._socket, _lockedStart, _lockedEnd, _bufferCount, (_writeReq, status, error, state) =>
+                _writeReq.Write(Self._socket, _lockedStart, _lockedEnd, _bufferCount, (req, status, error, state) =>
                 {
                     var writeContext = (WriteContext)state;
                     writeContext.PoolWriteReq(writeContext._writeReq);


### PR DESCRIPTION
This should completely fix #972. I've been running the functional tests for a few hours on Windows and Linux and I haven't seen this issue which I saw about once every 20 runs before.

I added some tracing in `KestrelThread.OnStopRude`, and this also gets rid of most non-post handles getting walked in that method. The only handles that *sometimes* get walked now (maybe once every 5 functional test runs on my machine) seem to be the `UvPipeHandle`s created [here](https://github.com/aspnet/KestrelHttpServer/blob/bdf9f8dd4e27621c05fbfa302d96b719afc18ebd/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerPrimary.cs#L58) and [here](https://github.com/aspnet/KestrelHttpServer/blob/bdf9f8dd4e27621c05fbfa302d96b719afc18ebd/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerPrimary.cs#L72) in `ListenerPrimary`. My tracing doesn't indicate there are any timeouts disposing the listeners that would explain this. Fortunately, since these handles stay rooted until the `KestrelServer` is disposed and no longer referenced, you don't get the ODE on the finalizer thread in this case.

In the hours of running the functional tests on my Windows and Linux machines, I haven't yet seen #988. I might try a smaller VM to better emulate the conditions on Travis.

@davidfowl @mikeharder @cesarbs 