### PR TITLE
Copyless FrameRequestStream.CopyToAsync(...)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameRequestStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameRequestStream.cs
@@ -119,8 +119,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             var task = ValidateState(cancellationToken);
             if (task == null)
             {
-                // Needs .AsTask to match Stream's Async method return types
-                return _body.ReadAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken).AsTask();
+                return _body.ReadAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
+            }
+            return task;
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentException($"{nameof(bufferSize)} must be positive.", nameof(bufferSize));
+            }
+
+            var task = ValidateState(cancellationToken);
+            if (task == null)
+            {
+                return _body.CopyToAsync(destination, cancellationToken);
             }
             return task;
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolIteratorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolIteratorExtensions.cs
@@ -232,6 +232,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
             return new ArraySegment<byte>(array, 0, length);
         }
 
+        public static ArraySegment<byte> PeekArraySegment(this MemoryPoolIterator iter)
+        {
+            if (iter.IsDefault || iter.IsEnd)
+            {
+                return default(ArraySegment<byte>);
+            }
+
+            if (iter.Index < iter.Block.End)
+            {
+                return new ArraySegment<byte>(iter.Block.Array, iter.Index, iter.Block.End - iter.Index);
+            }
+
+            var block = iter.Block.Next;
+            while (block != null)
+            {
+                if (block.Start < block.End)
+                {
+                    return new ArraySegment<byte>(block.Array, block.Start, block.End - block.Start);
+                }
+                block = block.Next;
+            }
+
+            // The following should be unreachable due to the IsEnd check above.
+            throw new InvalidOperationException("This should be unreachable!");
+        }
+
         /// <summary>
         /// Checks that up to 8 bytes from <paramref name="begin"/> correspond to a known HTTP method.
         /// </summary>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
@@ -2,10 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
+using Microsoft.AspNetCore.Server.KestrelTests.TestHelpers;
+using Microsoft.Extensions.Internal;
+using Moq;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
 {
@@ -68,23 +76,119 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 // Input needs to be greater than 4032 bytes to allocate a block not backed by a slab.
                 var largeInput = new string('a', 8192);
 
-                input.Add(largeInput, true);
+                input.Add(largeInput);
                 // Add a smaller block to the end so that SocketInput attempts to return the large
                 // block to the memory pool.
-                input.Add("Hello", true);
+                input.Add("Hello", fin: true);
 
-                var readBuffer = new byte[8192];
+                var ms = new MemoryStream();
 
-                var count1 = await stream.ReadAsync(readBuffer, 0, 8192);
-                Assert.Equal(8192, count1);
-                AssertASCII(largeInput, new ArraySegment<byte>(readBuffer, 0, 8192));
+                await stream.CopyToAsync(ms);
+                var requestArray = ms.ToArray();
+                Assert.Equal(8197, requestArray.Length);
+                AssertASCII(largeInput + "Hello", new ArraySegment<byte>(requestArray, 0, requestArray.Length));
 
-                var count2 = await stream.ReadAsync(readBuffer, 0, 8192);
-                Assert.Equal(5, count2);
-                AssertASCII("Hello", new ArraySegment<byte>(readBuffer, 0, 5));
+                var count = await stream.ReadAsync(new byte[1], 0, 1);
+                Assert.Equal(0, count);
+            }
+        }
 
-                var count3 = await stream.ReadAsync(readBuffer, 0, 8192);
-                Assert.Equal(0, count3);
+        public static IEnumerable<object[]> StreamData => new[]
+        {
+            new object[] { new ThrowOnWriteSynchronousStream() },
+            new object[] { new ThrowOnWriteAsynchronousStream() },
+        };
+
+        public static IEnumerable<object[]> RequestData => new[]
+        {
+            // Remaining Data
+            new object[] { new FrameRequestHeaders { HeaderConnection = "close" }, new[] { "Hello ", "World!" } },
+            // Content-Length
+            new object[] { new FrameRequestHeaders { HeaderContentLength = "12" }, new[] { "Hello ", "World!" } },
+            // Chunked
+            new object[] { new FrameRequestHeaders { HeaderTransferEncoding = "chunked" }, new[] { "6\r\nHello \r\n", "6\r\nWorld!\r\n0\r\n\r\n" } },
+        };
+
+        public static IEnumerable<object[]> CombinedData => 
+            from stream in StreamData
+            from request in RequestData
+            select new[] { stream[0], request[0], request[1] };
+
+        [Theory]
+        [MemberData(nameof(RequestData))]
+        public async Task CopyToAsyncDoesNotCopyBlocks(FrameRequestHeaders headers, string[] data)
+        {
+            var writeCount = 0;
+            var writeTcs = new TaskCompletionSource<byte[]>();
+            var mockDestination = new Mock<Stream>();
+
+            mockDestination
+                .Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), CancellationToken.None))
+                .Callback((byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+                {
+                    writeTcs.SetResult(buffer);
+                    writeCount++;
+                })
+                .Returns(TaskCache.CompletedTask);
+
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For(HttpVersion.Http11, headers, input.FrameContext);
+
+                var copyToAsyncTask = body.CopyToAsync(mockDestination.Object);
+
+                // The block returned by IncomingStart always has at least 2048 available bytes,
+                // so no need to bounds check in this test.
+                var socketInput = input.FrameContext.SocketInput;
+                var bytes = Encoding.ASCII.GetBytes(data[0]);
+                var block = socketInput.IncomingStart();
+                Buffer.BlockCopy(bytes, 0, block.Array, block.End, bytes.Length);
+                socketInput.IncomingComplete(bytes.Length, null);
+
+                // Verify the block passed to WriteAsync is the same one incoming data was written into.
+                Assert.Same(block.Array, await writeTcs.Task);
+
+                writeTcs = new TaskCompletionSource<byte[]>();
+                bytes = Encoding.ASCII.GetBytes(data[1]);
+                block = socketInput.IncomingStart();
+                Buffer.BlockCopy(bytes, 0, block.Array, block.End, bytes.Length);
+                socketInput.IncomingComplete(bytes.Length, null);
+
+                Assert.Same(block.Array, await writeTcs.Task);
+
+                if (headers.HeaderConnection == "close")
+                {
+                    socketInput.IncomingFin();
+                }
+
+                await copyToAsyncTask;
+
+                Assert.Equal(2, writeCount);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CombinedData))]
+        public async Task CopyToAsyncAdvancesRequestStreamWhenDestinationWriteAsyncThrows(Stream writeStream, FrameRequestHeaders headers, string[] data)
+        {
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For(HttpVersion.Http11, headers, input.FrameContext);
+
+                input.Add(data[0]);
+
+                await Assert.ThrowsAsync<XunitException>(() => body.CopyToAsync(writeStream));
+
+                input.Add(data[1], fin: headers.HeaderConnection == "close");
+
+                // "Hello " should have been consumed
+                var readBuffer = new byte[6];
+                var count = await body.ReadAsync(new ArraySegment<byte>(readBuffer, 0, readBuffer.Length));
+                Assert.Equal(6, count);
+                AssertASCII("World!", new ArraySegment<byte>(readBuffer, 0, 6));
+
+                count = await body.ReadAsync(new ArraySegment<byte>(readBuffer, 0, readBuffer.Length));
+                Assert.Equal(0, count);
             }
         }
 
@@ -97,6 +201,85 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 Assert.Equal(bytes[index], actual.Array[actual.Offset + index]);
             }
+        }
+
+        private class ThrowOnWriteSynchronousStream : Stream
+        {
+            public override void Flush()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                throw new XunitException();
+            }
+
+            public override bool CanRead { get; }
+            public override bool CanSeek { get; }
+            public override bool CanWrite => true;
+            public override long Length { get; }
+            public override long Position { get; set; }
+        }
+
+        private class ThrowOnWriteAsynchronousStream : Stream
+        {
+            public override void Flush()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                await Task.Delay(1);
+                throw new XunitException();
+            }
+
+            public override bool CanRead { get; }
+            public override bool CanSeek { get; }
+            public override bool CanWrite => true;
+            public override long Length { get; }
+            public override long Position { get; set; }
         }
     }
 }


### PR DESCRIPTION
I'm going to add a test for behavior when `destinationstream.WriteAsync(...)` throws.

There are already quite a few tests that call `FrameRequestStream.CopyToAsync()`, but have been using the default implementation up to this point.