### PR TITLE
Only allocate key string when unknown

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.Generated.cs
@@ -4197,7 +4197,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         
         public unsafe void Append(byte[] keyBytes, int keyOffset, int keyLength, string value)
         {
-            var key = new string('\0', keyLength);
+            string key;
             fixed (byte* ptr = &keyBytes[keyOffset])
             {
                 var pUB = ptr;
@@ -4899,6 +4899,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                         break;
                 }
 
+                key = new string('\0', keyLength);
                 fixed(char *keyBuffer = key)
                 {
                     if (!AsciiUtilities.TryGetAsciiString(ptr, keyBuffer, keyLength))

--- a/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
+++ b/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
@@ -417,7 +417,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {(loop.ClassName == "FrameRequestHeaders" ? $@"
         public unsafe void Append(byte[] keyBytes, int keyOffset, int keyLength, string value)
         {{
-            var key = new string('\0', keyLength);
+            string key;
             fixed (byte* ptr = &keyBytes[keyOffset])
             {{
                 var pUB = ptr;
@@ -446,6 +446,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                         break;
                 ")}}}
 
+                key = new string('\0', keyLength);
                 fixed(char *keyBuffer = key)
                 {{
                     if (!AsciiUtilities.TryGetAsciiString(ptr, keyBuffer, keyLength))


### PR DESCRIPTION
Don't allocate a key string (which then isn't used) for known keys. (Cuts out 42% of string allocations - will be lower % with more headers as the value is still allocated)

Before
![unnecessary-allocations](https://aoa.blob.core.windows.net/aspnet/string-allocs.png)
After
![removed-unnecessary-allocations](https://aoa.blob.core.windows.net/aspnet/string-allocs-2.png)
String allocs are now only x4 higher than other things
![total-allocations](https://aoa.blob.core.windows.net/aspnet/string-allocs-3.png)

Resolves https://github.com/aspnet/KestrelHttpServer/issues/1011

/cc @halter73