### PR TITLE
Don't throw unobserved exception from AdaptedPipeline.ReadInputAsync

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/AdaptedPipeline.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/AdaptedPipeline.cs
@@ -52,7 +52,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal
                 catch (Exception ex)
                 {
                     SocketInput.IncomingComplete(0, ex);
-                    throw;
+
+                    // Don't rethrow the exception. It should be handled by the SocketInput consumer.
+                    return;
                 }
 
                 SocketInput.IncomingComplete(bytesRead, error: null);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -106,10 +106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         public Task StopAsync()
         {
-            _frame.StopAsync();
-            _frame.Input.CompleteAwaiting();
-
-            return _socketClosedTcs.Task;
+            return Task.WhenAll(_frame.StopAsync(), _socketClosedTcs.Task);
         }
 
         public virtual Task AbortAsync(Exception error = null)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -404,10 +404,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         /// </summary>
         public Task StopAsync()
         {
-            if (!_requestProcessingStopping)
-            {
-                _requestProcessingStopping = true;
-            }
+            _requestProcessingStopping = true;
+            Input.CompleteAwaiting();
 
             return _requestProcessingTask ?? TaskCache.CompletedTask;
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketInput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketInput.cs
@@ -332,6 +332,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private void SetConnectionError(Exception error)
         {
             _tcs.TrySetException(error);
+            // Prevent UnobservedTaskException
+            var ignore = _tcs.Task.Exception;
         }
 
         private void FinReceived()

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionAdapterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionAdapterTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Adapter;
-using Microsoft.AspNetCore.Server.KestrelTests.TestHelpers;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
@@ -109,6 +108,46 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             }
         }
 
+        [Fact]
+        public async Task ThrowingOnReadDoesNotUnobservedException()
+        {
+            var unobservedExceptionThrown = false;
+
+            EventHandler<UnobservedTaskExceptionEventArgs> unobservedExceptionHandler = (sender, args) =>
+            {
+                unobservedExceptionThrown = true;
+            };
+
+            try
+            {
+                TaskScheduler.UnobservedTaskException += unobservedExceptionHandler;
+
+                var adapter = new ThrowOnReadConnectionAdapter();
+                var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
+                {
+                    ConnectionAdapters = { adapter }
+                };
+
+                var serviceContext = new TestServiceContext();
+                using (var server = new TestServer(TestApp.EchoApp, serviceContext, listenOptions))
+                {
+                    using (var connection = server.CreateConnection())
+                    {
+                        await connection.Send("GET / HTTP/1.1\r\n\r\n");
+                        await connection.ReceiveEnd();
+                    }
+                }
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Assert.False(unobservedExceptionThrown);
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= unobservedExceptionHandler;
+            }
+        }
+
         private class RewritingConnectionAdapter : IConnectionAdapter
         {
             private RewritingStream _rewritingStream;
@@ -136,6 +175,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             public Task<IAdaptedConnection> OnConnectionAsync(ConnectionAdapterContext context)
             {
                 throw new Exception();
+            }
+        }
+
+        private class ThrowOnReadConnectionAdapter : IConnectionAdapter
+        {
+            public Task<IAdaptedConnection> OnConnectionAsync(ConnectionAdapterContext context)
+            {
+                return Task.FromResult<IAdaptedConnection>(new AdaptedConnection(new ThrowOnReadStream()));
             }
         }
 
@@ -247,6 +294,46 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
             }
+        }
+
+        private class ThrowOnReadStream : Stream
+        {
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                await Task.Delay(1);
+                throw new Exception();
+            }
+
+            public override void Flush()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanRead { get; }
+            public override bool CanSeek { get; }
+            public override bool CanWrite { get; }
+            public override long Length { get; }
+            public override long Position { get; set; }
         }
     }
 }


### PR DESCRIPTION
When I was investigating #1249 using Kestrel's SampleApp I saw the following unobserved exceptions.

```
   {"The decryption operation failed, see inner exception."}
   {"The certificate chain was issued by an authority that is not trusted"}
   at System.Net.Security._SslStream.EndRead(IAsyncResult asyncResult)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncTrimPromise`1.Complete(TInstance thisRef, Func`3 endMethod, IAsyncResult asyncResult, Boolean requiresSynchronization)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal.LoggingStream.<ReadAsync>d__17.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal.AdaptedPipeline.<ReadInputAsync>d__9.MoveNext()
   
TaskCanceledException "The request was aborted"
      at Microsoft.AspNetCore.Server.Kestrel.Internal.Http.SocketInput.CheckConnectionError()
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Http.SocketInput.GetResult()
   at Microsoft.AspNetCore.Server.Kestrel.Internal.Http.SocketInputExtensions.<ReadAsyncAwaited>d__1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal.LoggingStream.<ReadAsync>d__17.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal.AdaptedPipeline.<ReadInputAsync>d__9.MoveNext()
```

When I removed the connection filters, I still saw "The request was aborted" TaskCanceledExceptions. Those aren't fixed by this PR. I think it is better to wait until #1277 until fixing the non ConnectionAdapter related unobserved exceptions.
