### PR TITLE
Add header limit options (#475)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
@@ -49,8 +49,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 case RequestRejectionReason.WhitespaceIsNotAllowedInHeaderName:
                     ex = new BadHttpRequestException("Whitespace is not allowed in header name.");
                     break;
-                case RequestRejectionReason.HeaderLineMustEndInCRLFOnlyCRFound:
-                    ex = new BadHttpRequestException("Header line must end in CRLF; only CR found.");
+                case RequestRejectionReason.HeaderValueMustNotContainCR:
+                    ex = new BadHttpRequestException("Header value must not contain CR characters.");
                     break;
                 case RequestRejectionReason.HeaderValueLineFoldingNotSupported:
                     ex = new BadHttpRequestException("Header value line folding not supported.");
@@ -90,6 +90,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     break;
                 case RequestRejectionReason.MissingCrAfterVersion:
                     ex = new BadHttpRequestException("Missing CR in request line.");
+                    break;
+                case RequestRejectionReason.HeadersExceedMaxTotalSize:
+                    ex = new BadHttpRequestException("Request headers too long.");
+                    break;
+                case RequestRejectionReason.MissingCRInHeaderLine:
+                    ex = new BadHttpRequestException("No CR character found in header line.");
+                    break;
+                case RequestRejectionReason.TooManyHeaders:
+                    ex = new BadHttpRequestException("Request contains too many headers.");
                     break;
                 default:
                     ex = new BadHttpRequestException("Bad request.");

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         HeaderLineMustNotStartWithWhitespace,
         NoColonCharacterFoundInHeaderLine,
         WhitespaceIsNotAllowedInHeaderName,
-        HeaderLineMustEndInCRLFOnlyCRFound,
+        HeaderValueMustNotContainCR,
         HeaderValueLineFoldingNotSupported,
         MalformedRequestLineStatus,
         MalformedRequestInvalidHeaders,
@@ -31,5 +31,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         MissingSpaceAfterMethod,
         MissingSpaceAfterTarget,
         MissingCrAfterVersion,
+        HeadersExceedMaxTotalSize,
+        MissingCRInHeaderLine,
+        TooManyHeaders,
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerLimits.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerLimits.cs
@@ -14,6 +14,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         // Matches the default large_client_header_buffers in nginx.
         private int _maxRequestLineSize = 8 * 1024;
 
+        // Matches the default large_client_header_buffers in nginx.
+        private int _maxRequestHeadersTotalSize = 32 * 1024;
+
+        // Matches the default LimitRequestFields in Apache httpd.
+        private int _maxRequestHeaderCount = 100;
+
         /// <summary>
         /// Gets or sets the maximum size of the request buffer.
         /// </summary>
@@ -56,6 +62,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     throw new ArgumentOutOfRangeException(nameof(value), "Value must be a positive integer.");
                 }
                 _maxRequestLineSize = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum allowed size for the HTTP request headers.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to 32,768 bytes (32 KB).
+        /// </remarks>
+        public int MaxRequestHeadersTotalSize
+        {
+            get
+            {
+                return _maxRequestHeadersTotalSize;
+            }
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Value must a positive integer.");
+                }
+                _maxRequestHeadersTotalSize = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum allowed number of headers per HTTP request.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to 100.
+        /// </remarks>
+        public int MaxRequestHeaderCount
+        {
+            get
+            {
+                return _maxRequestHeaderCount;
+            }
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Value must a positive integer.");
+                }
+                _maxRequestHeaderCount = value;
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestHeaderLimitsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestHeaderLimitsTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
+{
+    public class RequestHeaderLimitsTests
+    {
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(0, 1337)]
+        [InlineData(1, 0)]
+        [InlineData(1, 1)]
+        [InlineData(1, 1337)]
+        [InlineData(5, 0)]
+        [InlineData(5, 1)]
+        [InlineData(5, 1337)]
+        public async Task ServerAcceptsRequestWithHeaderTotalSizeWithinLimit(int headerCount, int extraLimit)
+        {
+            var headers = MakeHeaders(headerCount);
+
+            using (var host = BuildWebHost(options =>
+            {
+                options.Limits.MaxRequestHeadersTotalSize = headers.Length + extraLimit;
+            }))
+            {
+                host.Start();
+
+                using (var connection = new TestConnection(host.GetPort()))
+                {
+                    await connection.SendEnd($"GET / HTTP/1.1\r\n{headers}\r\n");
+                    await connection.Receive($"HTTP/1.1 200 OK\r\n");
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(0, 1337)]
+        [InlineData(1, 1)]
+        [InlineData(1, 2)]
+        [InlineData(1, 1337)]
+        [InlineData(5, 5)]
+        [InlineData(5, 6)]
+        [InlineData(5, 1337)]
+        public async Task ServerAcceptsRequestWithHeaderCountWithinLimit(int headerCount, int maxHeaderCount)
+        {
+            var headers = MakeHeaders(headerCount);
+
+            using (var host = BuildWebHost(options =>
+            {
+                options.Limits.MaxRequestHeaderCount = maxHeaderCount;
+            }))
+            {
+                host.Start();
+
+                using (var connection = new TestConnection(host.GetPort()))
+                {
+                    await connection.SendEnd($"GET / HTTP/1.1\r\n{headers}\r\n");
+                    await connection.Receive($"HTTP/1.1 200 OK\r\n");
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(5)]
+        public async Task ServerRejectsRequestWithHeaderTotalSizeOverLimit(int headerCount)
+        {
+            var headers = MakeHeaders(headerCount);
+
+            using (var host = BuildWebHost(options =>
+            {
+                options.Limits.MaxRequestHeadersTotalSize = headers.Length - 1;
+            }))
+            {
+                host.Start();
+
+                using (var connection = new TestConnection(host.GetPort()))
+                {
+                    await connection.SendAllTryEnd($"GET / HTTP/1.1\r\n{headers}\r\n");
+                    await connection.Receive($"HTTP/1.1 400 Bad Request\r\n");
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(2, 1)]
+        [InlineData(5, 1)]
+        [InlineData(5, 4)]
+        public async Task ServerRejectsRequestWithHeaderCountOverLimit(int headerCount, int maxHeaderCount)
+        {
+            var headers = MakeHeaders(headerCount);
+
+            using (var host = BuildWebHost(options =>
+            {
+                options.Limits.MaxRequestHeaderCount = maxHeaderCount;
+            }))
+            {
+                host.Start();
+
+                using (var connection = new TestConnection(host.GetPort()))
+                {
+                    await connection.SendAllTryEnd($"GET / HTTP/1.1\r\n{headers}\r\n");
+                    await connection.Receive($"HTTP/1.1 400 Bad Request\r\n");
+                }
+            }
+        }
+
+        private static string MakeHeaders(int count)
+        {
+            return string.Join("", Enumerable
+                .Range(0, count)
+                .Select(i => $"Header-{i}: value{i}\r\n"));
+        }
+
+        private static IWebHost BuildWebHost(Action<KestrelServerOptions> options)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel(options)
+                .UseUrls("http://127.0.0.1:0/")
+                .Configure(app => app.Run(async context =>
+                {
+                    await context.Response.WriteAsync("hello, world");
+                }))
+                .Build();
+
+            return host;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -27,9 +27,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var connectionContext = new ConnectionContext()
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes("Header:value\r\n\r\n");
@@ -68,9 +70,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var connectionContext = new ConnectionContext()
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
@@ -109,8 +113,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
                     ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
@@ -148,8 +154,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
                     ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
@@ -187,23 +195,23 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
                     ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
                 socketInput.IncomingData(headerArray, 0, headerArray.Length);
 
-                Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                var exception = Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal("Header value line folding not supported.", exception.Message);
             }
         }
 
-        [Theory]
-        [InlineData("Header-1: value1\r\r\n")]
-        [InlineData("Header-1: value1\rHeader-2: value2\r\n\r\n")]
-        [InlineData("Header-1: value1\r\nHeader-2: value2\r\r\n")]
-        public void ThrowsOnHeaderLineNotEndingInCRLF(string rawHeaders)
+        [Fact]
+        public void ThrowsOnHeaderValueWithLineFolding_CharacterNotAvailableOnFirstAttempt()
         {
             var trace = new KestrelTrace(new TestKestrelTrace());
             var ltp = new LoggingThreadPool(trace);
@@ -214,15 +222,54 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
                     ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
+                frame.InitializeHeaders();
+
+                var headerArray = Encoding.ASCII.GetBytes("Header-1: value1\r\n");
+                socketInput.IncomingData(headerArray, 0, headerArray.Length);
+
+                Assert.False(frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+
+                socketInput.IncomingData(Encoding.ASCII.GetBytes(" "), 0, 1);
+
+                var exception = Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal("Header value line folding not supported.", exception.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData("Header-1: value1\r\r\n")]
+        [InlineData("Header-1: val\rue1\r\n")]
+        [InlineData("Header-1: value1\rHeader-2: value2\r\n\r\n")]
+        [InlineData("Header-1: value1\r\nHeader-2: value2\r\r\n")]
+        [InlineData("Header-1: value1\r\nHeader-2: v\ralue2\r\n")]
+        public void ThrowsOnHeaderValueContainingCR(string rawHeaders)
+        {
+            var trace = new KestrelTrace(new TestKestrelTrace());
+            var ltp = new LoggingThreadPool(trace);
+            using (var pool = new MemoryPool())
+            using (var socketInput = new SocketInput(pool, ltp))
+            {
+                var connectionContext = new ConnectionContext()
+                {
+                    DateHeaderValueManager = new DateHeaderValueManager(),
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
+                    Log = trace
+                };
+                var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
                 socketInput.IncomingData(headerArray, 0, headerArray.Length);
 
-                Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                var exception = Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal("Header value must not contain CR characters.", exception.Message);
             }
         }
 
@@ -241,15 +288,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
                     ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
                 socketInput.IncomingData(headerArray, 0, headerArray.Length);
 
-                Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                var exception = Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal("No ':' character found in header line.", exception.Message);
             }
         }
 
@@ -258,8 +308,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [InlineData("\tHeader: value\r\n\r\n")]
         [InlineData(" Header-1: value1\r\nHeader-2: value2\r\n\r\n")]
         [InlineData("\tHeader-1: value1\r\nHeader-2: value2\r\n\r\n")]
-        [InlineData("Header-1: value1\r\n Header-2: value2\r\n\r\n")]
-        [InlineData("Header-1: value1\r\n\tHeader-2: value2\r\n\r\n")]
         public void ThrowsOnHeaderLineStartingWithWhitespace(string rawHeaders)
         {
             var trace = new KestrelTrace(new TestKestrelTrace());
@@ -271,15 +319,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
                     ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
                 socketInput.IncomingData(headerArray, 0, headerArray.Length);
 
-                Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                var exception = Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal("Header line must not start with whitespace.", exception.Message);
             }
         }
 
@@ -303,21 +354,25 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
                     ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
                 socketInput.IncomingData(headerArray, 0, headerArray.Length);
 
-                Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                var exception = Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal("Whitespace is not allowed in header name.", exception.Message);
             }
         }
 
         [Theory]
+        [InlineData("Header-1: value1\r\nHeader-2: value2\r\n\r\r")]
         [InlineData("Header-1: value1\r\nHeader-2: value2\r\n\r ")]
-        [InlineData("Header-1: value1\r\nHeader-2: value2\r\nEnd\r\n")]
+        [InlineData("Header-1: value1\r\nHeader-2: value2\r\n\r \n")]
         public void ThrowsOnHeadersNotEndingInCRLFLine(string rawHeaders)
         {
             var trace = new KestrelTrace(new TestKestrelTrace());
@@ -329,15 +384,84 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
                     ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
                 socketInput.IncomingData(headerArray, 0, headerArray.Length);
 
-                Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                var exception = Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal("Headers corrupted, invalid header sequence.", exception.Message);
+            }
+        }
+
+        [Fact]
+        public void ThrowsWhenHeadersExceedTotalSizeLimit()
+        {
+            var trace = new KestrelTrace(new TestKestrelTrace());
+            var ltp = new LoggingThreadPool(trace);
+            using (var pool = new MemoryPool())
+            using (var socketInput = new SocketInput(pool, ltp))
+            {
+                const string headerLine = "Header: value\r\n";
+
+                var options = new KestrelServerOptions();
+                options.Limits.MaxRequestHeadersTotalSize = headerLine.Length - 1;
+
+                var connectionContext = new ConnectionContext()
+                {
+                    DateHeaderValueManager = new DateHeaderValueManager(),
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = options,
+                    Log = trace
+                };
+
+                var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
+                frame.InitializeHeaders();
+
+                var headerArray = Encoding.ASCII.GetBytes($"{headerLine}\r\n");
+                socketInput.IncomingData(headerArray, 0, headerArray.Length);
+
+                var exception = Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal("Request headers too long.", exception.Message);
+            }
+        }
+
+        [Fact]
+        public void ThrowsWhenHeadersExceedCountLimit()
+        {
+            var trace = new KestrelTrace(new TestKestrelTrace());
+            var ltp = new LoggingThreadPool(trace);
+            using (var pool = new MemoryPool())
+            using (var socketInput = new SocketInput(pool, ltp))
+            {
+                const string headerLines = "Header-1: value1\r\nHeader-2: value2\r\n";
+
+                var options = new KestrelServerOptions();
+                options.Limits.MaxRequestHeaderCount = 1;
+
+                var connectionContext = new ConnectionContext()
+                {
+                    DateHeaderValueManager = new DateHeaderValueManager(),
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = options,
+                    Log = trace
+                };
+
+                var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
+                frame.InitializeHeaders();
+
+                var headerArray = Encoding.ASCII.GetBytes($"{headerLines}\r\n");
+                socketInput.IncomingData(headerArray, 0, headerArray.Length);
+
+                var exception = Assert.Throws<BadHttpRequestException>(() => frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal("Request contains too many headers.", exception.Message);
             }
         }
 
@@ -358,9 +482,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var connectionContext = new ConnectionContext()
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = new KestrelServerOptions(),
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
                 frame.InitializeHeaders();
 
                 var headerArray = Encoding.ASCII.GetBytes(rawHeaders);
@@ -384,7 +510,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var connectionContext = new ConnectionContext()
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                ServerOptions = new KestrelServerOptions(),
             };
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.Scheme = "https";
@@ -394,6 +521,50 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             // Assert
             Assert.Equal("http", ((IFeatureCollection)frame).Get<IHttpRequestFeature>().Scheme);
+        }
+
+        [Fact]
+        public void ResetResetsHeaderLimits()
+        {
+            var trace = new KestrelTrace(new TestKestrelTrace());
+            var ltp = new LoggingThreadPool(trace);
+            using (var pool = new MemoryPool())
+            using (var socketInput = new SocketInput(pool, ltp))
+            {
+                const string headerLine1 = "Header-1: value1\r\n";
+                const string headerLine2 = "Header-2: value2\r\n";
+
+                var options = new KestrelServerOptions();
+                options.Limits.MaxRequestHeadersTotalSize = headerLine1.Length;
+                options.Limits.MaxRequestHeaderCount = 1;
+
+                var connectionContext = new ConnectionContext()
+                {
+                    DateHeaderValueManager = new DateHeaderValueManager(),
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                    ServerOptions = options
+                };
+
+                var frame = new Frame<object>(application: null, context: connectionContext);
+                frame.Reset();
+                frame.InitializeHeaders();
+
+                var headerArray1 = Encoding.ASCII.GetBytes($"{headerLine1}\r\n");
+                socketInput.IncomingData(headerArray1, 0, headerArray1.Length);
+
+                Assert.True(frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal(1, frame.RequestHeaders.Count);
+                Assert.Equal("value1", frame.RequestHeaders["Header-1"]);
+
+                frame.Reset();
+
+                var headerArray2 = Encoding.ASCII.GetBytes($"{headerLine2}\r\n");
+                socketInput.IncomingData(headerArray2, 0, headerArray1.Length);
+
+                Assert.True(frame.TakeMessageHeaders(socketInput, (FrameRequestHeaders)frame.RequestHeaders));
+                Assert.Equal(1, frame.RequestHeaders.Count);
+                Assert.Equal("value2", frame.RequestHeaders["Header-2"]);
+            }
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerLimitsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerLimitsTests.cs
@@ -63,5 +63,61 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             o.MaxRequestLineSize = value;
             Assert.Equal(value, o.MaxRequestLineSize);
         }
+
+        [Fact]
+        public void MaxRequestHeaderTotalSizeDefault()
+        {
+            Assert.Equal(32 * 1024, (new KestrelServerLimits()).MaxRequestHeadersTotalSize);
+        }
+
+        [Theory]
+        [InlineData(int.MinValue)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void MaxRequestHeaderTotalSizeInvalid(int value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                (new KestrelServerLimits()).MaxRequestHeadersTotalSize = value;
+            });
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(int.MaxValue)]
+        public void MaxRequestHeaderTotalSizeValid(int value)
+        {
+            var o = new KestrelServerLimits();
+            o.MaxRequestHeadersTotalSize = value;
+            Assert.Equal(value, o.MaxRequestHeadersTotalSize);
+        }
+
+        [Fact]
+        public void MaxRequestHeadersDefault()
+        {
+            Assert.Equal(100, (new KestrelServerLimits()).MaxRequestHeaderCount);
+        }
+
+        [Theory]
+        [InlineData(int.MinValue)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void MaxRequestHeadersInvalid(int value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                (new KestrelServerLimits()).MaxRequestHeaderCount = value;
+            });
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(int.MaxValue)]
+        public void MaxRequestHeadersValid(int value)
+        {
+            var o = new KestrelServerLimits();
+            o.MaxRequestHeaderCount = value;
+            Assert.Equal(value, o.MaxRequestHeaderCount);
+        }
     }
 }


### PR DESCRIPTION
New options in `KestrelServerLimits`:

* `MaxRequestHeadersTotalSize`: defaults to 32 KB.
* `MaxRequestHeaderCount`: defaults to 100.

Applies to normal request headers and trailing headers combined.

#475

cc @halter73 @mikeharder @Tratcher @davidfowl 