### PR TITLE
Change context relationships from inheritance to composition

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -66,7 +66,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
 
             _frame = FrameFactory(this);
-
             _lastTimestamp = Thread.Loop.Now();
         }
 
@@ -74,6 +73,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         internal Connection()
         {
         }
+
+        public KestrelServerOptions ServerOptions => ListenerContext.ServiceContext.ServerOptions;
+        private Func<ConnectionContext, Frame> FrameFactory => ListenerContext.ServiceContext.FrameFactory;
+        private IKestrelTrace Log => ListenerContext.ServiceContext.Log;
+        private IThreadPool ThreadPool => ListenerContext.ServiceContext.ThreadPool;
+        private ServerAddress ServerAddress => ListenerContext.ServerAddress;
+        private KestrelThread Thread => ListenerContext.Thread;
 
         public void Start()
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ConnectionContext.cs
@@ -7,26 +7,18 @@ using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
-    public class ConnectionContext : ListenerContext
+    public class ConnectionContext
     {
         public ConnectionContext()
         {
         }
 
-        public ConnectionContext(ListenerContext context) : base(context)
+        public ConnectionContext(ListenerContext context)
         {
+            ListenerContext = context;
         }
 
-        public ConnectionContext(ConnectionContext context) : base(context)
-        {
-            SocketInput = context.SocketInput;
-            SocketOutput = context.SocketOutput;
-            ConnectionControl = context.ConnectionControl;
-            RemoteEndPoint = context.RemoteEndPoint;
-            LocalEndPoint = context.LocalEndPoint;
-            ConnectionId = context.ConnectionId;
-            PrepareRequest = context.PrepareRequest;
-        }
+        public ListenerContext ListenerContext { get; set; }
 
         public SocketInput SocketInput { get; set; }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Listener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Listener.cs
@@ -23,6 +23,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         protected UvStreamHandle ListenSocket { get; private set; }
 
+        public IKestrelTrace Log => ServiceContext.Log;
+
         public Task StartAsync(
             ServerAddress address,
             KestrelThread thread)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerContext.cs
@@ -1,32 +1,21 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
-
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
-    public class ListenerContext : ServiceContext
+    public class ListenerContext
     {
-        public ListenerContext()
+        public ListenerContext(ServiceContext serviceContext)
         {
+            ServiceContext = serviceContext;
         }
 
-        public ListenerContext(ServiceContext serviceContext) 
-            : base(serviceContext)
-        {
-        }
-
-        public ListenerContext(ListenerContext listenerContext)
-            : base(listenerContext)
-        {
-            ServerAddress = listenerContext.ServerAddress;
-            Thread = listenerContext.Thread;
-        }
+        public ServiceContext ServiceContext { get; set; }
 
         public ServerAddress ServerAddress { get; set; }
 
         public KestrelThread Thread { get; set; }
+
+        public KestrelServerOptions ServerOptions => ServiceContext.ServerOptions;
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerSecondary.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
     /// <summary>
-    /// A secondary listener is delegated requests from a primary listener via a named pipe or 
+    /// A secondary listener is delegated requests from a primary listener via a named pipe or
     /// UNIX domain socket.
     /// </summary>
     public abstract class ListenerSecondary : ListenerContext, IAsyncDisposable
@@ -28,6 +28,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         }
 
         UvPipeHandle DispatchPipe { get; set; }
+
+        public IKestrelTrace Log => ServiceContext.Log;
 
         public Task StartAsync(
             string pipeName,

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/ServiceContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/ServiceContext.cs
@@ -10,20 +10,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
 {
     public class ServiceContext
     {
-        public ServiceContext()
-        {
-        }
-
-        public ServiceContext(ServiceContext context)
-        {
-            AppLifetime = context.AppLifetime;
-            Log = context.Log;
-            ThreadPool = context.ThreadPool;
-            FrameFactory = context.FrameFactory;
-            DateHeaderValueManager = context.DateHeaderValueManager;
-            ServerOptions = context.ServerOptions;
-        }
-
         public IApplicationLifetime AppLifetime { get; set; }
 
         public IKestrelTrace Log { get; set; }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
@@ -27,10 +27,13 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 engine.Start(count: 1);
 
                 var trace = new TestKestrelTrace();
-                var context = new ListenerContext(new TestServiceContext())
+                var serviceContext = new TestServiceContext
                 {
                     FrameFactory = connectionContext => new Frame<HttpContext>(
                         new DummyApplication(httpContext => TaskCache.CompletedTask), connectionContext),
+                };
+                var context = new ListenerContext(serviceContext)
+                {
                     ServerAddress = ServerAddress.FromUrl("http://127.0.0.1:0"),
                     Thread = engine.Threads[0]
                 };

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel;
+using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.Extensions.Primitives;
 using Xunit;
@@ -18,12 +19,16 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var serverOptions = new KestrelServerOptions();
 
-            var connectionContext = new ConnectionContext
+            var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                ServerOptions = serverOptions,
+                ServerOptions = serverOptions
             };
+            var listenerContext = new ListenerContext(serviceContext)
+            {
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+            };
+            var connectionContext = new ConnectionContext(listenerContext);
 
             var frame = new Frame<object>(application: null, context: connectionContext);
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -27,12 +27,17 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                    ServerOptions = new KestrelServerOptions(),
+                    ServerOptions = new KestrelServerOptions()
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -70,12 +75,17 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                    ServerOptions = new KestrelServerOptions(),
+                    ServerOptions = new KestrelServerOptions()
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -112,12 +122,17 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                    ServerOptions = new KestrelServerOptions(),
+                    ServerOptions = new KestrelServerOptions()
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -153,12 +168,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
+                    Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -194,13 +215,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -222,13 +248,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -259,13 +290,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -290,13 +326,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -322,13 +363,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -358,13 +404,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -389,13 +440,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -422,13 +478,17 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var options = new KestrelServerOptions();
                 options.Limits.MaxRequestHeadersTotalSize = headerLine.Length - 1;
 
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = options,
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
 
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -456,13 +516,17 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var options = new KestrelServerOptions();
                 options.Limits.MaxRequestHeaderCount = 1;
 
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = options,
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
 
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -491,12 +555,17 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                    ServerOptions = new KestrelServerOptions(),
+                    ServerOptions = new KestrelServerOptions()
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
+
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -519,12 +588,17 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void ResetResetsScheme()
         {
             // Arrange
-            var connectionContext = new ConnectionContext()
+            var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                ServerOptions = new KestrelServerOptions(),
+                ServerOptions = new KestrelServerOptions()
             };
+            var listenerContext = new ListenerContext(serviceContext)
+            {
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+            };
+            var connectionContext = new ConnectionContext(listenerContext);
+
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.Scheme = "https";
 
@@ -550,12 +624,16 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 options.Limits.MaxRequestHeadersTotalSize = headerLine1.Length;
                 options.Limits.MaxRequestHeaderCount = 1;
 
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = options
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
 
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -583,13 +661,20 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void ThrowsWhenStatusCodeIsSetAfterResponseStarted()
         {
             // Arrange
-            var connectionContext = new ConnectionContext()
+            var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                ServerOptions = new KestrelServerOptions(),
+                ServerOptions = new KestrelServerOptions()
+            };
+            var listenerContext = new ListenerContext(serviceContext)
+            {
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+            };
+            var connectionContext = new ConnectionContext(listenerContext)
+            {
                 SocketOutput = new MockSocketOuptut()
             };
+
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.InitializeHeaders();
 
@@ -605,13 +690,20 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void ThrowsWhenReasonPhraseIsSetAfterResponseStarted()
         {
             // Arrange
-            var connectionContext = new ConnectionContext()
+            var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                ServerOptions = new KestrelServerOptions(),
+                ServerOptions = new KestrelServerOptions()
+            };
+            var listenerContext = new ListenerContext(serviceContext)
+            {
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+            };
+            var connectionContext = new ConnectionContext(listenerContext)
+            {
                 SocketOutput = new MockSocketOuptut()
             };
+
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.InitializeHeaders();
 
@@ -627,13 +719,20 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void ThrowsWhenOnStartingIsSetAfterResponseStarted()
         {
             // Arrange
-            var connectionContext = new ConnectionContext()
+            var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                ServerOptions = new KestrelServerOptions(),
+                ServerOptions = new KestrelServerOptions()
+            };
+            var listenerContext = new ListenerContext(serviceContext)
+            {
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+            };
+            var connectionContext = new ConnectionContext(listenerContext)
+            {
                 SocketOutput = new MockSocketOuptut()
             };
+
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.InitializeHeaders();
             frame.Write(new ArraySegment<byte>(new byte[1]));
@@ -647,13 +746,20 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void InitializeHeadersResetsRequestHeaders()
         {
             // Arrange
-            var connectionContext = new ConnectionContext()
+            var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                ServerOptions = new KestrelServerOptions(),
+                ServerOptions = new KestrelServerOptions()
+            };
+            var listenerContext = new ListenerContext(serviceContext)
+            {
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+            };
+            var connectionContext = new ConnectionContext(listenerContext)
+            {
                 SocketOutput = new MockSocketOuptut()
             };
+
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.InitializeHeaders();
 
@@ -671,13 +777,20 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void InitializeHeadersResetsResponseHeaders()
         {
             // Arrange
-            var connectionContext = new ConnectionContext()
+            var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                ServerOptions = new KestrelServerOptions(),
+                ServerOptions = new KestrelServerOptions()
+            };
+            var listenerContext = new ListenerContext(serviceContext)
+            {
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+            };
+            var connectionContext = new ConnectionContext(listenerContext)
+            {
                 SocketOutput = new MockSocketOuptut()
             };
+
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.InitializeHeaders();
 
@@ -695,13 +808,20 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public void InitializeStreamsResetsStreams()
         {
             // Arrange
-            var connectionContext = new ConnectionContext()
+            var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                ServerOptions = new KestrelServerOptions(),
+                ServerOptions = new KestrelServerOptions()
+            };
+            var listenerContext = new ListenerContext(serviceContext)
+            {
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+            };
+            var connectionContext = new ConnectionContext(listenerContext)
+            {
                 SocketOutput = new MockSocketOuptut()
             };
+
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.InitializeHeaders();
 
@@ -732,13 +852,19 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
-                    ConnectionControl = new Mock<IConnectionControl>().Object,
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
+                };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                };
+                var connectionContext = new ConnectionContext(listenerContext)
+                {
+                    ConnectionControl = new Mock<IConnectionControl>().Object
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -779,13 +905,19 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
-                    ConnectionControl = new Mock<IConnectionControl>().Object,
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
+                };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                };
+                var connectionContext = new ConnectionContext(listenerContext)
+                {
+                    ConnectionControl = new Mock<IConnectionControl>().Object
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -806,14 +938,20 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionControl = new Mock<IConnectionControl>();
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
-                    ConnectionControl = connectionControl.Object,
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
+                };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                };
+                var connectionControl = new Mock<IConnectionControl>();
+                var connectionContext = new ConnectionContext(listenerContext)
+                {
+                    ConnectionControl = connectionControl.Object
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -834,14 +972,20 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionControl = new Mock<IConnectionControl>();
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
-                    ConnectionControl = connectionControl.Object,
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
+                };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionControl = new Mock<IConnectionControl>();
+                var connectionContext = new ConnectionContext(listenerContext)
+                {
+                    ConnectionControl = connectionControl.Object
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -859,11 +1003,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
-                    ConnectionControl = Mock.Of<IConnectionControl>(),
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions()
                     {
                         Limits =
@@ -872,6 +1014,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         }
                     },
                     Log = trace
+                };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext)
+                {
+                    ConnectionControl = Mock.Of<IConnectionControl>()
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -904,13 +1054,19 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
-                    ConnectionControl = Mock.Of<IConnectionControl>(),
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
+                };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext)
+                {
+                    ConnectionControl = Mock.Of<IConnectionControl>()
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -932,13 +1088,19 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
-                    ConnectionControl = Mock.Of<IConnectionControl>(),
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
+                };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext)
+                {
+                    ConnectionControl = Mock.Of<IConnectionControl>(),
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
@@ -960,13 +1122,17 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -1013,13 +1179,17 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
                 };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
+                };
+                var connectionContext = new ConnectionContext(listenerContext);
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
                 frame.InitializeHeaders();
@@ -1039,20 +1209,26 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var pool = new MemoryPool())
             using (var socketInput = new SocketInput(pool, ltp))
             {
-                var connectionControl = new Mock<IConnectionControl>();
-                var connectionContext = new ConnectionContext()
+                var serviceContext = new ServiceContext
                 {
-                    ConnectionControl = connectionControl.Object,
                     DateHeaderValueManager = new DateHeaderValueManager(),
-                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
                     ServerOptions = new KestrelServerOptions(),
                     Log = trace
+                };
+                var listenerContext = new ListenerContext(serviceContext)
+                {
+                    ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+                };
+                var connectionControl = new Mock<IConnectionControl>();
+                var connectionContext = new ConnectionContext(listenerContext)
+                {
+                    ConnectionControl = connectionControl.Object
                 };
                 var frame = new Frame<object>(application: null, context: connectionContext);
                 frame.Reset();
 
                 var requestProcessingTask = frame.RequestProcessingAsync();
-                connectionControl.Verify(cc => cc.SetTimeout((long)connectionContext.ServerOptions.Limits.KeepAliveTimeout.TotalMilliseconds));
+                connectionControl.Verify(cc => cc.SetTimeout((long)serviceContext.ServerOptions.Limits.KeepAliveTimeout.TotalMilliseconds));
 
                 frame.Stop();
                 socketInput.IncomingFin();

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockConnection.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockConnection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel;
+using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
@@ -17,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
         {
             ConnectionControl = this;
             RequestAbortedSource = new CancellationTokenSource();
-            ServerOptions = options;
+            ListenerContext = new ListenerContext(new ServiceContext { ServerOptions = options });
         }
 
         public override void Abort(Exception error = null)

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
@@ -22,19 +22,22 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var trace = new KestrelTrace(new TestKestrelTrace());
             var ltp = new LoggingThreadPool(trace);
-            var connectionContext = new ConnectionContext()
-            {
-                ServerAddress = new ServerAddress(),
-                ServerOptions = new KestrelServerOptions()
-            };
-            var context = new Frame<object>(null, connectionContext)
+            var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerAddress = ServerAddress.FromUrl("http://localhost:5000"),
-                ConnectionControl = this,
-                FrameControl = this
+                ServerOptions = new KestrelServerOptions()
             };
+            var listenerContext = new ListenerContext(serviceContext)
+            {
+                ServerAddress = ServerAddress.FromUrl("http://localhost:5000")
+            };
+            var connectionContext = new ConnectionContext(listenerContext)
+            {
+                ConnectionControl = this
+            };
+            var context = new Frame<object>(null, connectionContext);
             FrameContext = context;
+            FrameContext.FrameControl = this;
 
             _memoryPool = new MemoryPool();
             FrameContext.SocketInput = new SocketInput(_memoryPool, ltp);


### PR DESCRIPTION
We keep all contexts around while copying their fields at the same time. We can just point back to existing contexts.

This reduces memory usage per connection:

type | dev | this change | reduction
------|------|-------------|---------------
Connection | 216 bytes | 160 bytes | 26%
Frame | 560 bytes | 464 bytes | 17%

Listeners are a little slimmer too, but that doesn't matter much since there are only a few of them per Kestrel instance.

### dev

![dev_connection](https://cloud.githubusercontent.com/assets/924164/18795706/a3873868-817a-11e6-85e9-22165eb4f8f6.png)

![dev_frame](https://cloud.githubusercontent.com/assets/924164/18795737/d433337c-817a-11e6-89c8-09984d590d96.png)

### this change

![change_connection](https://cloud.githubusercontent.com/assets/924164/18795714/aac43784-817a-11e6-9844-77fceb9ef7bc.png)

![change_frame](https://cloud.githubusercontent.com/assets/924164/18795715/ac4ad19e-817a-11e6-9494-c84e81a13419.png)

@davidfowl @halter73 @mikeharder
