### PR TITLE
Handle requests using absolute-form request URIs

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -29,10 +29,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private const byte ByteCR = (byte)'\r';
         private const byte ByteLF = (byte)'\n';
         private const byte ByteColon = (byte)':';
+        private const byte ByteForwardSlash = (byte)'/';
         private const byte ByteSpace = (byte)' ';
         private const byte ByteTab = (byte)'\t';
         private const byte ByteQuestionMark = (byte)'?';
         private const byte BytePercentage = (byte)'%';
+
+        private const string EmptyPath = "/";
 
         private static readonly ArraySegment<byte> _endChunkedResponseBytes = CreateAsciiByteArraySegment("0\r\n\r\n");
         private static readonly ArraySegment<byte> _continueBytes = CreateAsciiByteArraySegment("HTTP/1.1 100 Continue\r\n\r\n");
@@ -976,7 +979,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         public RequestLineStatus TakeStartLine(SocketInput input)
         {
-            const int MaxInvalidRequestLineChars = 32;
+            // expected start line format: https://tools.ietf.org/html/rfc7230#section-3.1.1
 
             var scan = input.ConsumingStart();
             var start = scan;
@@ -1014,22 +1017,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 }
                 end.Take();
 
+                // begin consuming method
                 string method;
                 var begin = scan;
                 if (!begin.GetKnownMethod(out method))
                 {
                     if (scan.Seek(ByteSpace, ref end) == -1)
                     {
-                        RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                            Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                        RejectInvalidStartLine(start, end);
                     }
 
                     method = begin.GetAsciiString(ref scan);
 
                     if (method == null)
                     {
-                        RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                            Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                        RejectInvalidStartLine(start, end);
                     }
 
                     // Note: We're not in the fast path any more (GetKnownMethod should have handled any HTTP Method we're aware of)
@@ -1038,8 +1040,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     {
                         if (!IsValidTokenChar(method[i]))
                         {
-                            RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                                Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                            RejectInvalidStartLine(start, end);
                         }
                     }
                 }
@@ -1048,14 +1049,38 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     scan.Skip(method.Length);
                 }
 
+                // consume space
                 scan.Take();
+
+                // begin consuming request-target
                 begin = scan;
+
+                var targetBegin = scan;
+
+                if (targetBegin.Peek() != ByteForwardSlash)
+                {
+                    string requestUriScheme;
+                    if (scan.GetKnownHttpSchema(out requestUriScheme))
+                    {
+                        // Start-line can contain uri in absolute form. e.g. 'GET http://contoso.com/favicon.ico HTTP/1.1'
+                        // Clients should only send this to proxies, but the spec requires we handle it anyways.
+                        // cref https://tools.ietf.org/html/rfc7230#section-5.3
+                        scan.Skip(requestUriScheme.Length);
+
+                        if (scan.Seek(ByteForwardSlash, ByteSpace, ByteQuestionMark, ref end) == -1)
+                        {
+                            RejectInvalidStartLine(start, end);
+                        }
+
+                        begin = scan;
+                    }
+                }
+
                 var needDecode = false;
                 var chFound = scan.Seek(ByteSpace, ByteQuestionMark, BytePercentage, ref end);
                 if (chFound == -1)
                 {
-                    RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                        Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                    RejectInvalidStartLine(start, end);
                 }
                 else if (chFound == BytePercentage)
                 {
@@ -1063,40 +1088,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     chFound = scan.Seek(ByteSpace, ByteQuestionMark, ref end);
                     if (chFound == -1)
                     {
-                        RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                            Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                        RejectInvalidStartLine(start, end);
                     }
                 }
 
                 var pathBegin = begin;
                 var pathEnd = scan;
 
-                var queryString = "";
+                var queryString = string.Empty;
                 if (chFound == ByteQuestionMark)
                 {
                     begin = scan;
                     if (scan.Seek(ByteSpace, ref end) == -1)
                     {
-                        RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                            Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                        RejectInvalidStartLine(start, end);
                     }
                     queryString = begin.GetAsciiString(ref scan);
                 }
 
                 var queryEnd = scan;
 
-                if (pathBegin.Peek() == ByteSpace)
+                if (pathBegin.Peek() == ByteSpace && targetBegin.Index == pathBegin.Index)
                 {
-                    RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                        Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                    RejectInvalidStartLine(start, end);
                 }
 
+                // consume space
                 scan.Take();
+
+                // begin consuming HTTP-version
                 begin = scan;
                 if (scan.Seek(ByteCR, ref end) == -1)
                 {
-                    RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                        Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                    RejectInvalidStartLine(start, end);
                 }
 
                 string httpVersion;
@@ -1106,8 +1130,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                     if (httpVersion == string.Empty)
                     {
-                        RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                            Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                        RejectInvalidStartLine(start, end);
                     }
                     else
                     {
@@ -1115,11 +1138,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     }
                 }
 
-                scan.Take(); // consume CR
+                // consume CR
+                scan.Take();
                 if (scan.Take() != ByteLF)
                 {
-                    RejectRequest(RequestRejectionReason.InvalidRequestLine,
-                        Log.IsEnabled(LogLevel.Information) ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars) : string.Empty);
+                    RejectInvalidStartLine(start, end);
                 }
 
                 // URIs are always encoded/escaped to ASCII https://tools.ietf.org/html/rfc3986#page-11
@@ -1130,7 +1153,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 if (needDecode)
                 {
                     // Read raw target before mutating memory.
-                    rawTarget = pathBegin.GetAsciiString(ref queryEnd);
+                    rawTarget = targetBegin.GetAsciiString(ref queryEnd);
 
                     // URI was encoded, unescape and then parse as utf8
                     pathEnd = UrlPathDecoder.Unescape(pathBegin, pathEnd);
@@ -1141,19 +1164,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     // URI wasn't encoded, parse as ASCII
                     requestUrlPath = pathBegin.GetAsciiString(ref pathEnd);
 
-                    if (queryString.Length == 0)
+                    if (queryString.Length == 0 && targetBegin.Index == pathBegin.Index)
                     {
                         // No need to allocate an extra string if the path didn't need
-                        // decoding and there's no query string following it.
+                        // decoding and there's no query string following it, and the
+                        // request-target isn't absolute-form
                         rawTarget = requestUrlPath;
                     }
                     else
                     {
-                        rawTarget = pathBegin.GetAsciiString(ref queryEnd);
+                        rawTarget = targetBegin.GetAsciiString(ref queryEnd);
                     }
                 }
 
-                var normalizedTarget = PathNormalizer.RemoveDotSegments(requestUrlPath);
+                if (targetBegin.Index < pathBegin.Index)
+                {
+                    // validation of absolute-form URI may be slow, but clients
+                    // should not be sending this form anyways, so perf optimization 
+                    // not high priority
+                    Uri _;
+                    if (!Uri.TryCreate(rawTarget, UriKind.Absolute, out _))
+                    {
+                        RejectInvalidStartLine(start, end);
+                    }
+                }
+
+                var normalizedUrlPath = requestUrlPath == null
+                    ? EmptyPath
+                    : PathNormalizer.RemoveDotSegments(requestUrlPath);
 
                 consumed = scan;
                 Method = method;
@@ -1162,17 +1200,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 HttpVersion = httpVersion;
 
                 bool caseMatches;
-                if (RequestUrlStartsWithPathBase(normalizedTarget, out caseMatches))
+                if (RequestUrlStartsWithPathBase(normalizedUrlPath, out caseMatches))
                 {
-                    PathBase = caseMatches ? _pathBase : normalizedTarget.Substring(0, _pathBase.Length);
-                    Path = normalizedTarget.Substring(_pathBase.Length);
+                    // request-target is in origin-form or absolute-form 
+                    // and path should be adjusted for matching the server base path
+                    PathBase = caseMatches ? _pathBase : normalizedUrlPath.Substring(0, _pathBase.Length);
+                    Path = normalizedUrlPath.Substring(_pathBase.Length);
                 }
-                else if (rawTarget[0] == '/') // check rawTarget since normalizedTarget can be "" or "/" after dot segment removal
+                else if ((requestUrlPath?.Length > 0 && requestUrlPath[0] == '/')
+                    || (rawTarget.Length > 0 && rawTarget[0] == '/')
+                    || ReferenceEquals(normalizedUrlPath, EmptyPath))
                 {
-                    Path = normalizedTarget;
+                    // request-target is in origin-form or absolute-form
+                    Path = normalizedUrlPath;
                 }
                 else
                 {
+                    // request-target is in asterisk-form and authority-form
+                    // also the catch-all for other malformed request-targets
                     Path = string.Empty;
                     PathBase = string.Empty;
                     QueryString = string.Empty;
@@ -1478,6 +1523,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             throw new ObjectDisposedException(
                     "The response has been aborted due to an unhandled application exception.",
                     _applicationException);
+        }
+
+        private void RejectInvalidStartLine(MemoryPoolIterator start, MemoryPoolIterator end)
+        {
+            const int MaxInvalidRequestLineChars = 32;
+
+            RejectRequest(RequestRejectionReason.InvalidRequestLine,
+                Log.IsEnabled(LogLevel.Information)
+                    ? start.GetAsciiStringEscaped(end, MaxInvalidRequestLineChars)
+                    : string.Empty);
         }
 
         public void RejectRequest(RequestRejectionReason reason)

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -453,6 +453,72 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
+        [Theory]
+        [InlineData("http://localhost/abs/path", "/abs/path", null)]
+        [InlineData("https://localhost/abs/path", "/abs/path", null)] // handles mismatch scheme
+        [InlineData("https://localhost:22/abs/path", "/abs/path", null)] // handles mismatched ports
+        [InlineData("https://differenthost/abs/path", "/abs/path", null)] // handles mismatched hostname
+        [InlineData("http://localhost/", "/", null)]
+        [InlineData("http://root@contoso.com/path", "/path", null)]
+        [InlineData("http://root:password@contoso.com/path", "/path", null)]
+        [InlineData("https://localhost/", "/", null)]
+        [InlineData("http://localhost", "/", null)]
+        [InlineData("http://127.0.0.1/", "/", null)]
+        [InlineData("http://[::1]/", "/", null)]
+        [InlineData("http://[::1]:8080/", "/", null)]
+        [InlineData("http://localhost?q=123&w=xyz", "/", "123")]
+        [InlineData("http://localhost/?q=123&w=xyz", "/", "123")]
+        [InlineData("http://localhost/path?q=123&w=xyz", "/path", "123")]
+        [InlineData("http://localhost/path%20with%20space?q=abc%20123", "/path with space", "abc 123")]
+        public async Task CanHandleRequestsWithUrlInAbsoluteForm(string requestUrl, string expectedPath, string queryValue)
+        {
+            var pathTcs = new TaskCompletionSource<PathString>();
+            var rawTargetTcs = new TaskCompletionSource<string>();
+            var hostTcs = new TaskCompletionSource<HostString>();
+            var queryTcs = new TaskCompletionSource<IQueryCollection>();
+
+            using (var server = new TestServer(async context =>
+                 {
+                     pathTcs.TrySetResult(context.Request.Path);
+                     hostTcs.TrySetResult(context.Request.Host);
+                     queryTcs.TrySetResult(context.Request.Query);
+                     rawTargetTcs.TrySetResult(context.Features.Get<IHttpRequestFeature>().RawTarget);
+                     await context.Response.WriteAsync("Done");
+                 }))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.Send(
+                        $"GET {requestUrl} HTTP/1.1",
+                        "Content-Length: 0",
+                        "Host: localhost",
+                        "",
+                        "");
+
+                    await connection.Receive($"HTTP/1.1 200 OK",
+                        $"Date: {server.Context.DateHeaderValue}",
+                        "Transfer-Encoding: chunked",
+                        "",
+                        "4",
+                        "Done")
+                        .TimeoutAfter(TimeSpan.FromSeconds(10));
+
+                    await Task.WhenAll(pathTcs.Task, rawTargetTcs.Task, hostTcs.Task, queryTcs.Task).TimeoutAfter(TimeSpan.FromSeconds(30));
+                    Assert.Equal(new PathString(expectedPath), pathTcs.Task.Result);
+                    Assert.Equal(requestUrl, rawTargetTcs.Task.Result);
+                    Assert.Equal("localhost", hostTcs.Task.Result.ToString());
+                    if (queryValue == null)
+                    {
+                        Assert.False(queryTcs.Task.Result.ContainsKey("q"));
+                    }
+                    else
+                    {
+                        Assert.Equal(queryValue, queryTcs.Task.Result["q"]);
+                    }
+                }
+            }
+        }
+
         private async Task TestRemoteIPAddress(string registerAddress, string requestAddress, string expectAddress)
         {
             var builder = new WebHostBuilder()

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/BadHttpRequestTests.cs
@@ -52,6 +52,29 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [InlineData("} / HTTP/1.0\r\n")]
         [InlineData("get@ / HTTP/1.0\r\n")]
         [InlineData("post= / HTTP/1.0\r\n")]
+        [InlineData("GET http:// HTTP/1.1\r\n")]
+        [InlineData("GET http:/// HTTP/1.1\r\n")]
+        [InlineData("GET https:// HTTP/1.1\r\n")]
+        [InlineData("GET http://// HTTP/1.1\r\n")]
+        [InlineData("GET http://:80 HTTP/1.1\r\n")]
+        [InlineData("GET http://:80/abc HTTP/1.1\r\n")]
+        [InlineData("GET http://user@ HTTP/1.1\r\n")]
+        [InlineData("GET http://user@/abc HTTP/1.1\r\n")]
+        [InlineData("GET http://abc%20xyz/abc HTTP/1.1\r\n")]
+        [InlineData("GET http://%20/abc?query=%0A HTTP/1.1\r\n")]
+        // TODO invalidate requests that don't meet the HTTP spec. See https://github.com/aspnet/KestrelHttpServer/issues/1279
+        //[InlineData("GET otherscheme://host/ HTTP/1.1\r\n")]
+        //[InlineData("GET ws://host/ HTTP/1.1\r\n")]
+        //[InlineData("GET wss://host/ HTTP/1.1\r\n")]
+        //[InlineData("GET http HTTP/1.1\r\n")]
+        //[InlineData("GET http: HTTP/1.1\r\n")]
+        //[InlineData("GET http:/ HTTP/1.1\r\n")]
+        //[InlineData("GET https HTTP/1.1\r\n")]
+        //[InlineData("GET https: HTTP/1.1\r\n")]
+        //[InlineData("GET https:/ HTTP/1.1\r\n")]
+        //[InlineData("GET www.contoso.com HTTP/1.1\r\n")]
+        //[InlineData("GET * HTTP/1.1\r\n")] // asterisk form only supported in OPTIONS requests
+        //[InlineData("GET ../../ HTTP/1.1\r\n")] // relative form is invalid
         public async Task TestInvalidRequestLines(string request)
         {
             using (var server = new TestServer(context => TaskCache.CompletedTask))
@@ -63,6 +86,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 }
             }
         }
+
+
 
         [Theory]
         [InlineData("GET / H\r\n")]
@@ -82,6 +107,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [InlineData("GET / HTTP/1.\r\n")]
         [InlineData("GET / hello\r\n")]
         [InlineData("GET / 8charact\r\n")]
+        [InlineData("GET /  HTTP/1.1\r\n")]
+        [InlineData("GET / / HTTP/1.1\r\n")]
+        [InlineData("GET http://  HTTP/1.1\r\n")]
+        [InlineData("GET https://  HTTP/1.1\r\n")]
+        [InlineData("GET https:// / HTTP/1.1\r\n")]
         public async Task TestInvalidRequestLinesWithUnsupportedVersion(string request)
         {
             using (var server = new TestServer(context => TaskCache.CompletedTask))

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -476,23 +476,32 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
         [Theory]
-        [InlineData("http://host/abs/path", "/abs/path")]
-        [InlineData("https://host/abs/path", "/abs/path")]
-        [InlineData("https://host:22/abs/path", "/abs/path")]
-        [InlineData("https://user@host:9080/abs/path", "/abs/path")]
-        [InlineData("http://host/", "/")]
-        [InlineData("https://host/", "/")]
-        [InlineData("http://host", "/")]
-        [InlineData("http://user@host/", "/")]
-        [InlineData("http://127.0.0.1/", "/")]
-        [InlineData("http://user@127.0.0.1/", "/")]
-        [InlineData("http://user@127.0.0.1:8080/", "/")]
-        [InlineData("http://127.0.0.1:8080/", "/")]
-        [InlineData("http://[::1]", "/")]
-        [InlineData("http://[::1]/path", "/path")]
-        [InlineData("http://[::1]:8080/", "/")]
-        [InlineData("http://user@[::1]:8080/", "/")]
-        public void TakeStartLineHandlesRequestTarget(string rawTarget, string expectedPath)
+        [InlineData("/", "/", "")]
+        [InlineData("/?q=123&a=xyz", "/", "?q=123&a=xyz")]
+        [InlineData("/path/?q=123&a=xyz", "/path/", "?q=123&a=xyz")]
+        [InlineData("/abs/path", "/abs/path", "")]
+        [InlineData("http://host/abs/path", "/abs/path", "")]
+        [InlineData("http://host/abs/path/", "/abs/path/", "")]
+        [InlineData("http://host/abs/path?q=123", "/abs/path", "?q=123")]
+        [InlineData("http://host/abs/path/?q=123", "/abs/path/", "?q=123")]
+        [InlineData("http://host/abs/path/?q=1%202%203", "/abs/path/", "?q=1%202%203")]
+        [InlineData("http://host/a%20b%20c/", "/a b c/", "")]
+        [InlineData("https://host/abs/path", "/abs/path", "")]
+        [InlineData("https://host:22/abs/path", "/abs/path", "")]
+        [InlineData("https://user@host:9080/abs/path", "/abs/path", "")]
+        [InlineData("http://host/", "/", "")]
+        [InlineData("https://host/", "/", "")]
+        [InlineData("http://host", "/", "")]
+        [InlineData("http://user@host/", "/", "")]
+        [InlineData("http://127.0.0.1/", "/", "")]
+        [InlineData("http://user@127.0.0.1/", "/", "")]
+        [InlineData("http://user@127.0.0.1:8080/", "/", "")]
+        [InlineData("http://127.0.0.1:8080/", "/", "")]
+        [InlineData("http://[::1]", "/", "")]
+        [InlineData("http://[::1]/path", "/path", "")]
+        [InlineData("http://[::1]:8080/", "/", "")]
+        [InlineData("http://user@[::1]:8080/", "/", "")]
+        public void TakeStartLineHandlesRequestTarget(string rawTarget, string expectedPath, string expectedQuery)
         {
             var firstLine = Encoding.ASCII.GetBytes($"GET {rawTarget} HTTP/1.1\r\n");
             _socketInput.IncomingData(firstLine, 0, firstLine.Length);
@@ -502,6 +511,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             Assert.Equal(Frame.RequestLineStatus.Done, status);
             Assert.Equal(expectedPath, _frame.Path);
             Assert.Equal(rawTarget, _frame.RawTarget);
+            Assert.Equal(expectedQuery, _frame.QueryString);
         }
 
         [Theory]


### PR DESCRIPTION
An absolute-form request URI has a start line in form: "GET http://host/path HTTP/1.1".
RFC 7230 section 5.3.2 stipulates that servers should allow absolute-form request URIs.

This change will handles requests using absolute-form. The scheme and authority
section of the absolute URI are ignored, but will still appear in `IHttpRequestFeature.RawTarget`.

Resolves #666 

cc @cesarbs @Tratcher 