### PR TITLE
Don't log stack traces for localhost bind failures.

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
@@ -150,14 +150,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                         }
                         catch (AggregateException ex) when (ex.InnerException is UvException)
                         {
-                            if ((ex.InnerException as UvException).StatusCode == Constants.EADDRINUSE)
+                            var uvEx = (UvException)ex.InnerException;
+                            if (uvEx.StatusCode == Constants.EADDRINUSE)
                             {
                                 throw new IOException($"Failed to bind to address {parsedAddress.ToString()} on the IPv4 loopback interface: port already in use.", ex);
                             }
                             else
                             {
-                                _logger.LogWarning(0, ex, $"Unable to bind to {parsedAddress.ToString()} on the IPv4 loopback interface.");
-                                exceptions.Add(ex.InnerException);
+                                _logger.LogWarning(0, $"Unable to bind to {parsedAddress.ToString()} on the IPv4 loopback interface: ({uvEx.Message})");
+                                exceptions.Add(uvEx);
                             }
                         }
 
@@ -169,14 +170,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                         }
                         catch (AggregateException ex) when (ex.InnerException is UvException)
                         {
-                            if ((ex.InnerException as UvException).StatusCode == Constants.EADDRINUSE)
+                            var uvEx = (UvException)ex.InnerException;
+                            if (uvEx.StatusCode == Constants.EADDRINUSE)
                             {
                                 throw new IOException($"Failed to bind to address {parsedAddress.ToString()} on the IPv6 loopback interface: port already in use.", ex);
                             }
                             else
                             {
-                                _logger.LogWarning(0, ex, $"Unable to bind to {parsedAddress.ToString()} on the IPv6 loopback interface.");
-                                exceptions.Add(ex.InnerException);
+                                _logger.LogWarning(0, $"Unable to bind to {parsedAddress.ToString()} on the IPv6 loopback interface: ({uvEx.Message})");
+                                exceptions.Add(uvEx);
                             }
                         }
 


### PR DESCRIPTION
#1001 
We're getting almost daily hits on this issue. A non-fatal error is being displayed like a fatal error and it distracts users from their real problems. Azure may or may not ever change their implementation.
@muratg @halter73 

I also recommend we backport this to 1.0.x and 1.1.x.

Before:
```
dbug: Microsoft.AspNetCore.Hosting.Internal.WebHost[3]
      Hosting starting
warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Unable to bind to http://localhost:19786 on the IPv6 loopback interface.
System.AggregateException: One or more errors occurred. ---> Microsoft.AspNetCore.Server.Kestrel.Internal.Networking.UvException: Error -4089 EAFNOSUPPORT address family not supported
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Networking.Libuv.tcp_bind(UvTcpHandle handle, SockAddr& addr, Int32 flags) in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Networking\Libuv.cs:line 202
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Networking.UvTcpHandle.Bind(ServerAddress address) in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Networking\UvTcpHandle.cs:line 48
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Http.TcpListenerPrimary.CreateListenSocket() in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Http\TcpListenerPrimary.cs:line 39
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Http.Listener.<StartAsync>b__8_0(Object state) in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Http\Listener.cs:line 39
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Http.ListenerPrimary.<StartAsync>d__12.MoveNext() in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Http\ListenerPrimary.cs:line 54
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Internal.KestrelEngine.CreateServer(ServerAddress address) in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\KestrelEngine.cs:line 118
   at Microsoft.AspNetCore.Server.Kestrel.KestrelServer.Start[TContext](IHttpApplication`1 application) in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\KestrelServer.cs:line 168
---> (Inner Exception #0) Microsoft.AspNetCore.Server.Kestrel.Internal.Networking.UvException: Error -4089 EAFNOSUPPORT address family not supported
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Networking.Libuv.tcp_bind(UvTcpHandle handle, SockAddr& addr, Int32 flags) in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Networking\Libuv.cs:line 202
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Networking.UvTcpHandle.Bind(ServerAddress address) in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Networking\UvTcpHandle.cs:line 48
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Http.TcpListenerPrimary.CreateListenSocket() in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Http\TcpListenerPrimary.cs:line 39
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Http.Listener.<StartAsync>b__8_0(Object state) in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Http\Listener.cs:line 39
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Http.ListenerPrimary.<StartAsync>d__12.MoveNext() in C:\git\Universe\KestrelHttpServer\src\Microsoft.AspNetCore.Server.Kestrel\Internal\Http\ListenerPrimary.cs:line 54<---

dbug: Microsoft.AspNetCore.Hosting.Internal.WebHost[4]
      Hosting started
Hosting environment: Production
Content root path: D:\home\site\wwwroot\
Now listening on: http://localhost:19786
Application started. Press Ctrl+C to shut down.
```

After:
```
dbug: Microsoft.AspNetCore.Hosting.Internal.WebHost[3]
      Hosting starting
info: Microsoft.AspNetCore.Server.Kestrel[0]
      Unable to bind to http://localhost:20266 on the IPv6 loopback interface.
dbug: Microsoft.AspNetCore.Hosting.Internal.WebHost[4]
      Hosting started
Hosting environment: Production
Content root path: D:\home\site\wwwroot\
Now listening on: http://localhost:20266
Application started. Press Ctrl+C to shut down.
```

We could add an additional log for real fatal errors on line 185.