### PR TITLE
Use Ben's Magic Number for FindFirstEqualByte

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/KestrelEngine.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/KestrelEngine.cs
@@ -38,6 +38,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
 
         public void Start(int count)
         {
+            JitReadonlyConsts();
+
             for (var index = 0; index < count; index++)
             {
                 Threads.Add(new KestrelThread(this));
@@ -47,6 +49,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
             {
                 thread.StartAsync().Wait();
             }
+        }
+
+        public static void JitReadonlyConsts()
+        {
+            MemoryPoolIterator.StaticReadonlysJitted = true;
+            MemoryPoolIteratorExtensions.StaticReadonlysJitted = true;
         }
 
         public void Dispose()


### PR DESCRIPTION
De Bruijn sequence as suggested by @mburbea in https://github.com/aspnet/KestrelHttpServer/issues/1129

Also inlines due to issue https://github.com/dotnet/coreclr/issues/7386

Added the `JitReadonlyConsts()` function as it was non-deterministic on when the `readonly statics` where evaluated. 

If it was first evaluated in the same function that used it then it wouldn't do branch elimination.

Added comments also...

Need to use most recent coreclr for items such as https://github.com/dotnet/coreclr/pull/7367 and https://github.com/dotnet/coreclr/pull/7407