### PR TITLE
Limit request line length (#784)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
@@ -79,6 +79,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 case RequestRejectionReason.NonAsciiOrNullCharactersInInputString:
                     ex = new BadHttpRequestException("The input string contains non-ASCII or null characters.");
                     break;
+                case RequestRejectionReason.RequestLineTooLong:
+                    ex = new BadHttpRequestException("Request line too long.");
+                    break;
+                case RequestRejectionReason.MissingSpaceAfterMethod:
+                    ex = new BadHttpRequestException("No space character found after method in request line.");
+                    break;
+                case RequestRejectionReason.MissingSpaceAfterTarget:
+                    ex = new BadHttpRequestException("No space character found after target in request line.");
+                    break;
+                case RequestRejectionReason.MissingCrAfterVersion:
+                    ex = new BadHttpRequestException("Missing CR in request line.");
+                    break;
                 default:
                     ex = new BadHttpRequestException("Bad request.");
                     break;
@@ -92,7 +104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             switch (reason)
             {
                 case RequestRejectionReason.MalformedRequestLineStatus:
-                    ex = new BadHttpRequestException($"Malformed request: {value}");
+                    ex = new BadHttpRequestException($"Invalid request line: {value}");
                     break;
                 case RequestRejectionReason.InvalidContentLength:
                     ex = new BadHttpRequestException($"Invalid content length: {value}");

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -47,9 +47,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             ConnectionId = GenerateConnectionId(Interlocked.Increment(ref _lastConnectionId));
 
-            if (ServerOptions.MaxRequestBufferSize.HasValue)
+            if (ServerOptions.Limits.MaxRequestBufferSize.HasValue)
             {
-                _bufferSizeControl = new BufferSizeControl(ServerOptions.MaxRequestBufferSize.Value, this, Thread);
+                _bufferSizeControl = new BufferSizeControl(ServerOptions.Limits.MaxRequestBufferSize.Value, this, Thread);
             }
 
             SocketInput = new SocketInput(Thread.Memory, ThreadPool, _bufferSizeControl);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
@@ -26,6 +26,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         ChunkedRequestIncomplete,
         PathContainsNullCharacters,
         InvalidCharactersInHeaderName,
-        NonAsciiOrNullCharactersInInputString
+        NonAsciiOrNullCharactersInInputString,
+        RequestLineTooLong,
+        MissingSpaceAfterMethod,
+        MissingSpaceAfterTarget,
+        MissingCrAfterVersion,
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
@@ -56,6 +56,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel
 
         public void Start<TContext>(IHttpApplication<TContext> application)
         {
+            ValidateOptions();
+
             if (_disposables != null)
             {
                 // The server has already started and/or has not been cleaned up yet
@@ -194,6 +196,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     _disposables.Pop().Dispose();
                 }
                 _disposables = null;
+            }
+        }
+
+        private void ValidateOptions()
+        {
+            if (Options.Limits.MaxRequestBufferSize.HasValue &&
+                Options.Limits.MaxRequestBufferSize < Options.Limits.MaxRequestLineSize)
+            {
+                throw new InvalidOperationException(
+                    $"Maximum request buffer size ({Options.Limits.MaxRequestBufferSize.Value}) must be greater than or equal to maximum request line size ({Options.Limits.MaxRequestLineSize}).");
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerLimits.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerLimits.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel
+{
+    public class KestrelServerLimits
+    {
+        // Matches the default client_max_body_size in nginx.  Also large enough that most requests
+        // should be under the limit.
+        private long? _maxRequestBufferSize = 1024 * 1024;
+
+        // Matches the default large_client_header_buffers in nginx.
+        private int _maxRequestLineSize = 8 * 1024;
+
+        /// <summary>
+        /// Gets or sets the maximum size of the request buffer.
+        /// </summary>
+        /// <remarks>
+        /// When set to null, the size of the request buffer is unlimited.
+        /// Defaults to 1,048,576 bytes (1 MB).
+        /// </remarks>
+        public long? MaxRequestBufferSize
+        {
+            get
+            {
+                return _maxRequestBufferSize;
+            }
+            set
+            {
+                if (value.HasValue && value.Value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Value must be null or a positive integer.");
+                }
+                _maxRequestBufferSize = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum allowed size for the HTTP request line.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to 8,192 bytes (8 KB).
+        /// </remarks>
+        public int MaxRequestLineSize
+        {
+            get
+            {
+                return _maxRequestLineSize;
+            }
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Value must be a positive integer.");
+                }
+                _maxRequestLineSize = value;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
 using System;
 using Microsoft.AspNetCore.Server.Kestrel.Filter;
 
@@ -11,10 +8,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel
     /// </summary>
     public class KestrelServerOptions
     {
-        // Matches the default client_max_body_size in nginx.  Also large enough that most requests
-        // should be under the limit.
-        private long? _maxRequestBufferSize = 1024 * 1024;
-
         /// <summary>
         /// Gets or sets whether the <c>Server</c> header should be included in each response.
         /// </summary>
@@ -41,27 +34,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         public IConnectionFilter ConnectionFilter { get; set; }
 
         /// <summary>
-        /// Maximum size of the request buffer.
-        /// If value is null, the size of the request buffer is unlimited.
+        /// <para>
+        /// This property is obsolete and will be removed in a future version.
+        /// Use <c>Limits.MaxRequestBufferSize</c> instead.
+        /// </para>
+        /// <para>
+        /// Gets or sets the maximum size of the request buffer.
+        /// </para>
         /// </summary>
         /// <remarks>
+        /// When set to null, the size of the request buffer is unlimited.
         /// Defaults to 1,048,576 bytes (1 MB).
         /// </remarks>
+        [Obsolete]
         public long? MaxRequestBufferSize
         {
             get
             {
-                return _maxRequestBufferSize;
+                return Limits.MaxRequestBufferSize;
             }
             set
             {
-                if (value.HasValue && value.Value <= 0)
-                {
-                    throw new ArgumentOutOfRangeException("value", "Value must be null or a positive integer.");
-                }
-                _maxRequestBufferSize = value;
+                Limits.MaxRequestBufferSize = value;
             }
         }
+
+        /// <summary>
+        /// Provides access to request limit options.
+        /// </summary>
+        public KestrelServerLimits Limits { get; } = new KestrelServerLimits();
 
         /// <summary>
         /// Set to false to enable Nagle's algorithm for all connections.

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestLineSizeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestLineSizeTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
+{
+    public class MaxRequestLineSizeTests
+    {
+        [Theory]
+        [InlineData("GET / HTTP/1.1\r\n", 16)]
+        [InlineData("GET / HTTP/1.1\r\n", 17)]
+        [InlineData("GET / HTTP/1.1\r\n", 137)]
+        [InlineData("POST /abc/de HTTP/1.1\r\n", 23)]
+        [InlineData("POST /abc/de HTTP/1.1\r\n", 24)]
+        [InlineData("POST /abc/de HTTP/1.1\r\n", 287)]
+        [InlineData("PUT /abc/de?f=ghi HTTP/1.1\r\n", 28)]
+        [InlineData("PUT /abc/de?f=ghi HTTP/1.1\r\n", 29)]
+        [InlineData("PUT /abc/de?f=ghi HTTP/1.1\r\n", 589)]
+        [InlineData("DELETE /a%20b%20c/d%20e?f=ghi HTTP/1.1\r\n", 40)]
+        [InlineData("DELETE /a%20b%20c/d%20e?f=ghi HTTP/1.1\r\n", 41)]
+        [InlineData("DELETE /a%20b%20c/d%20e?f=ghi HTTP/1.1\r\n", 1027)]
+        public async Task ServerAcceptsRequestLineWithinLimit(string requestLine, int limit)
+        {
+            var maxRequestLineSize = limit;
+
+            using (var host = BuildWebHost(options =>
+            {
+                options.Limits.MaxRequestLineSize = maxRequestLineSize;
+            }))
+            {
+                host.Start();
+
+                using (var connection = new TestConnection(host.GetPort()))
+                {
+                    await connection.SendEnd($"{requestLine}\r\n");
+                    await connection.Receive($"HTTP/1.1 200 OK\r\n");
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("GET / HTTP/1.1\r\n")]
+        [InlineData("POST /abc/de HTTP/1.1\r\n")]
+        [InlineData("PUT /abc/de?f=ghi HTTP/1.1\r\n")]
+        [InlineData("DELETE /a%20b%20c/d%20e?f=ghi HTTP/1.1\r\n")]
+        public async Task ServerRejectsRequestLineExceedingLimit(string requestLine)
+        {
+            using (var host = BuildWebHost(options =>
+            {
+                options.Limits.MaxRequestLineSize = requestLine.Length - 1; // stop short of the '\n'
+            }))
+            {
+                host.Start();
+
+                using (var connection = new TestConnection(host.GetPort()))
+                {
+                    await connection.SendAllTryEnd($"{requestLine}\r\n");
+                    await connection.Receive($"HTTP/1.1 400 Bad Request\r\n");
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(1, 2)]
+        [InlineData(int.MaxValue - 1, int.MaxValue)]
+        public void ServerFailsToStartWhenMaxRequestBufferSizeIsLessThanMaxRequestLineSize(long maxRequestBufferSize, int maxRequestLineSize)
+        {
+            using (var host = BuildWebHost(options =>
+            {
+                options.Limits.MaxRequestBufferSize = maxRequestBufferSize;
+                options.Limits.MaxRequestLineSize = maxRequestLineSize;
+            }))
+            {
+                Assert.Throws<InvalidOperationException>(() => host.Start());
+            }
+        }
+
+        private IWebHost BuildWebHost(Action<KestrelServerOptions> options)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel(options)
+                .UseUrls("http://127.0.0.1:0/")
+                .Configure(app => app.Run(async context =>
+                {
+                    await context.Response.WriteAsync("hello, world");
+                }))
+                .Build();
+
+            return host;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerLimitsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerLimitsTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Server.Kestrel;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.KestrelTests
+{
+    public class KestrelServerLimitsTests
+    {
+        [Fact]
+        public void MaxRequestBufferSizeDefault()
+        {
+            Assert.Equal(1024 * 1024, (new KestrelServerLimits()).MaxRequestBufferSize);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void MaxRequestBufferSizeInvalid(int value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                (new KestrelServerLimits()).MaxRequestBufferSize = value;
+            });
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public void MaxRequestBufferSizeValid(int? value)
+        {
+            var o = new KestrelServerLimits();
+            o.MaxRequestBufferSize = value;
+            Assert.Equal(value, o.MaxRequestBufferSize);
+        }
+
+        [Fact]
+        public void MaxRequestLineSizeDefault()
+        {
+            Assert.Equal(8 * 1024, (new KestrelServerLimits()).MaxRequestLineSize);
+        }
+
+        [Theory]
+        [InlineData(int.MinValue)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void MaxRequestLineSizeInvalid(int value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                (new KestrelServerLimits()).MaxRequestLineSize = value;
+            });
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(int.MaxValue)]
+        public void MaxRequestLineSizeValid(int value)
+        {
+            var o = new KestrelServerLimits();
+            o.MaxRequestLineSize = value;
+            Assert.Equal(value, o.MaxRequestLineSize);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerOptionsTests.cs
@@ -2,41 +2,42 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Microsoft.AspNetCore.Server.Kestrel;
-using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
 {
     public class KestrelServerInformationTests
     {
+#pragma warning disable CS0612
         [Fact]
-        public void MaxRequestBufferSizeDefault()
+        public void MaxRequestBufferSizeIsMarkedObsolete()
         {
-            Assert.Equal(1024 * 1024, (new KestrelServerOptions()).MaxRequestBufferSize);
+            Assert.NotNull(typeof(KestrelServerOptions)
+                .GetProperty(nameof(KestrelServerOptions.MaxRequestBufferSize))
+                .GetCustomAttributes(false)
+                .OfType<ObsoleteAttribute>()
+                .SingleOrDefault());
         }
 
-        [Theory]
-        [InlineData(-1)]
-        [InlineData(0)]
-        public void MaxRequestBufferSizeInvalid(int value)
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                (new KestrelServerOptions()).MaxRequestBufferSize = value;
-            });
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData(1)]
-        public void MaxRequestBufferSizeValid(int? value)
+        [Fact]
+        public void MaxRequestBufferSizeGetsLimitsProperty()
         {
             var o = new KestrelServerOptions();
-            o.MaxRequestBufferSize = value;
-            Assert.Equal(value, o.MaxRequestBufferSize);
+            o.Limits.MaxRequestBufferSize = 42;
+            Assert.Equal(42, o.MaxRequestBufferSize);
         }
+
+        [Fact]
+        public void MaxRequestBufferSizeSetsLimitsProperty()
+        {
+            var o = new KestrelServerOptions();
+            o.MaxRequestBufferSize = 42;
+            Assert.Equal(42, o.Limits.MaxRequestBufferSize);
+        }
+#pragma warning restore CS0612
 
         [Fact]
         public void SetThreadCountUsingProcessorCount()

--- a/test/shared/TestConnection.cs
+++ b/test/shared/TestConnection.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Testing
                 var task = _reader.ReadAsync(actual, offset, actual.Length - offset);
                 if (!Debugger.IsAttached)
                 {
-                    Assert.True(task.Wait(4000), "timeout");
+                    Assert.True(await Task.WhenAny(task, Task.Delay(10000)) == task, "TestConnection.Receive timed out.");
                 }
                 var count = await task;
                 if (count == 0)


### PR DESCRIPTION
#784

In order to address this, I've added new `MemoryPoolIterator.Seek` overloads. One allows setting a limit on how many bytes can be scanned, and returns (via an `out` parameter) the number of bytes scanned; the other one allows passing in another `MemoryPoolIterator` to server as a limit on the seek operation.

This change changes the behavior of `Frame.TakeStartLine` to wait until the final LF has been received before parsing the line. If LF is not found before the line limit, the request is rejected. Because of this change, `BadHttpRequestTests.ServerClosesConnectionAsSoonAsBadRequestLineIsDetected` is not a meaningful test anymore.

cc @halter73 @mikeharder @davidfowl 