### PR TITLE
Remove TCP Loopback Fast Path code (#1147).

### DIFF
--- a/test/shared/TestConnection.cs
+++ b/test/shared/TestConnection.cs
@@ -167,21 +167,6 @@ namespace Microsoft.AspNetCore.Testing
         public static Socket CreateConnectedLoopbackSocket(int port)
         {
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            if (PlatformApis.IsWindows)
-            {
-                const int SIO_LOOPBACK_FAST_PATH = -1744830448;
-                var optionInValue = BitConverter.GetBytes(1);
-                try
-                {
-                    socket.IOControl(SIO_LOOPBACK_FAST_PATH, optionInValue, null);
-                }
-                catch
-                {
-                    // If the operating system version on this machine did
-                    // not support SIO_LOOPBACK_FAST_PATH (i.e. version
-                    // prior to Windows 8 / Windows Server 2012), handle the exception
-                }
-            }
             socket.Connect(new IPEndPoint(IPAddress.Loopback, port));
             return socket;
         }


### PR DESCRIPTION
See https://github.com/aspnet/KestrelHttpServer/issues/1147#issuecomment-251817618 for reason for this change.

Considering the issue seen in test code, I think we should remove this from server code too. If we want to keep it, we should add an option to enable/disable it.

@halter73 @mikeharder @davidfowl 