### PR TITLE
Improve keep-alive timeout

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
@@ -32,6 +32,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             {
                 while (!_requestProcessingStopping)
                 {
+                    ConnectionControl.SetTimeout(_keepAliveMilliseconds);
+
                     while (!_requestProcessingStopping && TakeStartLine(SocketInput) != RequestLineStatus.Done)
                     {
                         if (SocketInput.CheckFinOrThrow())

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IConnectionControl.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IConnectionControl.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         void Pause();
         void Resume();
         void End(ProduceEndType endType);
-        void Stop();
+        void SetTimeout(long milliseconds);
+        void CancelTimeout();
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
@@ -172,7 +172,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 var limit = buffer.Array == null ? inputLengthLimit : Math.Min(buffer.Count, inputLengthLimit);
                 if (limit == 0)
                 {
-                    _context.RequestFinished();
                     return new ValueTask<int>(0);
                 }
 
@@ -187,11 +186,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     if (actual == 0)
                     {
                         _context.RejectRequest(RequestRejectionReason.UnexpectedEndOfRequestContent);
-                    }
-
-                    if (_inputLength == 0)
-                    {
-                        _context.RequestFinished();
                     }
 
                     return new ValueTask<int>(actual);
@@ -210,11 +204,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 if (actual == 0)
                 {
                     _context.RejectRequest(RequestRejectionReason.UnexpectedEndOfRequestContent);
-                }
-
-                if (_inputLength == 0)
-                {
-                    _context.RequestFinished();
                 }
 
                 return actual;
@@ -367,8 +356,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     _mode = Mode.Complete;
                 }
-
-                _context.RequestFinished();
 
                 return 0;
             }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/Libuv.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/Libuv.cs
@@ -56,6 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             _uv_timer_init = NativeMethods.uv_timer_init;
             _uv_timer_start = NativeMethods.uv_timer_start;
             _uv_timer_stop = NativeMethods.uv_timer_stop;
+            _uv_now = NativeMethods.uv_now;
         }
 
         // Second ctor that doesn't set any fields only to be used by MockLibuv
@@ -434,6 +435,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             ThrowIfErrored(_uv_timer_stop(handle));
         }
 
+        protected Func<UvLoopHandle, long> _uv_now;
+        unsafe public long now(UvLoopHandle loop)
+        {
+            loop.Validate();
+            return _uv_now(loop);
+        }
+
         public delegate int uv_tcp_getsockname_func(UvTcpHandle handle, out SockAddr addr, ref int namelen);
         protected uv_tcp_getsockname_func _uv_tcp_getsockname;
         public void tcp_getsockname(UvTcpHandle handle, out SockAddr addr, ref int namelen)
@@ -639,6 +647,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 
             [DllImport("libuv", CallingConvention = CallingConvention.Cdecl)]
             unsafe public static extern int uv_timer_stop(UvTimerHandle handle);
+
+            [DllImport("libuv", CallingConvention = CallingConvention.Cdecl)]
+            unsafe public static extern long uv_now(UvLoopHandle loop);
 
             [DllImport("WS2_32.dll", CallingConvention = CallingConvention.Winapi)]
             unsafe public static extern int WSAIoctl(

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvLoopHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvLoopHandle.cs
@@ -33,6 +33,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             _uv.stop(this);
         }
 
+        public long Now()
+        {
+            return _uv.now(this);
+        }
+
         unsafe protected override bool ReleaseHandle()
         {
             var memory = handle;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerLimits.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerLimits.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         // Matches the default LimitRequestFields in Apache httpd.
         private int _maxRequestHeaderCount = 100;
 
-        // Matches the default http.sys keep-alive timouet.
-        private TimeSpan _keepAliveTimeout = TimeSpan.FromMinutes(2);
+        // Matches the default http.sys connection timeout.
+        private TimeSpan _connectionTimeout = TimeSpan.FromMinutes(2);
 
         /// <summary>
         /// Gets or sets the maximum size of the response buffer before write
@@ -146,17 +146,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         /// Gets or sets the keep-alive timeout.
         /// </summary>
         /// <remarks>
-        /// Defaults to 2 minutes. Timeout granularity is in seconds. Sub-second values will be rounded to the next second.
+        /// Defaults to 2 minutes.
         /// </remarks>
         public TimeSpan KeepAliveTimeout
         {
             get
             {
-                return _keepAliveTimeout;
+                return _connectionTimeout;
             }
             set
             {
-                _keepAliveTimeout = TimeSpan.FromSeconds(Math.Ceiling(value.TotalSeconds));
+                _connectionTimeout = value;
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.IO;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
@@ -13,23 +16,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
     public class KeepAliveTimeoutTests
     {
         private static readonly TimeSpan KeepAliveTimeout = TimeSpan.FromSeconds(10);
-        private static readonly int LongDelay = (int)TimeSpan.FromSeconds(30).TotalMilliseconds;
-        private static readonly int ShortDelay = LongDelay / 10;
+        private static readonly TimeSpan LongDelay = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan ShortDelay = TimeSpan.FromSeconds(LongDelay.TotalSeconds / 10);
 
         [Fact]
         public async Task TestKeepAliveTimeout()
         {
-            using (var server = CreateServer())
+            var longRunningCancellationTokenSource = new CancellationTokenSource();
+            var upgradeCancellationTokenSource = new CancellationTokenSource();
+
+            using (var server = CreateServer(longRunningCancellationTokenSource.Token, upgradeCancellationTokenSource.Token))
             {
                 var tasks = new[]
                 {
                     ConnectionClosedWhenKeepAliveTimeoutExpires(server),
-                    ConnectionClosedWhenKeepAliveTimeoutExpiresAfterChunkedRequest(server),
-                    KeepAliveTimeoutResetsBetweenContentLengthRequests(server),
-                    KeepAliveTimeoutResetsBetweenChunkedRequests(server),
-                    KeepAliveTimeoutNotTriggeredMidContentLengthRequest(server),
-                    KeepAliveTimeoutNotTriggeredMidChunkedRequest(server),
-                    ConnectionTimesOutWhenOpenedButNoRequestSent(server)
+                    ConnectionKeptAliveBetweenRequests(server),
+                    ConnectionNotTimedOutWhileRequestBeingSent(server),
+                    ConnectionNotTimedOutWhileAppIsRunning(server, longRunningCancellationTokenSource),
+                    ConnectionTimesOutWhenOpenedButNoRequestSent(server),
+                    KeepAliveTimeoutDoesNotApplyToUpgradedConnections(server, upgradeCancellationTokenSource)
                 };
 
                 await Task.WhenAll(tasks);
@@ -59,110 +64,76 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        private async Task ConnectionClosedWhenKeepAliveTimeoutExpiresAfterChunkedRequest(TestServer server)
+        private async Task ConnectionKeptAliveBetweenRequests(TestServer server)
         {
             using (var connection = new TestConnection(server.Port))
             {
+                for (var i = 0; i < 10; i++)
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "",
+                        "");
+                    await Task.Delay(ShortDelay);
+                }
+
+                for (var i = 0; i < 10; i++)
+                {
+                    await ReceiveResponse(connection, server.Context);
+                }
+            }
+        }
+
+        private async Task ConnectionNotTimedOutWhileRequestBeingSent(TestServer server)
+        {
+            using (var connection = new TestConnection(server.Port))
+            {
+                var cts = new CancellationTokenSource();
+                cts.CancelAfter(LongDelay);
+
                 await connection.Send(
                         "POST / HTTP/1.1",
                         "Transfer-Encoding: chunked",
                         "",
-                        "5", "hello",
-                        "6", " world",
+                        "");
+
+                while (!cts.IsCancellationRequested)
+                {
+                    await connection.Send(
+                        "1",
+                        "a",
+                        "");
+                }
+
+                await connection.Send(
                         "0",
-                         "",
-                         "");
+                        "",
+                        "");
                 await ReceiveResponse(connection, server.Context);
-
-                await Task.Delay(LongDelay);
-
-                await Assert.ThrowsAsync<IOException>(async () =>
-                {
-                    await connection.Send(
-                        "GET / HTTP/1.1",
-                        "",
-                        "");
-                    await ReceiveResponse(connection, server.Context);
-                });
             }
         }
 
-        private async Task KeepAliveTimeoutResetsBetweenContentLengthRequests(TestServer server)
-        {
-            using (var connection = new TestConnection(server.Port))
-            {
-                for (var i = 0; i < 10; i++)
-                {
-                    await connection.Send(
-                        "GET / HTTP/1.1",
-                        "",
-                        "");
-                    await Task.Delay(ShortDelay);
-                }
-
-                for (var i = 0; i < 10; i++)
-                {
-                    await ReceiveResponse(connection, server.Context);
-                }
-            }
-        }
-
-        private async Task KeepAliveTimeoutResetsBetweenChunkedRequests(TestServer server)
-        {
-            using (var connection = new TestConnection(server.Port))
-            {
-                for (var i = 0; i < 10; i++)
-                {
-                    await connection.Send(
-                        "POST / HTTP/1.1",
-                        "Transfer-Encoding: chunked",
-                        "",
-                        "5", "hello",
-                        "6", " world",
-                        "0",
-                         "",
-                         "");
-                    await Task.Delay(ShortDelay);
-                }
-
-                for (var i = 0; i < 10; i++)
-                {
-                    await ReceiveResponse(connection, server.Context);
-                }
-            }
-        }
-
-        private async Task KeepAliveTimeoutNotTriggeredMidContentLengthRequest(TestServer server)
+        private async Task ConnectionNotTimedOutWhileAppIsRunning(TestServer server, CancellationTokenSource cts)
         {
             using (var connection = new TestConnection(server.Port))
             {
                 await connection.Send(
-                    "POST / HTTP/1.1",
-                    "Content-Length: 8",
+                    "GET /longrunning HTTP/1.1",
                     "",
-                    "a");
-                await Task.Delay(LongDelay);
-                await connection.Send("bcdefgh");
-                await ReceiveResponse(connection, server.Context);
-            }
-        }
+                    "");
+                cts.CancelAfter(LongDelay);
 
-        private async Task KeepAliveTimeoutNotTriggeredMidChunkedRequest(TestServer server)
-        {
-            using (var connection = new TestConnection(server.Port))
-            {
+                while (!cts.IsCancellationRequested)
+                {
+                    await Task.Delay(1000);
+                }
+
+                await ReceiveResponse(connection, server.Context);
+
                 await connection.Send(
-                        "POST / HTTP/1.1",
-                        "Transfer-Encoding: chunked",
-                        "",
-                        "5", "hello",
-                        "");
-                await Task.Delay(LongDelay);
-                await connection.Send(
-                        "6", " world",
-                        "0",
-                         "",
-                         "");
+                    "GET / HTTP/1.1",
+                    "",
+                    "");
                 await ReceiveResponse(connection, server.Context);
             }
         }
@@ -182,9 +153,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        private TestServer CreateServer()
+        private async Task KeepAliveTimeoutDoesNotApplyToUpgradedConnections(TestServer server, CancellationTokenSource cts)
         {
-            return new TestServer(App, new TestServiceContext
+            using (var connection = new TestConnection(server.Port))
+            {
+                await connection.Send(
+                    "GET /upgrade HTTP/1.1",
+                    "",
+                    "");
+                await connection.Receive(
+                    "HTTP/1.1 101 Switching Protocols",
+                    "Connection: Upgrade",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+                cts.CancelAfter(LongDelay);
+
+                while (!cts.IsCancellationRequested)
+                {
+                    await Task.Delay(1000);
+                }
+
+                await connection.Receive("hello, world");
+            }
+        }
+
+        private TestServer CreateServer(CancellationToken longRunningCt, CancellationToken upgradeCt)
+        {
+            return new TestServer(httpContext => App(httpContext, longRunningCt, upgradeCt), new TestServiceContext
             {
                 ServerOptions = new KestrelServerOptions
                 {
@@ -197,11 +193,36 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             });
         }
 
-        private async Task App(HttpContext httpContext)
+        private async Task App(HttpContext httpContext, CancellationToken longRunningCt, CancellationToken upgradeCt)
         {
-            const string response = "hello, world";
-            httpContext.Response.ContentLength = response.Length;
-            await httpContext.Response.WriteAsync(response);
+            var ct = httpContext.RequestAborted;
+
+            if (httpContext.Request.Path == "/longrunning")
+            {
+                while (!longRunningCt.IsCancellationRequested)
+                {
+                    await Task.Delay(1000);
+                }
+
+                await httpContext.Response.WriteAsync("hello, world");
+            }
+            else if (httpContext.Request.Path == "/upgrade")
+            {
+                using (var stream = await httpContext.Features.Get<IHttpUpgradeFeature>().UpgradeAsync())
+                {
+                    while (!upgradeCt.IsCancellationRequested)
+                    {
+                        await Task.Delay(LongDelay);
+                    }
+
+                    var responseBytes = Encoding.ASCII.GetBytes("hello, world");
+                    await stream.WriteAsync(responseBytes, 0, responseBytes.Length);
+                }
+            }
+            else
+            {
+                await httpContext.Response.WriteAsync("hello, world");
+            }
         }
 
         private async Task ReceiveResponse(TestConnection connection, TestServiceContext testServiceContext)
@@ -209,9 +230,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             await connection.Receive(
                 "HTTP/1.1 200 OK",
                 $"Date: {testServiceContext.DateHeaderValue}",
-                "Content-Length: 12",
+                "Transfer-Encoding: chunked",
                 "",
-                "hello, world");
+                "c",
+                "hello, world",
+                "0",
+                "",
+                "");
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerLimitsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerLimitsTests.cs
@@ -161,11 +161,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [InlineData(2.1)]
         [InlineData(2.5)]
         [InlineData(2.9)]
-        public void KeepAliveTimeoutIsRoundedToTheNextSecond(double seconds)
+        public void KeepAliveTimeoutValid(double seconds)
         {
             var o = new KestrelServerLimits();
             o.KeepAliveTimeout = TimeSpan.FromSeconds(seconds);
-            Assert.Equal(Math.Ceiling(seconds), o.KeepAliveTimeout.TotalSeconds);
+            Assert.Equal(seconds, o.KeepAliveTimeout.TotalSeconds);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockConnection.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockConnection.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
 
         public MockConnection(KestrelServerOptions options)
         {
+            ConnectionControl = this;
             RequestAbortedSource = new CancellationTokenSource();
             ServerOptions = options;
         }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockLibuv.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockLibuv.cs
@@ -129,6 +129,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
             _uv_timer_init = (loop, handle) => 0;
             _uv_timer_start = (handle, callback, timeout, repeat) => 0;
             _uv_timer_stop = handle => 0;
+            _uv_now = (loop) => DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
         }
 
         public Func<UvStreamHandle, int, Action<int>, int> OnWrite { get; set; }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
@@ -22,7 +22,12 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var trace = new KestrelTrace(new TestKestrelTrace());
             var ltp = new LoggingThreadPool(trace);
-            var context = new Frame<object>(null, new ConnectionContext() { ServerAddress = new ServerAddress() })
+            var connectionContext = new ConnectionContext()
+            {
+                ServerAddress = new ServerAddress(),
+                ServerOptions = new KestrelServerOptions()
+            };
+            var context = new Frame<object>(null, connectionContext)
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
                 ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
@@ -63,7 +68,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
         }
 
-        public void Stop()
+        public void SetTimeout(long milliseconds)
+        {
+        }
+
+        public void CancelTimeout()
         {
         }
 


### PR DESCRIPTION
* Track time more accurately
* Control timeout in `Connection` instead of `Frame`

@halter73 @mikeharder @davidfowl 