### PR TITLE
Handle non "chunked" Transfer-Encoding header values (#1181)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
@@ -99,6 +99,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 case RequestRejectionReason.UnrecognizedHTTPVersion:
                     ex = new BadHttpRequestException($"Unrecognized HTTP version: {value}", 505);
                     break;
+                case RequestRejectionReason.FinalTransferCodingNotChunked:
+                    ex = new BadHttpRequestException($"Final transfer coding is not \"chunked\": \"{value}\"", 400);
+                    break;
                 default:
                     ex = new BadHttpRequestException("Bad request.", 400);
                     break;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
@@ -27,5 +27,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         MissingCRInHeaderLine,
         TooManyHeaders,
         RequestTimeout,
+        FinalTransferCodingNotChunked
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/TransferCoding.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/TransferCoding.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
+{
+    [Flags]
+    public enum TransferCoding
+    {
+        None,
+        Chunked,
+        Other
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.KestrelTests.TestHelpers;
 using Microsoft.Extensions.Internal;
@@ -186,6 +187,19 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 var count = await stream.ReadAsync(new byte[1], 0, 1);
                 Assert.Equal(0, count);
+            }
+        }
+
+        [Fact]
+        public void ForThrowsWhenFinalTransferCodingIsNotChunked()
+        {
+            using (var input = new TestInput())
+            {
+                var ex = Assert.Throws<BadHttpRequestException>(() =>
+                    MessageBody.For(HttpVersion.Http10, new FrameRequestHeaders { HeaderTransferEncoding = "chunked, not-chunked" }, input.FrameContext));
+
+                Assert.Equal(400, ex.StatusCode);
+                Assert.Equal("Final transfer coding is not \"chunked\": \"chunked, not-chunked\"", ex.Message);
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestInput.cs
@@ -38,6 +38,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var context = new Frame<object>(null, connectionContext);
             FrameContext = context;
             FrameContext.FrameControl = this;
+            FrameContext.ConnectionContext.ListenerContext.ServiceContext.Log = trace;
 
             _memoryPool = new MemoryPool();
             FrameContext.SocketInput = new SocketInput(_memoryPool, ltp);

--- a/test/shared/TestConnection.cs
+++ b/test/shared/TestConnection.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Testing
         {
             await Receive(lines);
             var ch = new char[128];
-            var count = await _reader.ReadAsync(ch, 0, 128);
+            var count = await _reader.ReadAsync(ch, 0, 128).TimeoutAfter(TimeSpan.FromMinutes(1));
             var text = new string(ch, 0, count);
             Assert.Equal("", text);
         }
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Testing
             try
             {
                 var ch = new char[128];
-                var count = await _reader.ReadAsync(ch, 0, 128);
+                var count = await _reader.ReadAsync(ch, 0, 128).TimeoutAfter(TimeSpan.FromMinutes(1));
                 var text = new string(ch, 0, count);
                 Assert.Equal("", text);
             }


### PR DESCRIPTION
#1181

- Reject request if `chunked` is not final token in `Transfer-Encoding`
- Close connection if `chunked` is not final token in response `Transfer-Encoding`

Point for discussion: should we insert `chunked` and auto-chunk responses that don't have `chunked` in `Transfer-Encoding`? Or should we leave it up to the app to chunk the response in those cases? The problem with not auto-chunking is that Kestrel will now close the connection if such a response is sent.

@halter73 @davidfowl @Tratcher @mikeharder
