### PR TITLE
Implement Stream Flush+FlushAsync fully

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/LoggingStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/LoggingStream.cs
@@ -71,6 +71,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal
             _inner.Flush();
         }
 
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return _inner.FlushAsync(cancellationToken);
+        }
+
         public override int Read(byte[] buffer, int offset, int count)
         {
             int read = _inner.Read(buffer, offset, count);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/RawStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/RawStream.cs
@@ -117,14 +117,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal
 
         public override void Flush()
         {
-            // No-op since writes are immediate.
+            _output.Flush();
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
-            // No-op since writes are immediate.
-            return TaskCache.CompletedTask;
+            return _output.FlushAsync(cancellationToken);
         }
+
 
         private ValueTask<int> ReadAsync(ArraySegment<byte> buffer)
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/StreamSocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/StreamSocketOutput.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
-using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal
 {
@@ -114,14 +113,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal
             end.Block.Pool.Return(end.Block);
         }
 
-        // Flush no-ops. We rely on connection filter streams to auto-flush.
         public void Flush()
         {
+            _outputStream.Flush();
         }
 
         public Task FlushAsync(CancellationToken cancellationToken)
         {
-            return TaskCache.CompletedTask;
+            return _outputStream.FlushAsync(cancellationToken);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionAdapterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionAdapterTests.cs
@@ -186,7 +186,12 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             public override void Flush()
             {
-                // No-op
+                _innerStream.Flush();
+            }
+
+            public override Task FlushAsync(CancellationToken cancellationToken)
+            {
+                return _innerStream.FlushAsync(cancellationToken);
             }
 
             public override int Read(byte[] buffer, int offset, int count)


### PR DESCRIPTION
Streams should pass through the flush and not assume the underlying Stream's Flush behaviour

SslStream's FlushAsync has been fixed for 1.2.0 (2.0?) https://github.com/dotnet/corefx/pull/14035