### PR TITLE
Fix NuGet downgrade warning

### DIFF
--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -1,7 +1,6 @@
 {
   "version": "1.1.0-*",
   "dependencies": {
-    "Microsoft.AspNetCore.Server.Kestrel": "1.2.0-*",
     "Microsoft.AspNetCore.Server.Kestrel.Https": "1.2.0-*",
     "Microsoft.Extensions.Logging.Console": "1.2.0-*"
   },

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
     "Microsoft.AspNetCore.Http.Abstractions": "1.2.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.2.0-*",
     "Microsoft.AspNetCore.Server.Kestrel.Https": "1.2.0-*",
     "Microsoft.AspNetCore.Testing": "1.2.0-*",
     "Microsoft.Extensions.Logging.Testing": "1.2.0-*",

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/project.json
@@ -2,7 +2,6 @@
   "version": "1.1.0-*",
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.2.0-*",
     "Microsoft.AspNetCore.Server.Kestrel.Https": "1.2.0-*",
     "Microsoft.AspNetCore.Testing": "1.2.0-*",
     "Moq": "4.6.36-*",


### PR DESCRIPTION
Works around warning where a P2P reference is explicitly listed in the project. For e.g.

warn :  SampleApp (>= 1.1.0) -> Microsoft.AspNetCore.Server.Kestrel.Https (>= 1.2.0) -> Microsoft.AspNetCore.Server.Kestrel
warn :  SampleApp (>= 1.1.0) -> Microsoft.AspNetCore.Server.Kestrel (>= 1.2.0)