### PR TITLE
Improve inlinability of libuv success checking

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/KestrelThread.cs
@@ -279,7 +279,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
 
             try
             {
-                var ran1 = _loop.Run();
+                _loop.Run();
                 if (_stopImmediate)
                 {
                     // thread-abort form of exit, resources will be leaked
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
                 _post.Dispose();
 
                 // Ensure the Dispose operations complete in the event loop.
-                var ran2 = _loop.Run();
+                _loop.Run();
 
                 _loop.Dispose();
             }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/Libuv.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/Libuv.cs
@@ -313,10 +313,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         }
 
         protected Func<UvStreamHandle, uv_buf_t[], int, int> _uv_try_write;
-        public void try_write(UvStreamHandle handle, uv_buf_t[] bufs, int nbufs)
+        public int try_write(UvStreamHandle handle, uv_buf_t[] bufs, int nbufs)
         {
             handle.Validate();
-            ThrowIfErrored(_uv_try_write(handle, bufs, nbufs));
+            var count = _uv_try_write(handle, bufs, nbufs);
+            ThrowIfErrored(count);
+            return count;
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvLoopHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvLoopHandle.cs
@@ -23,9 +23,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             _uv.loop_init(this);
         }
 
-        public int Run(int mode = 0)
+        public void Run(int mode = 0)
         {
-            return _uv.run(this, mode);
+            _uv.run(this, mode);
         }
 
         public void Stop()

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvStreamHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvStreamHandle.cs
@@ -118,9 +118,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             _uv.read_stop(this);
         }
 
-        public int TryWrite(Libuv.uv_buf_t buf)
+        public void TryWrite(Libuv.uv_buf_t buf)
         {
-            return _uv.try_write(this, new[] { buf }, 1);
+            _uv.try_write(this, new[] { buf }, 1);
         }
 
         private static void UvConnectionCb(IntPtr handle, int status)
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             var stream = FromIntPtr<UvStreamHandle>(handle);
 
             Exception error;
-            status = stream.Libuv.Check(status, out error);
+            stream.Libuv.Check(status, out error);
 
             try
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvStreamHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvStreamHandle.cs
@@ -118,9 +118,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             _uv.read_stop(this);
         }
 
-        public void TryWrite(Libuv.uv_buf_t buf)
+        public int TryWrite(Libuv.uv_buf_t buf)
         {
-            _uv.try_write(this, new[] { buf }, 1);
+            return _uv.try_write(this, new[] { buf }, 1);
         }
 
         private static void UvConnectionCb(IntPtr handle, int status)


### PR DESCRIPTION
Reviewing  https://github.com/aspnet/KestrelHttpServer/issues/1058

Currently the throwing `int Check(int statusCode)` and the non throwing `int Check(int statusCode, out Exception error)` are non-inlinable functions with the second being fairly large.

As one of these is called on every libuv call it would be better to have them much trimmer and inlinable; especially for the common success case.

`[FAILED: unprofitable inline] Microsoft.AspNetCore.Server.Kestrel.Internal.Networking.Libuv:Check(int,byref):int:this`
`[FAILED: unprofitable inline] Microsoft.AspNetCore.Server.Kestrel.Internal.Networking.Libuv:Check(int):int:this`

This changes the throwing check to `ThrowIfErrored`, which is what it does, and drops the return type from both (which nothing does anything with) as well as delegating the rarely taken error path to other functions to make the two functions much smaller and inlinable.

*Note:* Need coreclr post https://github.com/dotnet/coreclr/pull/6103 for the magic `FAILED: does not return`; though will still work similarly, just might also inline the throw call.

/cc @halter73 @cesarbs @davidfowl 