### PR TITLE
Assume zero length on non-keepalive requests without Content-Length or Transfer-Encoding header (#1104)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
@@ -234,6 +234,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             var connection = headers.HeaderConnection.ToString();
             if (connection.Length > 0)
             {
+                if (connection.Equals("upgrade", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new ForRemainingData(context);
+                }
+
                 keepAlive = connection.Equals("keep-alive", StringComparison.OrdinalIgnoreCase);
             }
 
@@ -257,12 +262,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 }
             }
 
-            if (keepAlive)
-            {
-                return new ForContentLength(true, 0, context);
-            }
-
-            return new ForRemainingData(context);
+            return new ForContentLength(keepAlive, 0, context);
         }
 
         private class ForRemainingData : MessageBody

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
@@ -102,6 +102,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "0",
                          "",
                         "POST / HTTP/1.0",
+                        "Content-Length: 7",
                         "",
                         "Goodbye");
                     await connection.Receive(

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionFilterTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var filter = new RewritingConnectionFilter();
             var serviceContext = new TestServiceContext(filter);
 
-            var sendString = "POST / HTTP/1.0\r\n\r\nHello World?";
+            var sendString = "POST / HTTP/1.0\r\nContent-Length: 12\r\n\r\nHello World?";
 
             using (var server = new TestServer(App, serviceContext))
             {
@@ -66,6 +66,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "POST / HTTP/1.0",
+                        "Content-Length: 12",
                         "",
                         "Hello World?");
                     await connection.ReceiveEnd(
@@ -91,6 +92,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     {
                         await connection.SendEnd(
                             "POST / HTTP/1.0",
+                            "Content-Length: 12",
                             "",
                             "Hello World?");
                     }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(HttpVersion.Http10, new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(HttpVersion.Http10, new FrameRequestHeaders { HeaderContentLength = "5" }, input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(HttpVersion.Http10, new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(HttpVersion.Http10, new FrameRequestHeaders { HeaderContentLength = "5" }, input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -65,11 +65,107 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
         [Fact]
-        public async Task CanHandleLargeBlocks()
+        public void Http10NoContentLength()
         {
             using (var input = new TestInput())
             {
                 var body = MessageBody.For(HttpVersion.Http10, new FrameRequestHeaders(), input.FrameContext);
+                var stream = new FrameRequestStream();
+                stream.StartAcceptingReads(body);
+
+                input.Add("Hello", true);
+
+                var buffer1 = new byte[1024];
+                Assert.Equal(0, stream.Read(buffer1, 0, 1024));
+            }
+        }
+
+        [Fact]
+        public async Task Http10NoContentLengthAsync()
+        {
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For(HttpVersion.Http10, new FrameRequestHeaders(), input.FrameContext);
+                var stream = new FrameRequestStream();
+                stream.StartAcceptingReads(body);
+
+                input.Add("Hello", true);
+
+                var buffer1 = new byte[1024];
+                Assert.Equal(0, await stream.ReadAsync(buffer1, 0, 1024));
+            }
+        }
+
+        [Fact]
+        public void Http11NoContentLength()
+        {
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders(), input.FrameContext);
+                var stream = new FrameRequestStream();
+                stream.StartAcceptingReads(body);
+
+                input.Add("Hello", true);
+
+                var buffer1 = new byte[1024];
+                Assert.Equal(0, stream.Read(buffer1, 0, 1024));
+            }
+        }
+
+        [Fact]
+        public async Task Http11NoContentLengthAsync()
+        {
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders(), input.FrameContext);
+                var stream = new FrameRequestStream();
+                stream.StartAcceptingReads(body);
+
+                input.Add("Hello", true);
+
+                var buffer1 = new byte[1024];
+                Assert.Equal(0, await stream.ReadAsync(buffer1, 0, 1024));
+            }
+        }
+
+        [Fact]
+        public void Http11NoContentLengthConnectionClose()
+        {
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderConnection = "close" }, input.FrameContext);
+                var stream = new FrameRequestStream();
+                stream.StartAcceptingReads(body);
+
+                input.Add("Hello", true);
+
+                var buffer1 = new byte[1024];
+                Assert.Equal(0, stream.Read(buffer1, 0, 1024));
+            }
+        }
+
+        [Fact]
+        public async Task Http11NoContentLengthConnectionCloseAsync()
+        {
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderConnection = "close" }, input.FrameContext);
+                var stream = new FrameRequestStream();
+                stream.StartAcceptingReads(body);
+
+                input.Add("Hello", true);
+
+                var buffer1 = new byte[1024];
+                Assert.Equal(0, await stream.ReadAsync(buffer1, 0, 1024));
+            }
+        }
+
+        [Fact]
+        public async Task CanHandleLargeBlocks()
+        {
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For(HttpVersion.Http10, new FrameRequestHeaders { HeaderContentLength = "8197" }, input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -101,8 +197,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         public static IEnumerable<object[]> RequestData => new[]
         {
-            // Remaining Data
-            new object[] { new FrameRequestHeaders { HeaderConnection = "close" }, new[] { "Hello ", "World!" } },
             // Content-Length
             new object[] { new FrameRequestHeaders { HeaderContentLength = "12" }, new[] { "Hello ", "World!" } },
             // Chunked


### PR DESCRIPTION
Prevent hangs when the client sends a `Connection: close` request but waits for the server to close the connection first, while the server is hung waiting for data from the client when no length was specified. This happens when a `Connection: close` request does not include a `Content-Length` or `Transfer-Encoding: chunked` header. See #1104.

@mikeharder pointed out that this might be considered a breaking change. This could break existing apps that expect to be able to read from `Connection: close` requests that send a body of unspecified length. This is a bad idea though, and apps should not be doing that, since there's no way to differentiate between message end and a premature connection close in this situation. cc @Eilon for input on that.

@halter73 