### PR TITLE
Interlocked.Read -> Volatile.Read

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         // Called on Libuv thread
         public void Tick(long timestamp)
         {
-            if (timestamp > Interlocked.Read(ref _timeoutTimestamp))
+            if (timestamp > PlatformApis.VolatileRead(ref _timeoutTimestamp))
             {
                 ConnectionControl.CancelTimeout();
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/DateHeaderValueManager.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/DateHeaderValueManager.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.Net.Http.Headers;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
@@ -158,7 +159,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
 
             // No requests since the last timer tick, we need to check if we're beyond the idle threshold
-            if ((now.Ticks - Interlocked.Read(ref _lastRequestSeenTicks)) >= _timeWithoutRequestsUntilIdle.Ticks)
+            if ((now.Ticks - PlatformApis.VolatileRead(ref _lastRequestSeenTicks)) >= _timeWithoutRequestsUntilIdle.Ticks)
             {
                 // No requests since idle threshold so stop the timer if it's still running
                 StopTimer();

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/PlatformApis.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/PlatformApis.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -16,5 +19,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         public static bool IsWindows { get; }
 
         public static bool IsDarwin { get; }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long VolatileRead(ref long value)
+        {
+            if (IntPtr.Size == 8)
+            {
+                return Volatile.Read(ref value);
+            }
+            else
+            {
+                // Avoid torn long reads on 32-bit
+                return Interlocked.Read(ref value);
+            }
+        }
     }
 }


### PR DESCRIPTION
`Interlocked.Read` is a much more heavyweight operation than a `Volatile.Read`;  and may cause a cpu pipeline stall. However there may be a reason it was chosen in preference?

`Volatile.Read` is (1op on x64)

``` csharp
public static long Read(ref long location)
{
    // The VM will replace this with a more efficient implementation.
    var value = location;
    Thread.MemoryBarrier();
    return value;
}
```

`Interlocked.Read` is (22 ops on x64)

``` csharp
public static long Read(ref long location)
{
    return Interlocked.CompareExchange(ref location, 0, 0);
}
```

/cc @cesarbs @halter73 
