### PR TITLE
Run functional tests sequentially to mitigate flakiness on OS X

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
@pranavkm This should mitigate the flakiness we're seeing on OS X with errors like `Server returned nothing (no headers, no data)`. It did when we were seeing the same error on `ThreadCountTests.OneToTenThreads`.

If this doesn't work, I'll revert the change and disable the offending tests (which potentially means all `AddressRegistrationTests`, all `PathBaseTests` and all `ResponseTests`, unfortunately).

The actual issue here seems to be that the process runs out of handles while running the tests - not sure why it manifests the way it does. Running sequentially reduces the amount of handles being allocated at the same time. That's the closest we got to an answer at the time we were investigating `ThreadCountTests`, but we ended up deciding to just disable those tests on OS X and move on.

~~@Eilon suggested I make this change in dev and port it to 1.0.1, but on a second thought I decided not to because that would impact dev work, since they take twice as long to run with this change. What we're really concerned with here is unblocking 1.0.1 builds.~~

I've filed https://github.com/aspnet/KestrelHttpServer/issues/1070 to have this properly investigated.

cc @halter73 @muratg 