### PR TITLE
Specify sequential layout to avoid warning

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/SockAddr.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/SockAddr.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
+    [StructLayout(LayoutKind.Sequential)]
     public struct SockAddr
     {
         // this type represents native memory occupied by sockaddr struct


### PR DESCRIPTION
The previous version caused this warning:

> SockAddr.cs(17,22): warning CS0414: The field 'SockAddr._field3' is assigned but its value is never used

To avoid the warning, explicitly specify `[StructLayout(LayoutKind.Sequential)]`. This does not change any behavior (since `Sequential` is the default for `struct`s), but it lets the compiler and readers know that layout is important.