### PR TITLE
Change SkipReason for ThreadCountTests on OS X

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ThreadCountTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ThreadCountTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
     {
         [ConditionalTheory]
         [MemberData(nameof(OneToTen))]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Test failures pending investigation.")]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Tests fail on OS X due to low file descriptor limit.")]
         public async Task OneToTenThreads(int threadCount)
         {
             var hostBuilder = new WebHostBuilder()
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     {
                         return context.Response.WriteAsync("Hello World");
                     });
-                });            
+                });
 
             using (var host = hostBuilder.Build())
             {
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         var requestTask = client.GetStringAsync($"http://localhost:{host.GetPort()}/");
                         requestTasks.Add(requestTask);
                     }
-                    
+
                     foreach (var result in await Task.WhenAll(requestTasks))
                     {
                         Assert.Equal("Hello World", result);


### PR DESCRIPTION
Since it looks like we'll leave those tests disabled on OS X indefinitely, change the skip reason to reflect the actual reason for that.

@halter73 @mikeharder @pranavkm 