### PR TITLE
Update ParseContentLength to remove unnecessary casting and unsafe

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.cs
@@ -233,10 +233,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
         }
 
-        public static unsafe long ParseContentLength(StringValues value)
+        public static long ParseContentLength(StringValues value)
         {
             long parsed;
-            if (!HeaderUtilities.TryParseInt64(new StringSegment(value.ToString()), out parsed))
+            if (!HeaderUtilities.TryParseInt64(value.ToString(), out parsed))
             {
                 ThrowInvalidContentLengthException(value);
             }


### PR DESCRIPTION
Addressing https://github.com/aspnet/KestrelHttpServer/commit/4da06e8acd799b3e5a92fce00dc686eb2c55e831#commitcomment-20129813

cc @davidfowl @cesarbs 