### PR TITLE
[WIP] Validate Host header

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
@@ -78,6 +78,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 case RequestRejectionReason.RequestTimeout:
                     ex = new BadHttpRequestException("Request timed out.", 408);
                     break;
+                case RequestRejectionReason.MissingHostHeader:
+                    ex = new BadHttpRequestException("Missing Host header.", 400);
+                    break;
+                case RequestRejectionReason.MultipleHostHeaders:
+                    ex = new BadHttpRequestException("Request contains multiple Host headers.", 400);
+                    break;
                 default:
                     ex = new BadHttpRequestException("Bad request.", 400);
                     break;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
@@ -231,6 +231,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             FrameRequestHeaders headers,
             Frame context)
         {
+            if (httpVersion == HttpVersion.Http11)
+            {
+                var hostHeaderCount = headers.HeaderHost.Count;
+
+                if (hostHeaderCount == 0)
+                {
+                    context.RejectRequest(RequestRejectionReason.MissingHostHeader);
+                }
+
+                if (hostHeaderCount > 1)
+                {
+                    context.RejectRequest(RequestRejectionReason.MultipleHostHeaders);
+                }
+            }
+
             // see also http://tools.ietf.org/html/rfc2616#section-4.4
             var keepAlive = httpVersion != HttpVersion.Http10;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
@@ -30,5 +30,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         FinalTransferCodingNotChunked,
         LengthRequired,
         LengthRequiredHttp10,
+        MissingHostHeader,
+        MultipleHostHeaders
     }
 }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllTryEnd($"GET / HTTP/1.1\r\n{rawHeaders}");
+                    await connection.SendAllTryEnd($"GET / HTTP/1.1\r\nHost: localhost\r\n{rawHeaders}");
                     await ReceiveBadRequestResponse(connection, "400 Bad Request", server.Context.DateHeaderValue);
                 }
             }
@@ -139,6 +139,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendAllTryEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "H\u00eb\u00e4d\u00ebr: value",
                         "",
                         "");
@@ -168,7 +169,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendAllTryEnd($"GET {path} HTTP/1.1\r\n");
+                    await connection.SendAllTryEnd($"GET {path} HTTP/1.1\r\nHost: localhost\r\n");
                     await ReceiveBadRequestResponse(connection, "400 Bad Request", server.Context.DateHeaderValue);
                 }
             }
@@ -183,7 +184,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.SendEnd($"{method} / HTTP/1.1\r\n\r\n");
+                    await connection.SendEnd($"{method} / HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     await ReceiveBadRequestResponse(connection, "411 Length Required", server.Context.DateHeaderValue);
                 }
             }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedRequestTests.cs
@@ -145,15 +145,18 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 5",
                         "",
                         "HelloPOST / HTTP/1.1",
+                        "Host: localhost",
                         "Transfer-Encoding: chunked",
                         "",
                         "C", "HelloChunked",
                         "0",
                         "",
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 7",
                         "",
                         "Goodbye");
@@ -223,6 +226,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 IEnumerable<string> sendSequence = new string[] {
                     "POST / HTTP/1.1",
+                    "Host: localhost",
                     "Transfer-Encoding: chunked",
                     "",
                     "C",
@@ -234,6 +238,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     sendSequence = sendSequence.Concat(new string[] {
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Transfer-Encoding: chunked",
                         "",
                         "C",
@@ -245,6 +250,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 sendSequence = sendSequence.Concat(new string[] {
                     "POST / HTTP/1.1",
+                    "Host: localhost",
                     "Content-Length: 7",
                     "",
                     "Goodbye"
@@ -284,6 +290,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendAllTryEnd(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         $"{transferEncodingHeaderLine}",
                         $"{headerLine}",
                         "",
@@ -324,6 +331,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendAllTryEnd(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         $"{transferEncodingHeaderLine}",
                         $"{headerLine}",
                         "",
@@ -392,6 +400,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 IEnumerable<string> sendSequence = new string[] {
                     "POST / HTTP/1.1",
+                    "Host: localhost",
                     "Transfer-Encoding: chunked",
                     "",
                     "C;hello there",
@@ -403,6 +412,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     sendSequence = sendSequence.Concat(new string[] {
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Transfer-Encoding: chunked",
                         "",
                         "C;hello there",
@@ -414,6 +424,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 sendSequence = sendSequence.Concat(new string[] {
                     "POST / HTTP/1.1",
+                    "Host: localhost",
                     "Content-Length: 7",
                     "",
                     "Goodbye"
@@ -455,6 +466,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendAll(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Transfer-Encoding: chunked",
                         "",
                         "Cii");
@@ -497,6 +509,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendAll(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Transfer-Encoding: chunked",
                         "",
                         "C",
@@ -529,6 +542,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendAll(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Transfer-Encoding: not-chunked",
                         "",
                         "C",
@@ -551,6 +565,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendAll(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Transfer-Encoding: not-chunked",
                         "Content-Length: 22",
                         "",
@@ -573,6 +588,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendAll(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Transfer-Encoding: chunked, not-chunked",
                         "",
                         "C",
@@ -595,6 +611,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendAll(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Transfer-Encoding: chunked, not-chunked",
                         "Content-Length: 22",
                         "",

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ChunkedResponseTests.cs
@@ -45,6 +45,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -104,6 +105,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "Connection: close",
                         "",
                         "");
@@ -139,6 +141,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -174,6 +177,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -212,6 +216,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
 
@@ -248,6 +253,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -279,6 +285,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     // client closing the connection.
                     await connection.Send(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveForcedEnd(
@@ -309,6 +316,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     // SendEnd is not called, so it isn't the client closing the connection.
                     await connection.Send(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
 
@@ -344,6 +352,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.Receive(
@@ -385,6 +394,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/DefaultHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/DefaultHeaderTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "GET / HTTP/1.0",
                         "",

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/EngineTests.cs
@@ -154,8 +154,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "Connection: close",
                         "Content-Length: 7",
                         "",
@@ -220,8 +222,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 using (var connection = server.CreateConnection())
                 {
                     var requestData =
-                        Enumerable.Repeat("GET / HTTP/1.1\r\n", loopCount)
-                            .Concat(new[] { "GET / HTTP/1.1\r\nContent-Length: 7\r\nConnection: close\r\n\r\nGoodbye" });
+                        Enumerable.Repeat("GET / HTTP/1.1\r\nHost: localhost\r\n", loopCount)
+                            .Concat(new[] { "GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 7\r\nConnection: close\r\n\r\nGoodbye" });
 
                     var response = string.Join("\r\n", new string[] {
                         "HTTP/1.1 200 OK",
@@ -388,6 +390,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.Send(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Expect: 100-continue",
                         "Connection: close",
                         "Content-Length: 11",
@@ -441,6 +444,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "GET / HTTP/1.0",
                         "Connection: keep-alive",
@@ -474,6 +478,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "Connection: close",
                         "",
                         "");
@@ -513,6 +518,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "HEAD / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -544,15 +550,19 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 3",
                         "",
                         "204POST / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 3",
                         "",
                         "205POST / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 3",
                         "",
                         "304POST / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 3",
                         "",
                         "200");
@@ -592,6 +602,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     // https://github.com/aspnet/KestrelHttpServer/issues/1104 is not regressing.
                     await connection.Send(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "Connection: close",
                         "",
                         "");
@@ -637,6 +648,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.Send(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -691,8 +703,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "Connection: close",
                         "",
                         "");
@@ -746,6 +760,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.Send(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveForcedEnd(
@@ -788,6 +803,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.Send(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveForcedEnd(
@@ -813,8 +829,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "Post / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 7",
                         "",
                         "Goodbye");
@@ -842,6 +860,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "POST / HTTP/1.1");
                     await connection.ReceiveForcedEnd(
@@ -861,6 +880,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "POST / HTTP/1.1",
                         "Content-Length: 7");
@@ -920,8 +940,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "Connection: close",
                         "",
                         "");
@@ -983,6 +1005,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.Send(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveForcedEnd(
@@ -1049,9 +1072,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     // Never send the body so CopyToAsync always fails.
                     await connection.Send(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 5",
                         "",
                         "HelloPOST / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 5",
                         "",
                         "");
@@ -1118,6 +1143,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.Send(
                         "POST / HTTP/1.1",
+                        "Host: localhost",
                         "Content-Length: 5",
                         "",
                         "Hello");
@@ -1217,8 +1243,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -1264,8 +1292,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -1298,6 +1328,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         $"GET {inputPath} HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -1339,6 +1370,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -1383,6 +1415,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -1423,6 +1456,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET / HTTP/1.1",
+                        "Host: localhost",
                         "Connection: Upgrade",
                         "",
                         "Hello World");

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -833,7 +833,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var serviceContext = new ServiceContext
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
-                ServerOptions = new KestrelServerOptions()
+                ServerOptions = new KestrelServerOptions(),
+                Log = new TestKestrelTrace()
             };
             var listenerContext = new ListenerContext(serviceContext)
             {
@@ -846,6 +847,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.InitializeHeaders();
+
+            frame.RequestHeaders.Append("Host", "localhost");
 
             var messageBody = MessageBody.For(HttpVersion.Http11, (FrameRequestHeaders)frame.RequestHeaders, frame);
             frame.InitializeStreams(messageBody);

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MessageBodyTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderHost = "localhost" }, input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders(), input.FrameContext);
+                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderHost = "localhost" }, input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderConnection = "close" }, input.FrameContext);
+                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderConnection = "close", HeaderHost = "localhost" }, input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderConnection = "close" }, input.FrameContext);
+                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderConnection = "close", HeaderHost = "localhost" }, input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 
@@ -196,7 +196,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             using (var input = new TestInput())
             {
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
-                    MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderTransferEncoding = "chunked, not-chunked" }, input.FrameContext));
+                    MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderTransferEncoding = "chunked, not-chunked", HeaderHost = "localhost" }, input.FrameContext));
 
                 Assert.Equal(400, ex.StatusCode);
                 Assert.Equal("Final transfer coding is not \"chunked\": \"chunked, not-chunked\"", ex.Message);
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 input.FrameContext.Method = method;
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
-                    MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders(), input.FrameContext));
+                    MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderHost = "localhost" }, input.FrameContext));
 
                 Assert.Equal(411, ex.StatusCode);
                 Assert.Equal($"{method} request contains no Content-Length or Transfer-Encoding header", ex.Message);
@@ -244,9 +244,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         public static IEnumerable<object[]> RequestData => new[]
         {
             // Content-Length
-            new object[] { new FrameRequestHeaders { HeaderContentLength = "12" }, new[] { "Hello ", "World!" } },
+            new object[] { new FrameRequestHeaders { HeaderContentLength = "12", HeaderHost = "localhost" }, new[] { "Hello ", "World!" } },
             // Chunked
-            new object[] { new FrameRequestHeaders { HeaderTransferEncoding = "chunked" }, new[] { "6\r\nHello \r\n", "6\r\nWorld!\r\n0\r\n\r\n" } },
+            new object[] { new FrameRequestHeaders { HeaderTransferEncoding = "chunked", HeaderHost = "localhost" }, new[] { "6\r\nHello \r\n", "6\r\nWorld!\r\n0\r\n\r\n" } },
         };
 
         public static IEnumerable<object[]> CombinedData => 
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             using (var input = new TestInput())
             {
-                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderConnection = headerConnection }, input.FrameContext);
+                var body = MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders { HeaderConnection = headerConnection, HeaderHost = "localhost" }, input.FrameContext);
                 var stream = new FrameRequestStream();
                 stream.StartAcceptingReads(body);
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/RequestTargetProcessingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/RequestTargetProcessingTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         "GET /%41%CC%8A/A/../B/%41%CC%8A HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -73,6 +74,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         $"GET {requestTarget} HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(
@@ -117,6 +119,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 {
                     await connection.SendEnd(
                         $"GET {requestTarget} HTTP/1.1",
+                        "Host: localhost",
                         "",
                         "");
                     await connection.ReceiveEnd(


### PR DESCRIPTION
Closes #839

This only validates the header for HTTP/1.1 requests, per the RFC. Does it make sense to reject HTTP/1.0 requests as well?

> a Host header field with an invalid field-value.

I'm assuming this would be taken care of by general header field validation?

Still have to take care of the functional tests. Quite tedious work :cry: 