### PR TITLE
[WIP][Tentative] Implement BeginRead/EndRead and BeginWrite/EndWrite on netstandard1.7

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Filter/Internal/LibuvStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Filter/Internal/LibuvStream.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Filter.Internal
             return _input.ReadAsync(buffer.Array, buffer.Offset, buffer.Count);
         }
 
-#if NET451
+#if (NET451 || NETSTANDARD1_7)
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
             var task = ReadAsync(buffer, offset, count, default(CancellationToken), state);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Filter/Internal/LoggingStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Filter/Internal/LoggingStream.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Filter.Internal
             _logger.LogDebug(builder.ToString());
         }
 
-#if NET451
+#if (NET451 || NETSTANDARD1_7)
         // The below APM methods call the underlying Read/WriteAsync methods which will still be logged.
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/project.json
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/project.json
@@ -40,6 +40,12 @@
         "System.Threading.Thread": "4.4.0-*",
         "System.Threading.ThreadPool": "4.4.0-*"
       }
+    },
+    "netstandard1.7": {
+      "dependencies": {
+        "System.Threading.Thread": "4.4.0-*",
+        "System.Threading.ThreadPool": "4.4.0-*"
+      }
     }
   },
   "buildOptions": {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class AddressRegistrationTests
     {
-        [Theory(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)"), MemberData(nameof(AddressRegistrationDataIPv4))]
+        [Theory, MemberData(nameof(AddressRegistrationDataIPv4))]
         public async Task RegisterAddresses_IPv4_Success(string addressInput, Func<IServerAddressesFeature, string[]> testUrls)
         {
             await RegisterAddresses_Success(addressInput, testUrls);
@@ -35,14 +35,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             await RegisterAddresses_Success(addressInput, testUrls);
         }
 
-        [ConditionalTheory(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)"), MemberData(nameof(AddressRegistrationDataIPv4Port443))]
+        [ConditionalTheory, MemberData(nameof(AddressRegistrationDataIPv4Port443))]
         [PortSupportedCondition(443)]
         public async Task RegisterAddresses_IPv4Port443_Success(string addressInput, Func<IServerAddressesFeature, string[]> testUrls)
         {
             await RegisterAddresses_Success(addressInput, testUrls);
         }
 
-        [ConditionalTheory(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)"), MemberData(nameof(AddressRegistrationDataIPv6))]
+        [ConditionalTheory, MemberData(nameof(AddressRegistrationDataIPv6))]
         [IPv6SupportedCondition]
         public async Task RegisterAddresses_IPv6_Success(string addressInput, Func<IServerAddressesFeature, string[]> testUrls)
         {
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             await RegisterAddresses_Success(addressInput, testUrls);
         }
 
-        [ConditionalTheory(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)"), MemberData(nameof(AddressRegistrationDataIPv6Port443))]
+        [ConditionalTheory, MemberData(nameof(AddressRegistrationDataIPv6Port443))]
         [IPv6SupportedCondition]
         [PortSupportedCondition(443)]
         public async Task RegisterAddresses_IPv6Port443_Success(string addressInput, Func<IServerAddressesFeature, string[]> testUrls)
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             await RegisterAddresses_Success(addressInput, testUrls);
         }
 
-        [ConditionalTheory(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)"), MemberData(nameof(AddressRegistrationDataIPv6ScopeId))]
+        [ConditionalTheory, MemberData(nameof(AddressRegistrationDataIPv6ScopeId))]
         [IPv6SupportedCondition]
         public async Task RegisterAddresses_IPv6ScopeId_Success(string addressInput, Func<IServerAddressesFeature, string[]> testUrls)
         {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpClientSlimTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpClientSlimTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task GetStringAsyncHttps()
         {
             using (var host = StartHost(protocol: "https"))
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task PostAsyncHttps()
         {
             using (var host = StartHost(protocol: "https",

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpsTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         // Regression test for https://github.com/aspnet/KestrelHttpServer/issues/1103#issuecomment-246971172
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task DoesNotThrowObjectDisposedExceptionOnConnectionAbort()
         {
             var x509Certificate2 = new X509Certificate2(@"TestResources/testCert.pfx", "testPassword");
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             Assert.False(loggerFactory.ErrorLogger.ObjectDisposedExceptionLogged);
         }
 
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task DoesNotThrowObjectDisposedExceptionFromWriteAsyncAfterConnectionIsAborted()
         {
             var tcs = new TaskCompletionSource<object>();

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/LoggingConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/LoggingConnectionFilterTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
     public class LoggingConnectionFilterTests
     {
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task LoggingConnectionFilterCanBeAddedBeforeAndAfterHttpsFilter()
         {
             var host = new WebHostBuilder()

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [Theory(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Theory]
         [MemberData("LargeUploadData")]
         public async Task LargeUpload(long? maxRequestBufferSize, bool ssl, bool expectPause)
         {
@@ -118,13 +118,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         // The maximum is harder to determine, since there can be OS-level buffers in both the client
                         // and server, which allow the client to send more than maxRequestBufferSize before getting
                         // paused.  We assume the combined buffers are smaller than the difference between
-                        // data.Length and maxRequestBufferSize.                          
+                        // data.Length and maxRequestBufferSize.
                         var maximumExpectedBytesWritten = data.Length - 1;
 
                         // Block until the send task has gone a while without writing bytes AND
                         // the bytes written exceeds the minimum expected.  This indicates the server buffer
                         // is full.
-                        // 
+                        //
                         // If the send task is paused before the expected number of bytes have been
                         // written, keep waiting since the pause may have been caused by something else
                         // like a slow machine.

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpsConnectionFilterTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         // https://github.com/aspnet/KestrelHttpServer/issues/240
         // This test currently fails on mono because of an issue with SslStream.
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task CanReadAndWriteWithHttpsConnectionFilter()
         {
             var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task RequireCertificateFailsWhenNoCertificate()
         {
             var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task AllowCertificateContinuesWhenNoCertificate()
         {
             var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
 
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task CertificatePassedToHttpContext()
         {
             var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task HttpsSchemePassedToRequestFeature()
         {
             var serviceContext = new TestServiceContext(
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task DoesNotSupportTls10()
         {
             var serviceContext = new TestServiceContext(new HttpsConnectionFilter(
@@ -295,7 +295,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
-        [Fact(Skip = "SslStream hanging on write after update to CoreFx 4.4 (https://github.com/dotnet/corefx/issues/14698)")]
+        [Fact]
         public async Task CertificatePassedToHttpContextIsNotDisposed()
         {
             var serviceContext = new TestServiceContext(new HttpsConnectionFilter(


### PR DESCRIPTION
Possible workaround for `SslStream` issue after update to CoreFX 4.4 packages: https://github.com/dotnet/corefx/issues/14698#issuecomment-269725058

Likely not the right thing to do.

cc @davidfowl @pakrym @benaadams 