### PR TITLE
Avoid blocking shutdown in tests by calling TrySetResult inline

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpsTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 LastLogLevel = logLevel;
                 LastEventId = eventId;
-                LogTcs.SetResult(null);
+                Task.Run(() => LogTcs.SetResult(null));
             }
 
             public bool IsEnabled(LogLevel logLevel)


### PR DESCRIPTION
- This allows for a graceful shutdown with dotnet test -Parallel None
- By default, the xunit synccontext will dispatch automatically off
  the KestrelThread, but it's best not to rely on this behavior.
- Fix deadlock in HttpsTests