### PR TITLE
Known strings fast compare

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.FeatureCollection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.FeatureCollection.cs
@@ -109,7 +109,46 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             set
             {
-                Method = value;
+                if (value == KnownStrings.HttpGetMethod)
+                {
+                    Method = KnownStrings.HttpGetMethod;
+                }
+                else if (value == KnownStrings.HttpPostMethod)
+                {
+                    Method = KnownStrings.HttpPostMethod;
+                }
+                else if (value == KnownStrings.HttpHeadMethod)
+                {
+                    Method = KnownStrings.HttpHeadMethod;
+                }
+                else if (value == KnownStrings.HttpConnectMethod)
+                {
+                    Method = KnownStrings.HttpConnectMethod;
+                }
+                else if (value == KnownStrings.HttpDeleteMethod)
+                {
+                    Method = KnownStrings.HttpDeleteMethod;
+                }
+                else if (value == KnownStrings.HttpPatchMethod)
+                {
+                    Method = KnownStrings.HttpPatchMethod;
+                }
+                else if (value == KnownStrings.HttpPutMethod)
+                {
+                    Method = KnownStrings.HttpPutMethod;
+                }
+                else if (value == KnownStrings.HttpOptionsMethod)
+                {
+                    Method = KnownStrings.HttpOptionsMethod;
+                }
+                else if (value == KnownStrings.HttpTraceMethod)
+                {
+                    Method = KnownStrings.HttpTraceMethod;
+                }
+                else
+                {
+                    Method = value;
+                }
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private bool _autoChunk;
         protected Exception _applicationException;
 
-        private HttpVersionType _httpVersion;
+        protected HttpVersionType _httpVersion;
 
         private readonly string _pathBase;
 
@@ -1265,13 +1265,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
 
             Log.ApplicationError(ConnectionId, ex);
-        }
-
-        private enum HttpVersionType
-        {
-            Unset = -1,
-            Http10 = 0,
-            Http11 = 1
         }
 
         protected enum RequestLineStatus

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     if (!_requestProcessingStopping)
                     {
-                        var messageBody = MessageBody.For(HttpVersion, FrameRequestHeaders, this);
+                        var messageBody = MessageBody.For(_httpVersion, FrameRequestHeaders, this);
                         _keepAlive = messageBody.RequestKeepAlive;
 
                         InitializeStreams(messageBody);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/HttpVersionType.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/HttpVersionType.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
+{
+    public enum HttpVersionType
+    {
+        Unset = -1,
+        Http10 = 0,
+        Http11 = 1
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KnownStrings.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KnownStrings.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
+{
+    public static class KnownStrings
+    {
+        // Use readonly static rather than const so string compares can compare the pointer rather than the data when equal
+        public static readonly string HttpConnectMethod = "CONNECT";
+        public static readonly string HttpDeleteMethod = "DELETE";
+        public static readonly string HttpGetMethod = "GET";
+        public static readonly string HttpHeadMethod = "HEAD";
+        public static readonly string HttpPatchMethod = "PATCH";
+        public static readonly string HttpPostMethod = "POST";
+        public static readonly string HttpPutMethod = "PUT";
+        public static readonly string HttpOptionsMethod = "OPTIONS";
+        public static readonly string HttpTraceMethod = "TRACE";
+
+        public static readonly string Http10Version = "HTTP/1.0";
+        public static readonly string Http11Version = "HTTP/1.1";
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             // see also http://tools.ietf.org/html/rfc2616#section-4.4
 
-            var keepAlive = httpVersion != "HTTP/1.0";
+            var keepAlive = !ReferenceEquals(httpVersion, KnownStrings.Http10Version);
 
             var connection = headers.HeaderConnection.ToString();
             if (connection.Length > 0)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
@@ -97,13 +97,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         public abstract ValueTask<int> ReadAsyncImplementation(ArraySegment<byte> buffer, CancellationToken cancellationToken);
 
         public static MessageBody For(
-            string httpVersion,
+            HttpVersionType httpVersion,
             FrameRequestHeaders headers,
             Frame context)
         {
             // see also http://tools.ietf.org/html/rfc2616#section-4.4
 
-            var keepAlive = !ReferenceEquals(httpVersion, KnownStrings.Http10Version);
+            var keepAlive = httpVersion != HttpVersionType.Http10;
 
             var connection = headers.HeaderConnection.ToString();
             if (connection.Length > 0)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolIteratorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolIteratorExtensions.cs
@@ -4,25 +4,13 @@
 using System;
 using System.Diagnostics;
 using System.Text;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 {
     public static class MemoryPoolIteratorExtensions
     {
         private static readonly Encoding _utf8 = Encoding.UTF8;
-
-        public const string HttpConnectMethod = "CONNECT";
-        public const string HttpDeleteMethod = "DELETE";
-        public const string HttpGetMethod = "GET";
-        public const string HttpHeadMethod = "HEAD";
-        public const string HttpPatchMethod = "PATCH";
-        public const string HttpPostMethod = "POST";
-        public const string HttpPutMethod = "PUT";
-        public const string HttpOptionsMethod = "OPTIONS";
-        public const string HttpTraceMethod = "TRACE";
-
-        public const string Http10Version = "HTTP/1.0";
-        public const string Http11Version = "HTTP/1.1";
 
         // readonly primitive statics can be Jit'd to consts https://github.com/dotnet/coreclr/issues/1079
         private readonly static long _httpConnectMethodLong = GetAsciiStringAsLong("CONNECT ");
@@ -35,8 +23,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         private readonly static long _httpOptionsMethodLong = GetAsciiStringAsLong("OPTIONS ");
         private readonly static long _httpTraceMethodLong = GetAsciiStringAsLong("TRACE \0\0");
 
-        private readonly static long _http10VersionLong = GetAsciiStringAsLong("HTTP/1.0");
-        private readonly static long _http11VersionLong = GetAsciiStringAsLong("HTTP/1.1");
+        private readonly static long _http10VersionLong = GetAsciiStringAsLong(KnownStrings.Http10Version);
+        private readonly static long _http11VersionLong = GetAsciiStringAsLong(KnownStrings.Http11Version);
 
         private readonly static long _mask8Chars = GetMaskAsLong(new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff });
         private readonly static long _mask7Chars = GetMaskAsLong(new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00 });
@@ -48,14 +36,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
         static MemoryPoolIteratorExtensions()
         {
-            _knownMethods[0] = Tuple.Create(_mask4Chars, _httpPutMethodLong, HttpPutMethod);
-            _knownMethods[1] = Tuple.Create(_mask5Chars, _httpPostMethodLong, HttpPostMethod);
-            _knownMethods[2] = Tuple.Create(_mask5Chars, _httpHeadMethodLong, HttpHeadMethod);
-            _knownMethods[3] = Tuple.Create(_mask6Chars, _httpTraceMethodLong, HttpTraceMethod);
-            _knownMethods[4] = Tuple.Create(_mask6Chars, _httpPatchMethodLong, HttpPatchMethod);
-            _knownMethods[5] = Tuple.Create(_mask7Chars, _httpDeleteMethodLong, HttpDeleteMethod);
-            _knownMethods[6] = Tuple.Create(_mask8Chars, _httpConnectMethodLong, HttpConnectMethod);
-            _knownMethods[7] = Tuple.Create(_mask8Chars, _httpOptionsMethodLong, HttpOptionsMethod);
+            _knownMethods[0] = Tuple.Create(_mask4Chars, _httpPutMethodLong, KnownStrings.HttpPutMethod);
+            _knownMethods[1] = Tuple.Create(_mask5Chars, _httpPostMethodLong, KnownStrings.HttpPostMethod);
+            _knownMethods[2] = Tuple.Create(_mask5Chars, _httpHeadMethodLong, KnownStrings.HttpHeadMethod);
+            _knownMethods[3] = Tuple.Create(_mask6Chars, _httpTraceMethodLong, KnownStrings.HttpTraceMethod);
+            _knownMethods[4] = Tuple.Create(_mask6Chars, _httpPatchMethodLong, KnownStrings.HttpPatchMethod);
+            _knownMethods[5] = Tuple.Create(_mask7Chars, _httpDeleteMethodLong, KnownStrings.HttpDeleteMethod);
+            _knownMethods[6] = Tuple.Create(_mask8Chars, _httpConnectMethodLong, KnownStrings.HttpConnectMethod);
+            _knownMethods[7] = Tuple.Create(_mask8Chars, _httpOptionsMethodLong, KnownStrings.HttpOptionsMethod);
         }
 
         private unsafe static long GetAsciiStringAsLong(string str)
@@ -251,7 +239,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
             if ((value & _mask4Chars) == _httpGetMethodLong)
             {
-                knownMethod = HttpGetMethod;
+                knownMethod = KnownStrings.HttpGetMethod;
                 return true;
             }
             foreach (var x in _knownMethods)
@@ -286,11 +274,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
             if (value == _http11VersionLong)
             {
-                knownVersion = Http11Version;
+                knownVersion = KnownStrings.Http11Version;
             }
             else if (value == _http10VersionLong)
             {
-                knownVersion = Http10Version;
+                knownVersion = KnownStrings.Http10Version;
             }
 
             if (knownVersion != null)

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -502,7 +502,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.InitializeHeaders();
 
-            var messageBody = MessageBody.For(KnownStrings.Http11Version, (FrameRequestHeaders)frame.RequestHeaders, frame);
+            var messageBody = MessageBody.For(HttpVersionType.Http11, (FrameRequestHeaders)frame.RequestHeaders, frame);
             frame.InitializeStreams(messageBody);
 
             var originalRequestBody = frame.RequestBody;

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -502,7 +502,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.InitializeHeaders();
 
-            var messageBody = MessageBody.For("HTTP/1.1", (FrameRequestHeaders)frame.RequestHeaders, frame);
+            var messageBody = MessageBody.For(KnownStrings.Http11Version, (FrameRequestHeaders)frame.RequestHeaders, frame);
             frame.InitializeStreams(messageBody);
 
             var originalRequestBody = frame.RequestBody;

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(KnownStrings.Http10Version, new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(HttpVersionType.Http10, new FrameRequestHeaders(), input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(KnownStrings.Http10Version, new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(HttpVersionType.Http10, new FrameRequestHeaders(), input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(KnownStrings.Http10Version, new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(HttpVersionType.Http10, new FrameRequestHeaders(), input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For("HTTP/1.0", new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(KnownStrings.Http10Version, new FrameRequestHeaders(), input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For("HTTP/1.0", new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(KnownStrings.Http10Version, new FrameRequestHeaders(), input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For("HTTP/1.0", new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(KnownStrings.Http10Version, new FrameRequestHeaders(), input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 


### PR DESCRIPTION
Use allows `ReferenceEquals` rather than string compare (without assuming anything about interning)
Also use http version enum in `MessageBody.For` rather than http version string