### PR TITLE
Control-flow simplification in Frame.CreateResponseHeader() (#1168).

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -865,13 +865,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             responseHeaders.SetReadOnly();
 
-            if (!_keepAlive && !hasConnection)
+            if (!hasConnection)
             {
-                responseHeaders.SetRawConnection("close", _bytesConnectionClose);
-            }
-            else if (_keepAlive && !hasConnection && _httpVersion == Http.HttpVersion.Http10)
-            {
-                responseHeaders.SetRawConnection("keep-alive", _bytesConnectionKeepAlive);
+                if (!_keepAlive)
+                {
+                    responseHeaders.SetRawConnection("close", _bytesConnectionClose);
+                }
+                else if (_httpVersion == Http.HttpVersion.Http10)
+                {
+                    responseHeaders.SetRawConnection("keep-alive", _bytesConnectionKeepAlive);
+                }
             }
 
             if (ServerOptions.AddServerHeader && !responseHeaders.HasServer)


### PR DESCRIPTION
Thanks @cmckinsey for suggesting this change (#1168).

There's no noticeable change in benchmarks, but the code reads a lot better this way.

cc @halter73