### PR TITLE
Improved Memoryblock tracking

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPool.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPool.cs
@@ -61,6 +61,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         /// </summary>
         private bool _disposedValue = false; // To detect redundant calls
 
+        /// <summary>
+        /// Called to take a block from the pool.
+        /// </summary>
+        /// <returns>The block that is reserved for the called. It must be passed to Return when it is no longer being used.</returns>
 #if DEBUG
         public MemoryPoolBlock Lease([CallerMemberName] string memberName = "",
                              [CallerFilePath] string sourceFilePath = "",
@@ -68,11 +72,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         {
             Debug.Assert(!_disposedValue, "Block being leased from disposed pool!");
 #else
-
-        /// <summary>
-        /// Called to take a block from the pool.
-        /// </summary>
-        /// <returns>The block that is reserved for the called. It must be passed to Return when it is no longer being used.</returns>
         public MemoryPoolBlock Lease()
         {
 #endif
@@ -83,9 +82,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 #if DEBUG
                 block.Leaser = memberName + ", " + sourceFilePath + ", " + sourceLineNumber;
                 block.IsLeased = true;
-#if !NETSTANDARD1_3
-                block.StackTrace = new StackTrace(true).ToString();
-#endif
+                block.StackTrace = Environment.StackTrace;
 #endif
                 return block;
             }
@@ -94,9 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 #if DEBUG
             block.Leaser = memberName + ", " + sourceFilePath + ", " + sourceLineNumber;
             block.IsLeased = true;
-#if !NETSTANDARD1_3
-            block.StackTrace = new StackTrace(true).ToString();
-#endif
+            block.StackTrace = Environment.StackTrace;
 #endif
             return block;
         }
@@ -153,7 +148,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         {
 #if DEBUG
             Debug.Assert(block.Pool == this, "Returned block was not leased from this pool");
-            Debug.Assert(block.IsLeased, "Block being returned to pool twice: " + block.Leaser + "\n" + block.StackTrace);
+            Debug.Assert(block.IsLeased, $"Block being returned to pool twice: {block.Leaser}{Environment.NewLine}{block.StackTrace}");
             block.IsLeased = false;
 #endif
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPool.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPool.cs
@@ -82,7 +82,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 #if DEBUG
                 block.Leaser = memberName + ", " + sourceFilePath + ", " + sourceLineNumber;
                 block.IsLeased = true;
-                block.StackTrace = Environment.StackTrace;
 #endif
                 return block;
             }
@@ -91,7 +90,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 #if DEBUG
             block.Leaser = memberName + ", " + sourceFilePath + ", " + sourceLineNumber;
             block.IsLeased = true;
-            block.StackTrace = Environment.StackTrace;
 #endif
             return block;
         }
@@ -148,7 +146,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         {
 #if DEBUG
             Debug.Assert(block.Pool == this, "Returned block was not leased from this pool");
-            Debug.Assert(block.IsLeased, $"Block being returned to pool twice: {block.Leaser}{Environment.NewLine}{block.StackTrace}");
+            Debug.Assert(block.IsLeased, $"Block being returned to pool twice: {block.Leaser}{Environment.NewLine}");
             block.IsLeased = false;
 #endif
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolBlock.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolBlock.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         ~MemoryPoolBlock()
         {
 #if DEBUG
-            Debug.Assert(Slab == null || !Slab.IsActive, "Block being garbage collected instead of returned to pool: " + Leaser + "\n" + StackTrace);
+            Debug.Assert(Slab == null || !Slab.IsActive, $"{Environment.NewLine}{Environment.NewLine}*** Block being garbage collected instead of returned to pool: {Leaser} ***{Environment.NewLine}Allocation StackTrace:{Environment.NewLine}{StackTrace}");
 #endif
             if (Slab != null && Slab.IsActive)
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolBlock.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolBlock.cs
@@ -74,13 +74,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 #if DEBUG
         public bool IsLeased { get; set; }
         public string Leaser { get; set; }
-        public string StackTrace { get; set; }
 #endif
 
         ~MemoryPoolBlock()
         {
 #if DEBUG
-            Debug.Assert(Slab == null || !Slab.IsActive, $"{Environment.NewLine}{Environment.NewLine}*** Block being garbage collected instead of returned to pool: {Leaser} ***{Environment.NewLine}Allocation StackTrace:{Environment.NewLine}{StackTrace}");
+            Debug.Assert(Slab == null || !Slab.IsActive, $"{Environment.NewLine}{Environment.NewLine}*** Block being garbage collected instead of returned to pool: {Leaser} ***{Environment.NewLine}");
 #endif
             if (Slab != null && Slab.IsActive)
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolBlock.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolBlock.cs
@@ -71,10 +71,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         /// </summary>
         public MemoryPoolBlock Next;
 
+#if DEBUG
+        public bool IsLeased { get; set; }
+        public string Leaser { get; set; }
+        public string StackTrace { get; set; }
+#endif
+
         ~MemoryPoolBlock()
         {
-            Debug.Assert(Slab == null || !Slab.IsActive, "Block being garbage collected instead of returned to pool");
-
+#if DEBUG
+            Debug.Assert(Slab == null || !Slab.IsActive, "Block being garbage collected instead of returned to pool: " + Leaser + "\n" + StackTrace);
+#endif
             if (Slab != null && Slab.IsActive)
             {
                 Pool.Return(new MemoryPoolBlock(DataArrayPtr)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolSlab.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolSlab.cs
@@ -61,6 +61,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         {
             if (!_disposedValue)
             {
+                _disposedValue = true;
+
                 if (disposing)
                 {
                     // N/A: dispose managed state (managed objects).
@@ -72,8 +74,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
                 // set large fields to null.
                 Array = null;
-
-                _disposedValue = true;
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/KestrelEngine.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/KestrelEngine.cs
@@ -46,6 +46,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
                 thread.Stop(TimeSpan.FromSeconds(2.5));
             }
             Threads.Clear();
+#if DEBUG
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+#endif
         }
 
         public IDisposable CreateServer(ServerAddress address)

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/AsciiDecoding.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/AsciiDecoding.cs
@@ -59,6 +59,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         var end = GetIterator(begin, byteRange.Length);
 
                         Assert.Throws<BadHttpRequestException>(() => begin.GetAsciiString(end));
+
+                        pool.Return(mem);
                     }
                 }
             }
@@ -150,7 +152,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     var returnBlock = block;
                     block = block.Next;
-                    pool.Return(returnBlock);
+                    if (returnBlock != mem0 && returnBlock != mem1)
+                    {
+                        pool.Return(returnBlock);
+                    }
                 }
 
                 pool.Return(mem0);

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MemoryPoolIteratorTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MemoryPoolIteratorTests.cs
@@ -317,6 +317,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Assert.ThrowsAny<InvalidOperationException>(() => scan.Skip(8));
 
             _pool.Return(block);
+            _pool.Return(nextBlock);
         }
 
         [Theory]


### PR DESCRIPTION
Extending #991

In debug:
* Adds leaser info.
* Checks for double returns.
* Forces finalizer to cause the finalizer check to trigger.

Also fixed 3 tests that weren't handling blocks properly.

Should resolve #988

Resolves https://github.com/aspnet/KestrelHttpServer/issues/1012
Resolves https://github.com/aspnet/KestrelHttpServer/issues/1013

/cc @halter73 @davidfowl @mikeharder 