### PR TITLE
Handle response content length mismatches (#175)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.Generated.cs
@@ -3697,6 +3697,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             _bits = 0;
             _headers = default(HeaderReferences);
+            
             MaybeUnknown?.Clear();
         }
 
@@ -5670,6 +5671,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
             set
             {
+                _contentLength = ParseContentLength(value);
                 _bits |= 2048L;
                 _headers._ContentLength = value; 
                 _headers._rawContentLength = null;
@@ -7384,6 +7386,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     {
                         if ("Content-Length".Equals(key, StringComparison.OrdinalIgnoreCase))
                         {
+                            _contentLength = ParseContentLength(value);
                             _bits |= 2048L;
                             _headers._ContentLength = value;
                             _headers._rawContentLength = null;
@@ -7809,6 +7812,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                             {
                                 ThrowDuplicateKeyException();
                             }
+                            _contentLength = ParseContentLength(value);
                             _bits |= 2048L;
                             _headers._ContentLength = value;
                             _headers._rawContentLength = null;
@@ -8350,6 +8354,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                         {
                             if (((_bits & 2048L) != 0))
                             {
+                                _contentLength = null;
                                 _bits &= ~2048L;
                                 _headers._ContentLength = StringValues.Empty;
                                 _headers._rawContentLength = null;
@@ -8601,6 +8606,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             _bits = 0;
             _headers = default(HeaderReferences);
+            _contentLength = null;
             MaybeUnknown?.Clear();
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -229,6 +230,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                         ThrowInvalidHeaderCharacter(ch);
                     }
                 }
+            }
+        }
+
+        public static long ParseContentLength(StringValues value)
+        {
+            try
+            {
+                return long.Parse(value, NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite, CultureInfo.InvariantCulture);
+            }
+            catch (FormatException ex)
+            {
+                throw new InvalidOperationException("Content-Length value must be an integral number.", ex);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameResponseHeaders.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameResponseHeaders.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private static readonly byte[] _CrLf = new[] { (byte)'\r', (byte)'\n' };
         private static readonly byte[] _colonSpace = new[] { (byte)':', (byte)' ' };
 
+        private long? _contentLength;
+
         public bool HasConnection => HeaderConnection.Count != 0;
 
         public bool HasTransferEncoding => HeaderTransferEncoding.Count != 0;
@@ -22,6 +24,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         public bool HasServer => HeaderServer.Count != 0;
 
         public bool HasDate => HeaderDate.Count != 0;
+
+        public long? HeaderContentLengthValue => _contentLength;
 
         public Enumerator GetEnumerator()
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/IKestrelTrace.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
         void ConnectionDisconnectedWrite(string connectionId, int count, Exception ex);
 
-        void ConnectionHeadResponseBodyWrite(string connectionId, int count);
+        void ConnectionHeadResponseBodyWrite(string connectionId, long count);
 
         void ConnectionBadRequest(string connectionId, BadHttpRequestException ex);
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/KestrelTrace.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         private static readonly Action<ILogger, string, Exception> _applicationError;
         private static readonly Action<ILogger, string, Exception> _connectionError;
         private static readonly Action<ILogger, string, int, Exception> _connectionDisconnectedWrite;
-        private static readonly Action<ILogger, string, int, Exception> _connectionHeadResponseBodyWrite;
+        private static readonly Action<ILogger, string, long, Exception> _connectionHeadResponseBodyWrite;
         private static readonly Action<ILogger, Exception> _notAllConnectionsClosedGracefully;
         private static readonly Action<ILogger, string, string, Exception> _connectionBadRequest;
 
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
             _connectionDisconnectedWrite = LoggerMessage.Define<string, int>(LogLevel.Debug, 15, @"Connection id ""{ConnectionId}"" write of ""{count}"" bytes to disconnected client.");
             _notAllConnectionsClosedGracefully = LoggerMessage.Define(LogLevel.Debug, 16, "Some connections failed to close gracefully during server shutdown.");
             _connectionBadRequest = LoggerMessage.Define<string, string>(LogLevel.Information, 17, @"Connection id ""{ConnectionId}"" bad request data: ""{message}""");
-            _connectionHeadResponseBodyWrite = LoggerMessage.Define<string, int>(LogLevel.Debug, 18, @"Connection id ""{ConnectionId}"" write of ""{count}"" body bytes to non-body HEAD response.");
+            _connectionHeadResponseBodyWrite = LoggerMessage.Define<string, long>(LogLevel.Debug, 18, @"Connection id ""{ConnectionId}"" write of ""{count}"" body bytes to non-body HEAD response.");
         }
 
         public KestrelTrace(ILogger logger)
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
             _connectionDisconnectedWrite(_logger, connectionId, count, ex);
         }
 
-        public virtual void ConnectionHeadResponseBodyWrite(string connectionId, int count)
+        public virtual void ConnectionHeadResponseBodyWrite(string connectionId, long count)
         {
             _connectionHeadResponseBodyWrite(_logger, connectionId, count, null);
         }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
@@ -622,35 +622,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        public async Task WriteOnHeadResponseLoggedOnlyOnce(TestServiceContext testContext)
-        {
-            using (var server = new TestServer(async httpContext =>
-            {
-                await httpContext.Response.WriteAsync("hello, ");
-                await httpContext.Response.WriteAsync("world");
-                await httpContext.Response.WriteAsync("!");
-            }, testContext))
-            {
-                using (var connection = server.CreateConnection())
-                {
-                    await connection.SendEnd(
-                        "HEAD / HTTP/1.1",
-                        "",
-                        "");
-                    await connection.ReceiveEnd(
-                        "HTTP/1.1 200 OK",
-                        $"Date: {testContext.DateHeaderValue}",
-                        "",
-                        "");
-                }
-
-                Assert.Equal(1, ((TestKestrelTrace)testContext.Log).HeadResponseWrites);
-                Assert.Equal(13, ((TestKestrelTrace)testContext.Log).HeadResponseWriteByteCount);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(ConnectionFilterData))]
         public async Task ThrowingResultsIn500Response(TestServiceContext testContext)
         {
             bool onStartingCalled = false;
@@ -697,11 +668,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "Content-Length: 0",
                         "",
                         "");
-
-                    Assert.False(onStartingCalled);
-                    Assert.Equal(2, testLogger.ApplicationErrorsLogged);
                 }
             }
+
+            Assert.False(onStartingCalled);
+            Assert.Equal(2, testLogger.ApplicationErrorsLogged);
         }
 
         [Theory]
@@ -739,11 +710,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "Content-Length: 11",
                         "",
                         "Hello World");
-
-                    Assert.True(onStartingCalled);
-                    Assert.Equal(1, testLogger.ApplicationErrorsLogged);
                 }
             }
+
+            Assert.True(onStartingCalled);
+            Assert.Equal(1, testLogger.ApplicationErrorsLogged);
         }
 
         [Theory]
@@ -781,11 +752,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "Content-Length: 11",
                         "",
                         "Hello");
-
-                    Assert.True(onStartingCalled);
-                    Assert.Equal(1, testLogger.ApplicationErrorsLogged);
                 }
             }
+
+            Assert.True(onStartingCalled);
+            Assert.Equal(1, testLogger.ApplicationErrorsLogged);
         }
 
         [Theory]
@@ -925,16 +896,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "Content-Length: 0",
                         "",
                         "");
-
-                    Assert.Equal(2, onStartingCallCount2);
-
-                    // The first registered OnStarting callback should not be called,
-                    // since they are called LIFO and the other one failed.
-                    Assert.Equal(0, onStartingCallCount1);
-
-                    Assert.Equal(2, testLogger.ApplicationErrorsLogged);
                 }
             }
+
+            // The first registered OnStarting callback should not be called,
+            // since they are called LIFO and the other one failed.
+            Assert.Equal(0, onStartingCallCount1);
+            Assert.Equal(2, onStartingCallCount2);
+            Assert.Equal(2, testLogger.ApplicationErrorsLogged);
         }
 
         [Theory]
@@ -979,12 +948,12 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         "",
                         "Hello World");
                 }
-
-                // All OnCompleted callbacks should be called even if they throw.
-                Assert.Equal(2, testLogger.ApplicationErrorsLogged);
-                Assert.True(onCompletedCalled1);
-                Assert.True(onCompletedCalled2);
             }
+
+            // All OnCompleted callbacks should be called even if they throw.
+            Assert.Equal(2, testLogger.ApplicationErrorsLogged);
+            Assert.True(onCompletedCalled1);
+            Assert.True(onCompletedCalled2);
         }
 
         [Theory]

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
@@ -78,24 +78,29 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var responseHeaders = new FrameResponseHeaders();
 
-            Assert.Throws<InvalidOperationException>(() => {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
                 ((IHeaderDictionary)responseHeaders)[key] = value;
             });
 
-            Assert.Throws<InvalidOperationException>(() => {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
                 ((IHeaderDictionary)responseHeaders)[key] = new StringValues(new[] { "valid", value });
             });
 
-            Assert.Throws<InvalidOperationException>(() => {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
                 ((IDictionary<string, StringValues>)responseHeaders)[key] = value;
             });
 
-            Assert.Throws<InvalidOperationException>(() => {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
                 var kvp = new KeyValuePair<string, StringValues>(key, value);
                 ((ICollection<KeyValuePair<string, StringValues>>)responseHeaders).Add(kvp);
             });
 
-            Assert.Throws<InvalidOperationException>(() => {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
                 var kvp = new KeyValuePair<string, StringValues>(key, value);
                 ((IDictionary<string, StringValues>)responseHeaders).Add(key, value);
             });
@@ -141,6 +146,84 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             headers.SetReadOnly();
 
             Assert.Throws<InvalidOperationException>(() => dictionary.Clear());
+        }
+
+        [Fact]
+        public void ThrowsWhenAddingContentLengthWithNonNumericValue()
+        {
+            var headers = new FrameResponseHeaders();
+            var dictionary = (IDictionary<string, StringValues>)headers;
+
+            Assert.Throws<InvalidOperationException>(() => dictionary.Add("Content-Length", new[] { "bad" }));
+        }
+
+        [Fact]
+        public void ThrowsWhenSettingContentLengthToNonNumericValue()
+        {
+            var headers = new FrameResponseHeaders();
+            var dictionary = (IDictionary<string, StringValues>)headers;
+
+            Assert.Throws<InvalidOperationException>(() => ((IHeaderDictionary)headers)["Content-Length"] = "bad");
+        }
+
+        [Fact]
+        public void ThrowsWhenAssigningHeaderContentLengthToNonNumericValue()
+        {
+            var headers = new FrameResponseHeaders();
+            Assert.Throws<InvalidOperationException>(() => headers.HeaderContentLength = "bad");
+        }
+
+        [Fact]
+        public void ContentLengthValueCanBeReadAsLongAfterAddingHeader()
+        {
+            var headers = new FrameResponseHeaders();
+            var dictionary = (IDictionary<string, StringValues>)headers;
+            dictionary.Add("Content-Length", "42");
+
+            Assert.Equal(42, headers.HeaderContentLengthValue);
+        }
+
+        [Fact]
+        public void ContentLengthValueCanBeReadAsLongAfterSettingHeader()
+        {
+            var headers = new FrameResponseHeaders();
+            var dictionary = (IDictionary<string, StringValues>)headers;
+            dictionary["Content-Length"] = "42";
+
+            Assert.Equal(42, headers.HeaderContentLengthValue);
+        }
+
+        [Fact]
+        public void ContentLengthValueCanBeReadAsLongAfterAssigningHeader()
+        {
+            var headers = new FrameResponseHeaders();
+            headers.HeaderContentLength = "42";
+
+            Assert.Equal(42, headers.HeaderContentLengthValue);
+        }
+
+        [Fact]
+        public void ContentLengthValueClearedWhenHeaderIsRemoved()
+        {
+            var headers = new FrameResponseHeaders();
+            headers.HeaderContentLength = "42";
+            var dictionary = (IDictionary<string, StringValues>)headers;
+
+            dictionary.Remove("Content-Length");
+
+            Assert.Equal(null, headers.HeaderContentLengthValue);
+        }
+
+        [Fact]
+        public void ContentLengthValueClearedWhenHeadersCleared()
+        {
+            var headers = new FrameResponseHeaders();
+            headers.HeaderContentLength = "42";
+            var dictionary = (IDictionary<string, StringValues>)headers;
+
+            dictionary.Clear();
+
+            Assert.Equal(null, headers.HeaderContentLengthValue);
         }
     }
 }

--- a/test/shared/TestKestrelTrace.cs
+++ b/test/shared/TestKestrelTrace.cs
@@ -13,10 +13,6 @@ namespace Microsoft.AspNetCore.Testing
         {
         }
 
-        public int HeadResponseWrites { get; set; }
-
-        public int HeadResponseWriteByteCount { get; set; }
-
         public override void ConnectionRead(string connectionId, int count)
         {
             //_logger.LogDebug(1, @"Connection id ""{ConnectionId}"" recv {count} bytes.", connectionId, count);
@@ -30,12 +26,6 @@ namespace Microsoft.AspNetCore.Testing
         public override void ConnectionWriteCallback(string connectionId, int status)
         {
             //_logger.LogDebug(1, @"Connection id ""{ConnectionId}"" send finished with status {status}.", connectionId, status);
-        }
-
-        public override void ConnectionHeadResponseBodyWrite(string connectionId, int count)
-        {
-            HeadResponseWrites++;
-            HeadResponseWriteByteCount = count;
         }
     }
 }

--- a/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
+++ b/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
@@ -14,6 +14,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.GeneratedCode
             return values.Any() ? values.Select(formatter).Aggregate((a, b) => a + b) : "";
         }
 
+        static string If(bool condition, Func<string> formatter)
+        {
+            return condition ? formatter() : "";
+        }
+
         class KnownHeader
         {
             public string Name { get; set; }
@@ -228,7 +233,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 return StringValues.Empty;
             }}
             set
-            {{
+            {{{If(loop.ClassName == "FrameResponseHeaders" && header.Identifier == "ContentLength", () => @"
+                _contentLength = ParseContentLength(value);")}
                 {header.SetBit()};
                 _headers._{header.Identifier} = value; {(header.EnhancedSetter == false ? "" : $@"
                 _headers._raw{header.Identifier} = null;")}
@@ -304,7 +310,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 case {byLength.Key}:
                     {{{Each(byLength, header => $@"
                         if (""{header.Name}"".Equals(key, StringComparison.OrdinalIgnoreCase))
-                        {{
+                        {{{If(loop.ClassName == "FrameResponseHeaders" && header.Identifier == "ContentLength", () => @"
+                            _contentLength = ParseContentLength(value);")}
                             {header.SetBit()};
                             _headers._{header.Identifier} = value;{(header.EnhancedSetter == false ? "" : $@"
                             _headers._raw{header.Identifier} = null;")}
@@ -328,7 +335,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                             if ({header.TestBit()})
                             {{
                                 ThrowDuplicateKeyException();
-                            }}
+                            }}{
+                            If(loop.ClassName == "FrameResponseHeaders" && header.Identifier == "ContentLength", () => @"
+                            _contentLength = ParseContentLength(value);")}
                             {header.SetBit()};
                             _headers._{header.Identifier} = value;{(header.EnhancedSetter == false ? "" : $@"
                             _headers._raw{header.Identifier} = null;")}
@@ -349,7 +358,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                         if (""{header.Name}"".Equals(key, StringComparison.OrdinalIgnoreCase))
                         {{
                             if ({header.TestBit()})
-                            {{
+                            {{{If(loop.ClassName == "FrameResponseHeaders" && header.Identifier == "ContentLength", () => @"
+                                _contentLength = null;")}
                                 {header.ClearBit()};
                                 _headers._{header.Identifier} = StringValues.Empty;{(header.EnhancedSetter == false ? "" : $@"
                                 _headers._raw{header.Identifier} = null;")}
@@ -369,6 +379,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {{
             _bits = 0;
             _headers = default(HeaderReferences);
+            {(loop.ClassName == "FrameResponseHeaders" ? "_contentLength = null;" : "")}
             MaybeUnknown?.Clear();
         }}
 
@@ -435,7 +446,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                                     _headers._{header.Identifier} = AppendValue(_headers._{header.Identifier}, value);
                                 }}
                                 else
-                                {{
+                                {{{If(loop.ClassName == "FrameResponseHeaders" && header.Identifier == "ContentLength", () => @"
+                                    _contentLength = ParseContentLength(value);")}
                                     {header.SetBit()};
                                     _headers._{header.Identifier} = new StringValues(value);{(header.EnhancedSetter == false ? "" : $@"
                                     _headers._raw{header.Identifier} = null;")}


### PR DESCRIPTION
#175 

- [x] TODO: `InvalidOperationException` might not be the right exception type for this
- [x] TODO: is logging this as application errors OK or should we add new event IDs for response length mismatches?

@halter73 @Tratcher @mikeharder @davidfowl 