### PR TITLE
Reduce delay variability in KeepAliveTimeoutTests.ConnectionKeptAliveBetweenRequests() (#1157)

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
@@ -21,6 +21,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task TestKeepAliveTimeout()
         {
+            // Delays in these tests cannot be much longer than expected.
+            // Call ConfigureAwait(false) to get rid of Xunit's synchronization context,
+            // otherwise it can cause unexpectedly longer delays when multiple tests
+            // are running in parallel. These tests becomes flaky on slower
+            // hardware because the continuations for the delay tasks might take too long to be
+            // scheduled if running on Xunit's synchronization context.
+            await Task.Delay(1).ConfigureAwait(false);
+
             var longRunningCancellationTokenSource = new CancellationTokenSource();
             var upgradeCancellationTokenSource = new CancellationTokenSource();
 


### PR DESCRIPTION
#1157

`Task.Delay()` times vary *a lot* when running all tests at once. `ConfigureAwait` does the trick.

### Before change

```
Slept for 5258
Slept for 4792
Slept for 5110
Slept for 3939
Slept for 8251
Slept for 13205 <-- blows up
```

### After change

```
Slept for 3000
Slept for 3002
Slept for 2999
Slept for 2998
Slept for 3001
Slept for 2997
Slept for 2999
Slept for 2999
Slept for 3002
Slept for 2997

```

@halter73 