### PR TITLE
Add regression tests for 'Connection: keep-alive, upgrade' request header (#1171)

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing.xunit;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -182,6 +183,47 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     Assert.False(responseBodyPersisted);
                 }
             }
+        }
+
+        [Fact]
+        public void CanUpgradeRequestWithConnectionKeepAliveUpgradeHeader()
+        {
+            var dataRead = false;
+            var builder = new WebHostBuilder()
+               .UseKestrel()
+               .UseUrls($"http://127.0.0.1:0")
+               .Configure(app =>
+               {
+                   app.Run(async context =>
+                   {
+                       var stream = await context.Features.Get<IHttpUpgradeFeature>().UpgradeAsync();
+                       var data = new byte[3];
+                       var bytesRead = 0;
+
+                       while (bytesRead < 3)
+                       {
+                           bytesRead += await stream.ReadAsync(data, bytesRead, data.Length - bytesRead);
+                       }
+
+                       dataRead = Encoding.ASCII.GetString(data, 0, 3) == "abc";
+                   });
+               });
+
+            using (var host = builder.Build())
+            {
+                host.Start();
+
+                using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    socket.Connect(new IPEndPoint(IPAddress.Loopback, host.GetPort()));
+                    socket.Send(Encoding.ASCII.GetBytes("GET / HTTP/1.1\r\nConnection: keep-alive, upgrade\r\n\r\n"));
+                    socket.Send(Encoding.ASCII.GetBytes("abc"));
+
+                    while (socket.Receive(new byte[1024]) > 0) ;
+                }
+            }
+
+            Assert.True(dataRead);
         }
 
         private async Task TestRemoteIPAddress(string registerAddress, string requestAddress, string expectAddress)

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
@@ -88,6 +88,27 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
+        [Theory]
+        [InlineData("keep-alive, upgrade")]
+        [InlineData("Keep-Alive, Upgrade")]
+        [InlineData("upgrade, keep-alive")]
+        [InlineData("Upgrade, Keep-Alive")]
+        public void ConnectionUpgradeKeepAlive(string headerConnection)
+        {
+            using (var input = new TestInput())
+            {
+                var body = MessageBody.For("HTTP/1.1", new FrameRequestHeaders { HeaderConnection = headerConnection }, input.FrameContext);
+                var stream = new FrameRequestStream();
+                stream.StartAcceptingReads(body);
+
+                input.Add("Hello", true);
+
+                var buffer = new byte[1024];
+                Assert.Equal(5, stream.Read(buffer, 0, 1024));
+                AssertASCII("Hello", new ArraySegment<byte>(buffer, 0, 5));
+            }
+        }
+
         private void AssertASCII(string expected, ArraySegment<byte> actual)
         {
             var encoding = Encoding.ASCII;


### PR DESCRIPTION
#1171 

@halter73 @anurse @BrennanConroy 