### PR TITLE
Avoid zero-length writes to flush connection filter StreamSocketOutput

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Filter/Internal/StreamSocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Filter/Internal/StreamSocketOutput.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Filter.Internal
 {
@@ -34,11 +35,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Filter.Internal
 
         public void Write(ArraySegment<byte> buffer, bool chunk)
         {
-            if (buffer.Count == 0 )
-            {
-                return;
-            }
-
             if (chunk && buffer.Array != null)
             {
                 var beginChunkBytes = ChunkWriter.BeginChunkBytes(buffer.Count);
@@ -116,6 +112,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Filter.Internal
             }
 
             end.Block.Pool.Return(end.Block);
+        }
+
+        // Flush no-ops. We rely on connection filter streams to auto-flush.
+        public void Flush()
+        {
+        }
+
+        public Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return TaskCache.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
     {
         private static readonly ArraySegment<byte> _endChunkedResponseBytes = CreateAsciiByteArraySegment("0\r\n\r\n");
         private static readonly ArraySegment<byte> _continueBytes = CreateAsciiByteArraySegment("HTTP/1.1 100 Continue\r\n\r\n");
-        private static readonly ArraySegment<byte> _emptyData = new ArraySegment<byte>(new byte[0]);
 
         private static readonly byte[] _bytesConnectionClose = Encoding.ASCII.GetBytes("\r\nConnection: close");
         private static readonly byte[] _bytesConnectionKeepAlive = Encoding.ASCII.GetBytes("\r\nConnection: keep-alive");
@@ -506,13 +505,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         public void Flush()
         {
             ProduceStartAndFireOnStarting().GetAwaiter().GetResult();
-            SocketOutput.Write(_emptyData);
+            SocketOutput.Flush();
         }
 
         public async Task FlushAsync(CancellationToken cancellationToken)
         {
             await ProduceStartAndFireOnStarting();
-            await SocketOutput.WriteAsync(_emptyData, cancellationToken: cancellationToken);
+            await SocketOutput.FlushAsync(cancellationToken);
         }
 
         public void Write(ArraySegment<byte> data)
@@ -768,7 +767,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             ProduceStart(appCompleted: true);
 
             // Force flush
-            await SocketOutput.WriteAsync(_emptyData);
+            await SocketOutput.FlushAsync();
 
             await WriteSuffix();
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ISocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ISocketOutput.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
     {
         void Write(ArraySegment<byte> buffer, bool chunk = false);
         Task WriteAsync(ArraySegment<byte> buffer, bool chunk = false, CancellationToken cancellationToken = default(CancellationToken));
+        void Flush();
+        Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Returns an iterator pointing to the tail of the response buffer. Response data can be appended

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockSocketOuptut.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockSocketOuptut.cs
@@ -29,5 +29,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
         {
             return TaskCache.CompletedTask;
         }
+
+        public void Flush()
+        {
+        }
+
+        public Task FlushAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return TaskCache.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
- This works around a zero-length write bug in SslStream.

#1195