### PR TITLE
Prevent NullReferenceException in test runs (#1030).

### DIFF
--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockLibuv.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockLibuv.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
@@ -12,9 +15,13 @@ namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
         private bool _stopLoop;
         private readonly ManualResetEventSlim _loopWh = new ManualResetEventSlim();
 
+        private readonly string _stackTrace;
+
         unsafe public MockLibuv()
             : base(onlyForTesting: true)
         {
+            _stackTrace = Environment.StackTrace;
+
             OnWrite = (socket, buffers, triggerCompleted) =>
             {
                 triggerCompleted(0);
@@ -76,6 +83,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
             _uv_strerror = errno => IntPtr.Zero;
             _uv_read_start = UvReadStart;
             _uv_read_stop = handle => 0;
+            _uv_unsafe_async_send = handle =>
+            {
+                throw new Exception($"Why is this getting called?{Environment.NewLine}{_stackTrace}");
+            };
         }
 
         public Func<UvStreamHandle, int, Action<int>, int> OnWrite { get; set; }


### PR DESCRIPTION
#1030

cc @halter73 @mikeharder