### PR TITLE
Prevent block leak when socket is closed before connection filter is applied

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -51,6 +51,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         protected Stack<KeyValuePair<Func<object, Task>, object>> _onStarting;
         protected Stack<KeyValuePair<Func<object, Task>, object>> _onCompleted;
 
+        private TaskCompletionSource<object> _frameStartedTcs = new TaskCompletionSource<object>();
         private Task _requestProcessingTask;
         protected volatile bool _requestProcessingStopping; // volatile, see: https://msdn.microsoft.com/en-us/library/x13ttww7.aspx
         protected int _requestAborted;
@@ -204,6 +205,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         public Stream ResponseBody { get; set; }
 
         public Stream DuplexStream { get; set; }
+
+        public Task FrameStartedTask => _frameStartedTcs.Task;
 
         public CancellationToken RequestAborted
         {
@@ -366,6 +369,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     default(CancellationToken),
                     TaskCreationOptions.DenyChildAttach,
                     TaskScheduler.Default).Unwrap();
+            _frameStartedTcs.SetResult(null);
         }
 
         /// <summary>


### PR DESCRIPTION
When a connection filter is in use, there's a race in `Connection` when a connection is started and immediately ended with an error (e.g. when a client opens a socket and immediately disposes it, causing an RST to be sent to the server). The error prompts a call to `Connection.Abort()`, which ultimately leads to a call to `Connection.OnSocketClose()`. At the same time, `Connection.Start()` starts a task calling the filter's `OnConnectionAsync()` method, whose continuation will eventually call `Connection.ApplyConnectionFilter()`, which will instantiate a `FilteredStreamAdapter` and start it's read input task by calling `ReadInputAsync()`. This last task leases a block from the memory pool.

If `ApplyConnectionFilter()` has not been called by the time `OnSocketClose()` is called, `OnSocketClose()` will fail to dispose the `FilteredStreamAdapter` and the read input task will not be awaited. The block leased by `FilteredStreamAdapter` will thus never be returned to the pool and will be garbage collected instead.

The fix is to make sure `FilteredStreamAdapter` has been created when `OnSocketClosed()` is called. Since we also have to account for the case when there's no connection filter, a practical way to do this is to wait for a task that is completed once the frame has been started (which happens as soon as the connection is started when there's no filter, and as soon as the filter is applied (i.e. the `FilteredStreamAdapter` is created and it's read input task started) when there is one. `OnSocketClosed` can then wait until that task is completed and continue it with the code currently in place there.

cc @halter73 