### PR TITLE
Update cached Content-Length when setting raw header

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.Generated.cs
@@ -6083,6 +6083,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         }
         public void SetRawContentLength(StringValues value, byte[] raw)
         {
+            _contentLength = ParseContentLength(value);
             _bits |= 2048L;
             _headers._ContentLength = value;
             _headers._rawContentLength = raw;

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseHeadersTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Internal;
@@ -167,6 +168,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
         [Fact]
+        public void ThrowsWhenSettingRawContentLengthToNonNumericValue()
+        {
+            var headers = new FrameResponseHeaders();
+
+            Assert.Throws<InvalidOperationException>(() => headers.SetRawContentLength("bad", Encoding.ASCII.GetBytes("bad")));
+        }
+
+        [Fact]
         public void ThrowsWhenAssigningHeaderContentLengthToNonNumericValue()
         {
             var headers = new FrameResponseHeaders();
@@ -189,6 +198,15 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var headers = new FrameResponseHeaders();
             var dictionary = (IDictionary<string, StringValues>)headers;
             dictionary["Content-Length"] = "42";
+
+            Assert.Equal(42, headers.HeaderContentLengthValue);
+        }
+
+        [Fact]
+        public void ContentLengthValueCanBeReadAsLongAfterSettingRawHeader()
+        {
+            var headers = new FrameResponseHeaders();
+            headers.SetRawContentLength("42", Encoding.ASCII.GetBytes("42"));
 
             Assert.Equal(42, headers.HeaderContentLengthValue);
         }

--- a/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
+++ b/tools/Microsoft.AspNetCore.Server.Kestrel.GeneratedCode/KnownHeaders.cs
@@ -242,7 +242,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         }}")}
         {Each(loop.Headers.Where(header => header.EnhancedSetter), header => $@"
         public void SetRaw{header.Identifier}(StringValues value, byte[] raw)
-        {{
+        {{{If(loop.ClassName == "FrameResponseHeaders" && header.Identifier == "ContentLength", () => @"
+            _contentLength = ParseContentLength(value);")}
             {header.SetBit()};
             _headers._{header.Identifier} = value;
             _headers._raw{header.Identifier} = raw;


### PR DESCRIPTION
Missed this in https://github.com/aspnet/KestrelHttpServer/commit/f8813a600df30e018a6224048b31244be3d456b9 :(

@halter73 @Tratcher 