### PR TITLE
Abort connections not closed during shutdown

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             return _socketClosedTcs.Task;
         }
 
-        public virtual void Abort(Exception error = null)
+        public virtual Task AbortAsync(Exception error = null)
         {
             // Frame.Abort calls user code while this method is always
             // called from a libuv thread.
@@ -150,6 +150,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             {
                 _frame.Abort(error);
             });
+
+            return _socketClosedTcs.Task;
         }
 
         // Called on Libuv thread
@@ -285,7 +287,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             if (!normalRead)
             {
-                Abort(error);
+                AbortAsync(error);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     {
                         if (cancellationToken.IsCancellationRequested)
                         {
-                            _connection.Abort();
+                            _connection.AbortAsync();
                             _cancelled = true;
                             return TaskUtilities.GetCancelledTask(cancellationToken);
                         }
@@ -304,7 +304,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 {
                     // Abort the connection for any failed write
                     // Queued on threadpool so get it in as first op.
-                    _connection.Abort();
+                    _connection.AbortAsync();
                     _cancelled = true;
 
                     CompleteAllWrites();
@@ -374,7 +374,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             {
                 // Abort the connection for any failed write
                 // Queued on threadpool so get it in as first op.
-                _connection.Abort();
+                _connection.AbortAsync();
                 _cancelled = true;
                 _lastWriteError = error;
             }
@@ -532,7 +532,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                _connection.Abort();
+                _connection.AbortAsync();
                 _cancelled = true;
                 return TaskUtilities.GetCancelledTask(cancellationToken);
             }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/IKestrelTrace.cs
@@ -43,6 +43,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
         void NotAllConnectionsClosedGracefully();
 
+        void NotAllConnectionsAborted();
+
         void ApplicationError(string connectionId, Exception ex);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/KestrelThread.cs
@@ -165,6 +165,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
                 if (!await ConnectionManager.WalkConnectionsAndCloseAsync(_shutdownTimeout).ConfigureAwait(false))
                 {
                     _log.NotAllConnectionsClosedGracefully();
+
+                    if (!await ConnectionManager.WalkConnectionsAndAbortAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false))
+                    {
+                        _log.NotAllConnectionsAborted();
+                    }
                 }
 
                 var result = await WaitAsync(PostAsync(state =>
@@ -281,7 +286,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         {
             lock (_startSync)
             {
-                var tcs = (TaskCompletionSource<int>) parameter;
+                var tcs = (TaskCompletionSource<int>)parameter;
                 try
                 {
                     _loop.Init(_engine.Libuv);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/KestrelTrace.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         private static readonly Action<ILogger, string, int, Exception> _connectionDisconnectedWrite;
         private static readonly Action<ILogger, string, long, Exception> _connectionHeadResponseBodyWrite;
         private static readonly Action<ILogger, Exception> _notAllConnectionsClosedGracefully;
+        private static readonly Action<ILogger, Exception> _notAllConnectionsAborted;
         private static readonly Action<ILogger, string, string, Exception> _connectionBadRequest;
         private static readonly Action<ILogger, string, Exception> _connectionReset;
         private static readonly Action<ILogger, string, Exception> _requestProcessingError;
@@ -54,6 +55,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
             _connectionHeadResponseBodyWrite = LoggerMessage.Define<string, long>(LogLevel.Debug, 18, @"Connection id ""{ConnectionId}"" write of ""{count}"" body bytes to non-body HEAD response.");
             _connectionReset = LoggerMessage.Define<string>(LogLevel.Debug, 19, @"Connection id ""{ConnectionId}"" reset.");
             _requestProcessingError = LoggerMessage.Define<string>(LogLevel.Information, 20, @"Connection id ""{ConnectionId}"" request processing ended abnormally.");
+            _notAllConnectionsAborted = LoggerMessage.Define(LogLevel.Debug, 21, "Some connections failed to abort during server shutdown.");
         }
 
         public KestrelTrace(ILogger logger)
@@ -147,6 +149,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         public virtual void NotAllConnectionsClosedGracefully()
         {
             _notAllConnectionsClosedGracefully(_logger, null);
+        }
+
+        public virtual void NotAllConnectionsAborted()
+        {
+            _notAllConnectionsAborted(_logger, null);
         }
 
         public void ConnectionBadRequest(string connectionId, BadHttpRequestException ex)

--- a/test/shared/MockConnection.cs
+++ b/test/shared/MockConnection.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Testing
 {
@@ -24,9 +25,10 @@ namespace Microsoft.AspNetCore.Testing
             };
         }
 
-        public override void Abort(Exception error = null)
+        public override Task AbortAsync(Exception error = null)
         {
             RequestAbortedSource?.Cancel();
+            return TaskCache.CompletedTask;
         }
 
         public override void OnSocketClosed()


### PR DESCRIPTION
Connections that don't stop during shutdown continue doing work and could be allocating memory blocks and write reqs, leading to exceptions being thrown during shutdown after pools are disposed.

With this change, Kestrel aborts any connections that were not gracefully stopped and waits for their sockets to be closed. This prevents the errors above.

Should take care of #1112.