### PR TITLE
Handle client FIN as request abort

### DIFF
--- a/KestrelHttpServer.sln
+++ b/KestrelHttpServer.sln
@@ -42,6 +42,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{0EF2AC
 		test\shared\MockSocketOutput.cs = test\shared\MockSocketOutput.cs
 		test\shared\MockSystemClock.cs = test\shared\MockSystemClock.cs
 		test\shared\SocketInputExtensions.cs = test\shared\SocketInputExtensions.cs
+		test\shared\TestApp.cs = test\shared\TestApp.cs
 		test\shared\TestApplicationErrorLogger.cs = test\shared\TestApplicationErrorLogger.cs
 		test\shared\TestConnection.cs = test\shared\TestConnection.cs
 		test\shared\TestFrame.cs = test\shared\TestFrame.cs

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -103,7 +103,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         }
 
                         Assert.Equal(data.Length, bytesWritten);
-                        socket.Shutdown(SocketShutdown.Send);
                         clientFinishedSendingRequestBody.Set();
                     };
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestLineSizeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestLineSizeTests.cs
@@ -25,13 +25,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [InlineData("DELETE /a%20b%20c/d%20e?f=ghi HTTP/1.1\r\n\r\n", 1027)]
         public async Task ServerAcceptsRequestLineWithinLimit(string request, int limit)
         {
-            var maxRequestLineSize = limit;
-
             using (var server = CreateServer(limit))
             {
                 using (var connection = new TestConnection(server.Port))
                 {
-                    await connection.SendEnd(request);
+                    await connection.Send(request);
                     await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -57,8 +55,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 using (var connection = new TestConnection(server.Port))
                 {
-                    await connection.SendAllTryEnd($"{requestLine}\r\n");
-                    await connection.Receive(
+                    await connection.SendAll(requestLine);
+                    await connection.ReceiveForcedEnd(
                         "HTTP/1.1 414 URI Too Long",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestHeaderLimitsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestHeaderLimitsTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 using (var connection = new TestConnection(server.Port))
                 {
-                    await connection.SendEnd($"GET / HTTP/1.1\r\n{headers}\r\n");
+                    await connection.Send($"GET / HTTP/1.1\r\n{headers}\r\n");
                     await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 using (var connection = new TestConnection(server.Port))
                 {
-                    await connection.SendEnd($"GET / HTTP/1.1\r\n{headers}\r\n");
+                    await connection.Send($"GET / HTTP/1.1\r\n{headers}\r\n");
                     await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 using (var connection = new TestConnection(server.Port))
                 {
-                    await connection.SendAllTryEnd($"GET / HTTP/1.1\r\n{headers}\r\n");
+                    await connection.SendAll($"GET / HTTP/1.1\r\n{headers}\r\n");
                     await connection.ReceiveForcedEnd(
                         "HTTP/1.1 431 Request Header Fields Too Large",
                         "Connection: close",
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 using (var connection = new TestConnection(server.Port))
                 {
-                    await connection.SendAllTryEnd($"GET / HTTP/1.1\r\n{headers}\r\n");
+                    await connection.SendAll($"GET / HTTP/1.1\r\n{headers}\r\n");
                     await connection.ReceiveForcedEnd(
                         "HTTP/1.1 431 Request Header Fields Too Large",
                         "Connection: close",

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllTryEnd(request);
+                    await connection.SendAll(request);
                     await ReceiveBadRequestResponse(connection, "400 Bad Request", server.Context.DateHeaderValue);
                 }
             }
@@ -88,15 +88,13 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllTryEnd(request);
+                    await connection.SendAll(request);
                     await ReceiveBadRequestResponse(connection, "505 HTTP Version Not Supported", server.Context.DateHeaderValue);
                 }
             }
         }
 
         [Theory]
-        // Missing final CRLF
-        [InlineData("Header-1: value1\r\nHeader-2: value2\r\n")]
         // Leading whitespace
         [InlineData(" Header-1: value1\r\nHeader-2: value2\r\n\r\n")]
         [InlineData("\tHeader-1: value1\r\nHeader-2: value2\r\n\r\n")]
@@ -124,7 +122,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllTryEnd($"GET / HTTP/1.1\r\n{rawHeaders}");
+                    await connection.SendAll($"GET / HTTP/1.1\r\n{rawHeaders}");
                     await ReceiveBadRequestResponse(connection, "400 Bad Request", server.Context.DateHeaderValue);
                 }
             }
@@ -137,7 +135,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllTryEnd(
+                    await connection.SendAll(
                         "GET / HTTP/1.1",
                         "H\u00eb\u00e4d\u00ebr: value",
                         "",
@@ -168,7 +166,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllTryEnd($"GET {path} HTTP/1.1\r\n");
+                    await connection.SendAll($"GET {path} HTTP/1.1\r\n");
                     await ReceiveBadRequestResponse(connection, "400 Bad Request", server.Context.DateHeaderValue);
                 }
             }
@@ -183,7 +181,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd($"{method} / HTTP/1.1\r\n\r\n");
+                    await connection.Send($"{method} / HTTP/1.1\r\n\r\n");
                     await ReceiveBadRequestResponse(connection, "411 Length Required", server.Context.DateHeaderValue);
                 }
             }
@@ -198,7 +196,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd($"{method} / HTTP/1.0\r\n\r\n");
+                    await connection.Send($"{method} / HTTP/1.0\r\n\r\n");
                     await ReceiveBadRequestResponse(connection, "400 Bad Request", server.Context.DateHeaderValue);
                 }
             }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
@@ -68,13 +68,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "POST / HTTP/1.0",
                         "Transfer-Encoding: chunked",
                         "",
                         "5", "Hello",
                         "6", " World",
                         "0",
+                         "",
                          "");
                     await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
@@ -94,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "POST / HTTP/1.0",
                         "Transfer-Encoding: chunked",
                         "Connection: keep-alive",
@@ -143,7 +144,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "POST / HTTP/1.1",
                         "Content-Length: 5",
                         "",
@@ -254,8 +255,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(fullRequest);
-
+                    await connection.Send(fullRequest);
                     await connection.ReceiveEnd(expectedFullResponse);
                 }
             }
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllTryEnd(
+                    await connection.SendAll(
                         "POST / HTTP/1.1",
                         $"{transferEncodingHeaderLine}",
                         $"{headerLine}",
@@ -322,7 +322,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllTryEnd(
+                    await connection.SendAll(
                         "POST / HTTP/1.1",
                         $"{transferEncodingHeaderLine}",
                         $"{headerLine}",
@@ -423,8 +423,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(fullRequest);
-
+                    await connection.Send(fullRequest);
                     await connection.ReceiveEnd(expectedFullResponse);
                 }
             }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedResponseTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.1",
                         "",
                         "");
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.0",
                         "Connection: keep-alive",
                         "",
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.1",
                         "Connection: close",
                         "",
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.1",
                         "",
                         "");
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.1",
                         "",
                         "");
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.1",
                         "",
                         "");
@@ -246,7 +246,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.1",
                         "",
                         "");
@@ -264,7 +264,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        public async Task ConnectionClosedIfExeptionThrownAfterWrite(TestServiceContext testContext)
+        public async Task ConnectionClosedIfExceptionThrownAfterWrite(TestServiceContext testContext)
         {
             using (var server = new TestServer(async httpContext =>
             {
@@ -295,7 +295,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         [Theory]
         [MemberData(nameof(ConnectionFilterData))]
-        public async Task ConnectionClosedIfExeptionThrownAfterZeroLengthWrite(TestServiceContext testContext)
+        public async Task ConnectionClosedIfExceptionThrownAfterZeroLengthWrite(TestServiceContext testContext)
         {
             using (var server = new TestServer(async httpContext =>
             {
@@ -342,7 +342,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.1",
                         "",
                         "");
@@ -383,7 +383,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.1",
                         "",
                         "");

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/DefaultHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/DefaultHeaderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET / HTTP/1.1",
                         "",
                         "GET / HTTP/1.0",

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/RequestTargetProcessingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/RequestTargetProcessingTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         "GET /%41%CC%8A/A/../B/%41%CC%8A HTTP/1.1",
                         "",
                         "");
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         $"GET {requestTarget} HTTP/1.1",
                         "",
                         "");
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd(
+                    await connection.Send(
                         $"GET {requestTarget} HTTP/1.1",
                         "",
                         "");

--- a/test/shared/DummyApplication.cs
+++ b/test/shared/DummyApplication.cs
@@ -12,20 +12,27 @@ namespace Microsoft.AspNetCore.Testing
     public class DummyApplication : IHttpApplication<HttpContext>
     {
         private readonly RequestDelegate _requestDelegate;
+        private readonly IHttpContextFactory _httpContextFactory;
 
         public DummyApplication(RequestDelegate requestDelegate)
+            : this(requestDelegate, null)
+        {
+        }
+
+        public DummyApplication(RequestDelegate requestDelegate, IHttpContextFactory httpContextFactory)
         {
             _requestDelegate = requestDelegate;
+            _httpContextFactory = httpContextFactory;
         }
 
         public HttpContext CreateContext(IFeatureCollection contextFeatures)
         {
-            return new DefaultHttpContext(contextFeatures);
+            return _httpContextFactory?.Create(contextFeatures) ?? new DefaultHttpContext(contextFeatures);
         }
 
         public void DisposeContext(HttpContext context, Exception exception)
         {
-
+            _httpContextFactory?.Dispose(context);
         }
 
         public async Task ProcessRequestAsync(HttpContext context)

--- a/test/shared/TestApp.cs
+++ b/test/shared/TestApp.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    public static class TestApp
+    {
+        public static async Task EchoApp(HttpContext httpContext)
+        {
+            var request = httpContext.Request;
+            var response = httpContext.Response;
+            var buffer = new byte[httpContext.Request.ContentLength ?? 0];
+            var bytesRead = 0;
+
+            while (bytesRead < buffer.Length)
+            {
+                var count = await request.Body.ReadAsync(buffer, bytesRead, buffer.Length - bytesRead);
+                bytesRead += count;
+            }
+
+            if (buffer.Length > 0)
+            {
+                await response.Body.WriteAsync(buffer, 0, buffer.Length);
+            }
+        }
+
+        public static async Task EchoAppChunked(HttpContext httpContext)
+        {
+            var request = httpContext.Request;
+            var response = httpContext.Response;
+            var data = new MemoryStream();
+            await request.Body.CopyToAsync(data);
+            var bytes = data.ToArray();
+
+            response.Headers["Content-Length"] = bytes.Length.ToString();
+            await response.Body.WriteAsync(bytes, 0, bytes.Length);
+        }
+
+        public static Task EmptyApp(HttpContext httpContext)
+        {
+            return TaskCache.CompletedTask;
+        }
+    }
+}

--- a/test/shared/TestConnection.cs
+++ b/test/shared/TestConnection.cs
@@ -50,22 +50,6 @@ namespace Microsoft.AspNetCore.Testing
             _stream.Flush();
         }
 
-        public async Task SendAllTryEnd(params string[] lines)
-        {
-            await SendAll(lines);
-
-            try
-            {
-                _socket.Shutdown(SocketShutdown.Send);
-            }
-            catch (IOException)
-            {
-                // The server may forcefully close the connection (usually due to a bad request),
-                // so an IOException: "An existing connection was forcibly closed by the remote host"
-                // isn't guaranteed but not unexpected.
-            }
-        }
-
         public async Task Send(params string[] lines)
         {
             var text = string.Join("\r\n", lines);
@@ -82,12 +66,6 @@ namespace Microsoft.AspNetCore.Testing
             _stream.Flush();
         }
 
-        public async Task SendEnd(params string[] lines)
-        {
-            await Send(lines);
-            _socket.Shutdown(SocketShutdown.Send);
-        }
-
         public async Task Receive(params string[] lines)
         {
             var expected = string.Join("\r\n", lines);
@@ -95,6 +73,7 @@ namespace Microsoft.AspNetCore.Testing
             var offset = 0;
             while (offset < expected.Length)
             {
+                var data = new byte[expected.Length];
                 var task = _reader.ReadAsync(actual, offset, actual.Length - offset);
                 if (!Debugger.IsAttached)
                 {
@@ -108,12 +87,13 @@ namespace Microsoft.AspNetCore.Testing
                 offset += count;
             }
 
-            Assert.Equal(expected, new String(actual, 0, offset));
+            Assert.Equal(expected, new string(actual, 0, offset));
         }
 
         public async Task ReceiveEnd(params string[] lines)
         {
             await Receive(lines);
+            _socket.Shutdown(SocketShutdown.Send);
             var ch = new char[128];
             var count = await _reader.ReadAsync(ch, 0, 128).TimeoutAfter(TimeSpan.FromMinutes(1));
             var text = new string(ch, 0, count);
@@ -139,11 +119,16 @@ namespace Microsoft.AspNetCore.Testing
             }
         }
 
+        public void Shutdown(SocketShutdown how)
+        {
+            _socket.Shutdown(how);
+        }
+
         public Task WaitForConnectionClose()
         {
             var tcs = new TaskCompletionSource<object>();
             var eventArgs = new SocketAsyncEventArgs();
-            eventArgs.SetBuffer(new byte[1], 0, 1);
+            eventArgs.SetBuffer(new byte[128], 0, 128);
             eventArgs.Completed += ReceiveAsyncCompleted;
             eventArgs.UserToken = tcs;
 
@@ -157,10 +142,15 @@ namespace Microsoft.AspNetCore.Testing
 
         private void ReceiveAsyncCompleted(object sender, SocketAsyncEventArgs e)
         {
+            var tcs = (TaskCompletionSource<object>)e.UserToken;
             if (e.BytesTransferred == 0)
             {
-                var tcs = (TaskCompletionSource<object>)e.UserToken;
                 tcs.SetResult(null);
+            }
+            else
+            {
+                tcs.SetException(new IOException(
+                    $"Expected connection close, received data instead: \"{_reader.CurrentEncoding.GetString(e.Buffer, 0, e.BytesTransferred)}\""));
             }
         }
 

--- a/test/shared/TestServer.cs
+++ b/test/shared/TestServer.cs
@@ -29,12 +29,17 @@ namespace Microsoft.AspNetCore.Testing
         }
 
         public TestServer(RequestDelegate app, TestServiceContext context, string serverAddress)
+            : this(app, context, serverAddress, null)
+        {
+        }
+
+        public TestServer(RequestDelegate app, TestServiceContext context, string serverAddress, IHttpContextFactory httpContextFactory)
         {
             Context = context;
 
             context.FrameFactory = connectionContext =>
             {
-                return new Frame<HttpContext>(new DummyApplication(app), connectionContext);
+                return new Frame<HttpContext>(new DummyApplication(app, httpContextFactory), connectionContext);
             };
 
             try


### PR DESCRIPTION
#1139

[This](https://github.com/aspnet/KestrelHttpServer/pull/1218/files#diff-4837ca204b80ef23b080588614cea7f8R206) part of the change is mostly to avoid test failures in `HttpsTests.EmptyRequestLoggedAsInformation`. After the change to handle FIN as abort, this test started failing consistently because the `OnConnectionAsync` continuation would run after the abort had taken place, the connection had ended and the server had been disposed - at that point `ReadInputAsync` would try to lease a block from an already disposed memory pool, triggering the assert and failing the entire test run.

@halter73 @Tratcher @pakrym 