### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <!-- TODO remove rid when https://github.com/dotnet/sdk/issues/396 is resolved -->
     <RuntimeIdentifier Condition="'$(TargetFramework)'!='netcoreapp1.1'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
@@ -26,7 +27,7 @@
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameRequestStreamTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameRequestStreamTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             await Assert.ThrowsAsync<NotSupportedException>(() => stream.WriteAsync(new byte[1], 0, 1));
         }
 
-#if NET451
+#if NET452
         [Fact]
         public void BeginWriteThrows()
         {

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseStreamTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseStreamTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             await Assert.ThrowsAsync<NotSupportedException>(() => stream.ReadAsync(new byte[1], 0, 1));
         }
 
-#if NET451
+#if NET452
         [Fact]
         public void BeginReadThrows()
         {

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/Microsoft.AspNetCore.Server.KestrelTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/Microsoft.AspNetCore.Server.KestrelTests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- TODO remove rid when https://github.com/dotnet/sdk/issues/396 is resolved -->
     <RuntimeIdentifier Condition="'$(TargetFramework)'!='netcoreapp1.1'">win7-x64</RuntimeIdentifier>
@@ -24,7 +25,7 @@
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var t = Task.Run(async () =>
             {
                 var socket = TestConnection.CreateConnectedLoopbackSocket(port);
-#if NET451
+#if NET452
                 await Task.Factory.FromAsync(
                     socket.BeginSend,
                     socket.EndSend,
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var t = Task.Run(async () =>
             {
                 var socket = TestConnection.CreateConnectedLoopbackSocket(port);
-#if NET451
+#if NET452
                 await Task.Factory.FromAsync(
                     socket.BeginSend,
                     socket.EndSend,
@@ -221,7 +221,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var buffer = new ArraySegment<byte>(new byte[2048]);
                 while (true)
                 {
-#if NET451
+#if NET452
                     var count = await Task.Factory.FromAsync(
                         socket.BeginReceive,
                         socket.EndReceive,

--- a/test/shared/TestResources.cs
+++ b/test/shared/TestResources.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Testing
     public static class TestResources
     {
         private static readonly string _testCertificatePath =
-#if NET451
+#if NET452
             Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.pfx");
 #else
             Path.Combine(AppContext.BaseDirectory, "testCert.pfx");


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows