### PR TITLE
Always return valid values from MemoryPoolIterator.PeekLong()

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
@@ -59,6 +59,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         {
             try
             {
+                if (!BitConverter.IsLittleEndian)
+                {
+                    throw new PlatformNotSupportedException("Kestrel does not support big-endian architectures.");
+                }
+
                 ValidateOptions();
 
                 if (_disposables != null)

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MemoryPoolIteratorTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MemoryPoolIteratorTests.cs
@@ -299,23 +299,23 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             // Arrange
             var block = _pool.Lease();
-            var bytes = BitConverter.GetBytes(0x0102030405060708);
+            var bytes = BitConverter.GetBytes(0x0102030405060708UL);
             Buffer.BlockCopy(bytes, 0, block.Array, block.Start, bytes.Length);
             block.End += bytes.Length;
             var scan = block.GetIterator();
             var originalIndex = scan.Index;
 
-            // Act
-            var result = scan.PeekLong();
-
             // Assert
-            Assert.Equal(0x0102030405060708, result);
+            ulong result;
+            Assert.True(scan.TryPeekLong(out result));
+            Assert.Equal(0x0102030405060708UL, result);
             Assert.Equal(originalIndex, scan.Index);
 
             _pool.Return(block);
         }
 
         [Theory]
+        [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
@@ -323,31 +323,57 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [InlineData(5)]
         [InlineData(6)]
         [InlineData(7)]
-        public void PeekLongAtBlockBoundary(int blockBytes)
+        public void PeekLongNotEnoughBytes(int totalBytes)
         {
             // Arrange
-            var nextBlockBytes = 8 - blockBytes;
+            var block = _pool.Lease();
+            var bytes = BitConverter.GetBytes(0x0102030405060708UL);
+            var bytesLength = totalBytes;
+            Buffer.BlockCopy(bytes, 0, block.Array, block.Start, bytesLength);
+            block.End += bytesLength;
+            var scan = block.GetIterator();
+            var originalIndex = scan.Index;
+
+            // Assert
+            ulong result;
+            Assert.False(scan.TryPeekLong(out result));
+            Assert.Equal(originalIndex, scan.Index);
+            _pool.Return(block);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        public void PeekLongNotEnoughBytesAtBlockBoundary(int firstBlockBytes)
+        {
+            // Arrange
+            var expectedResult = 0x0102030405060708UL;
+            var nextBlockBytes = 7 - firstBlockBytes;
 
             var block = _pool.Lease();
-            block.End += blockBytes;
+            block.End += firstBlockBytes;
 
             var nextBlock = _pool.Lease();
             nextBlock.End += nextBlockBytes;
 
             block.Next = nextBlock;
 
-            var bytes = BitConverter.GetBytes(0x0102030405060708);
-            Buffer.BlockCopy(bytes, 0, block.Array, block.Start, blockBytes);
-            Buffer.BlockCopy(bytes, blockBytes, nextBlock.Array, nextBlock.Start, nextBlockBytes);
+            var bytes = BitConverter.GetBytes(expectedResult);
+            Buffer.BlockCopy(bytes, 0, block.Array, block.Start, firstBlockBytes);
+            Buffer.BlockCopy(bytes, firstBlockBytes, nextBlock.Array, nextBlock.Start, nextBlockBytes);
 
             var scan = block.GetIterator();
             var originalIndex = scan.Index;
 
-            // Act
-            var result = scan.PeekLong();
-
             // Assert
-            Assert.Equal(0x0102030405060708, result);
+            ulong result;
+            Assert.False(scan.TryPeekLong(out result));
             Assert.Equal(originalIndex, scan.Index);
 
             _pool.Return(block);
@@ -355,6 +381,109 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
         [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        public void PeekLongAtBlockBoundary(int firstBlockBytes)
+        {
+            // Arrange
+            var expectedResult = 0x0102030405060708UL;
+            var nonZeroData = 0xFF00FFFF0000FFFFUL;
+            var nextBlockBytes = 8 - firstBlockBytes;
+
+            var block = _pool.Lease();
+            block.Start += 8;
+            block.End = block.Start + firstBlockBytes;
+
+            var nextBlock = _pool.Lease();
+            nextBlock.Start += 8;
+            nextBlock.End = nextBlock.Start + nextBlockBytes;
+
+            block.Next = nextBlock;
+
+            var bytes = BitConverter.GetBytes(expectedResult);
+            Buffer.BlockCopy(bytes, 0, block.Array, block.Start, firstBlockBytes);
+            Buffer.BlockCopy(bytes, firstBlockBytes, nextBlock.Array, nextBlock.Start, nextBlockBytes);
+
+            // Fill in surrounding bytes with non-zero data
+            var nonZeroBytes = BitConverter.GetBytes(nonZeroData);
+            Buffer.BlockCopy(nonZeroBytes, 0, block.Array, block.Start - 8, 8);
+            Buffer.BlockCopy(nonZeroBytes, 0, block.Array, block.End, 8);
+            Buffer.BlockCopy(nonZeroBytes, 0, nextBlock.Array, nextBlock.Start - 8, 8);
+            Buffer.BlockCopy(nonZeroBytes, 0, nextBlock.Array, nextBlock.End, 8);
+
+            var scan = block.GetIterator();
+            var originalIndex = scan.Index;
+
+            // Assert
+            ulong result;
+            Assert.True(scan.TryPeekLong(out result));
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(originalIndex, scan.Index);
+
+            _pool.Return(block);
+            _pool.Return(nextBlock);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        public void PeekLongAtBlockBoundarayWithMostSignificatBitsSet(int firstBlockBytes)
+        {
+            // Arrange
+            var expectedResult = 0xFF02030405060708UL;
+            var nonZeroData = 0xFF00FFFF0000FFFFUL;
+            var nextBlockBytes = 8 - firstBlockBytes;
+
+            var block = _pool.Lease();
+            block.Start += 8;
+            block.End = block.Start + firstBlockBytes;
+
+            var nextBlock = _pool.Lease();
+            nextBlock.Start += 8;
+            nextBlock.End = nextBlock.Start + nextBlockBytes;
+
+            block.Next = nextBlock;
+
+            var expectedBytes = BitConverter.GetBytes(expectedResult);
+            Buffer.BlockCopy(expectedBytes, 0, block.Array, block.Start, firstBlockBytes);
+            Buffer.BlockCopy(expectedBytes, firstBlockBytes, nextBlock.Array, nextBlock.Start, nextBlockBytes);
+
+            // Fill in surrounding bytes with non-zero data
+            var nonZeroBytes = BitConverter.GetBytes(nonZeroData);
+            Buffer.BlockCopy(nonZeroBytes, 0, block.Array, block.Start - 8, 8);
+            Buffer.BlockCopy(nonZeroBytes, 0, block.Array, block.End, 8);
+            Buffer.BlockCopy(nonZeroBytes, 0, nextBlock.Array, nextBlock.Start - 8, 8);
+            Buffer.BlockCopy(nonZeroBytes, 0, nextBlock.Array, nextBlock.End, 8);
+
+            var scan = block.GetIterator();
+            var originalIndex = scan.Index;
+
+            // Assert
+            ulong result;
+            Assert.True(scan.TryPeekLong(out result));
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(originalIndex, scan.Index);
+
+            _pool.Return(block);
+            _pool.Return(nextBlock);
+        }
+
+        [Theory]
+        [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
@@ -432,23 +561,23 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
         [Theory]
-        [InlineData("CONNECT / HTTP/1.1", ' ', true, "CONNECT")]
-        [InlineData("DELETE / HTTP/1.1", ' ', true, "DELETE")]
-        [InlineData("GET / HTTP/1.1", ' ', true, "GET")]
-        [InlineData("HEAD / HTTP/1.1", ' ', true, "HEAD")]
-        [InlineData("PATCH / HTTP/1.1", ' ', true, "PATCH")]
-        [InlineData("POST / HTTP/1.1", ' ', true, "POST")]
-        [InlineData("PUT / HTTP/1.1", ' ', true, "PUT")]
-        [InlineData("OPTIONS / HTTP/1.1", ' ', true, "OPTIONS")]
-        [InlineData("TRACE / HTTP/1.1", ' ', true, "TRACE")]
-        [InlineData("GET/ HTTP/1.1", ' ', false, null)]
-        [InlineData("get / HTTP/1.1", ' ', false, null)]
-        [InlineData("GOT / HTTP/1.1", ' ', false, null)]
-        [InlineData("ABC / HTTP/1.1", ' ', false, null)]
-        [InlineData("PO / HTTP/1.1", ' ', false, null)]
-        [InlineData("PO ST / HTTP/1.1", ' ', false, null)]
-        [InlineData("short ", ' ', false, null)]
-        public void GetsKnownMethod(string input, char endChar, bool expectedResult, string expectedKnownString)
+        [InlineData("CONNECT / HTTP/1.1", true, "CONNECT")]
+        [InlineData("DELETE / HTTP/1.1", true, "DELETE")]
+        [InlineData("GET / HTTP/1.1", true, "GET")]
+        [InlineData("HEAD / HTTP/1.1", true, "HEAD")]
+        [InlineData("PATCH / HTTP/1.1", true, "PATCH")]
+        [InlineData("POST / HTTP/1.1", true, "POST")]
+        [InlineData("PUT / HTTP/1.1", true, "PUT")]
+        [InlineData("OPTIONS / HTTP/1.1", true, "OPTIONS")]
+        [InlineData("TRACE / HTTP/1.1", true, "TRACE")]
+        [InlineData("GET/ HTTP/1.1", false, null)]
+        [InlineData("get / HTTP/1.1", false, null)]
+        [InlineData("GOT / HTTP/1.1", false, null)]
+        [InlineData("ABC / HTTP/1.1", false, null)]
+        [InlineData("PO / HTTP/1.1", false, null)]
+        [InlineData("PO ST / HTTP/1.1", false, null)]
+        [InlineData("short ", false, null)]
+        public void GetsKnownMethod(string input, bool expectedResult, string expectedKnownString)
         {
             // Arrange
             var block = _pool.Lease();
@@ -465,17 +594,46 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Assert.Equal(expectedResult, result);
             Assert.Equal(expectedKnownString, knownString);
 
+            // Test at boundary
+            var maxSplit = Math.Min(input.Length, 8);
+            var nextBlock = _pool.Lease();
+
+            for (var split = 0; split <= maxSplit; split++)
+            {
+                // Arrange
+                block.Reset();
+                nextBlock.Reset();
+
+                Buffer.BlockCopy(chars, 0, block.Array, block.Start, split);
+                Buffer.BlockCopy(chars, split, nextBlock.Array, nextBlock.Start, chars.Length - split);
+
+                block.End += split;
+                nextBlock.End += chars.Length - split;
+                block.Next = nextBlock;
+
+                var boundaryBegin = block.GetIterator();
+                string boundaryKnownString;
+
+                // Act
+                var boundaryResult = boundaryBegin.GetKnownMethod(out boundaryKnownString);
+
+                // Assert
+                Assert.Equal(expectedResult, boundaryResult);
+                Assert.Equal(expectedKnownString, boundaryKnownString);
+            }
+
             _pool.Return(block);
+            _pool.Return(nextBlock);
         }
 
         [Theory]
-        [InlineData("HTTP/1.0\r", '\r', true, MemoryPoolIteratorExtensions.Http10Version)]
-        [InlineData("HTTP/1.1\r", '\r', true, MemoryPoolIteratorExtensions.Http11Version)]
-        [InlineData("HTTP/3.0\r", '\r', false, null)]
-        [InlineData("http/1.0\r", '\r', false, null)]
-        [InlineData("http/1.1\r", '\r', false, null)]
-        [InlineData("short ", ' ', false, null)]
-        public void GetsKnownVersion(string input, char endChar, bool expectedResult, string expectedKnownString)
+        [InlineData("HTTP/1.0\r", true, MemoryPoolIteratorExtensions.Http10Version)]
+        [InlineData("HTTP/1.1\r", true, MemoryPoolIteratorExtensions.Http11Version)]
+        [InlineData("HTTP/3.0\r", false, null)]
+        [InlineData("http/1.0\r", false, null)]
+        [InlineData("http/1.1\r", false, null)]
+        [InlineData("short ", false, null)]
+        public void GetsKnownVersion(string input, bool expectedResult, string expectedKnownString)
         {
             // Arrange
             var block = _pool.Lease();
@@ -491,7 +649,36 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Assert.Equal(expectedResult, result);
             Assert.Equal(expectedKnownString, knownString);
 
+            // Test at boundary
+            var maxSplit = Math.Min(input.Length, 9);
+            var nextBlock = _pool.Lease();
+
+            for (var split = 0; split <= maxSplit; split++)
+            {
+                // Arrange
+                block.Reset();
+                nextBlock.Reset();
+
+                Buffer.BlockCopy(chars, 0, block.Array, block.Start, split);
+                Buffer.BlockCopy(chars, split, nextBlock.Array, nextBlock.Start, chars.Length - split);
+
+                block.End += split;
+                nextBlock.End += chars.Length - split;
+                block.Next = nextBlock;
+
+                var boundaryBegin = block.GetIterator();
+                string boundaryKnownString;
+
+                // Act
+                var boundaryResult = boundaryBegin.GetKnownVersion(out boundaryKnownString);
+
+                // Assert
+                Assert.Equal(expectedResult, boundaryResult);
+                Assert.Equal(expectedKnownString, boundaryKnownString);
+            }
+
             _pool.Return(block);
+            _pool.Return(nextBlock);
         }
 
         [Theory]


### PR DESCRIPTION
- Fixed edge case where the iterator is at the end of a block
- Fixed edge case where one bits where improperly filled in on a right shift
- Make return value of PeekLong Nullable<ulong>

This fixes GetKnownMethod and GetKnownVersion

#1183