### PR TITLE
Fix AddressRegistrationTests.RegisterAddresses_IPv6ScopeId_Success (#1363)

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -70,6 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [ConditionalTheory, MemberData(nameof(AddressRegistrationDataIPv6ScopeId))]
         [IPv6SupportedCondition]
+        [IPv6ScopeIdPresentCondition]
         public async Task RegisterAddresses_IPv6ScopeId_Success(string addressInput, Func<IServerAddressesFeature, string[]> testUrls)
         {
             await RegisterAddresses_Success(addressInput, testUrls);

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/IPv6ScopeIdPresentConditionAttribute.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/IPv6ScopeIdPresentConditionAttribute.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using Microsoft.AspNetCore.Testing.xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
+{
+    public class IPv6ScopeIdPresentConditionAttribute : Attribute, ITestCondition
+    {
+        private static readonly Lazy<bool> _ipv6ScopeIdPresent = new Lazy<bool>(IPv6ScopeIdAddressPresent);
+
+        public bool IsMet => _ipv6ScopeIdPresent.Value;
+
+        public string SkipReason => "No IPv6 addresses with scope IDs were found on the host.";
+
+        private static bool IPv6ScopeIdAddressPresent()
+        {
+            try
+            {
+                return NetworkInterface.GetAllNetworkInterfaces()
+                    .Where(iface => iface.OperationalStatus == OperationalStatus.Up)
+                    .SelectMany(iface => iface.GetIPProperties().UnicastAddresses)
+                    .Any(addrInfo => addrInfo.Address.AddressFamily == AddressFamily.InterNetworkV6 && addrInfo.Address.ScopeId != 0);
+            }
+            catch (SocketException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/IPv6SupportedConditionAttribute.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/IPv6SupportedConditionAttribute.cs
@@ -13,21 +13,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
     {
         private static readonly Lazy<bool> _ipv6Supported = new Lazy<bool>(CanBindToIPv6Address);
 
-        public bool IsMet
-        {
-            get
-            {
-                return _ipv6Supported.Value;
-            }
-        }
+        public bool IsMet => _ipv6Supported.Value;
 
-        public string SkipReason
-        {
-            get
-            {
-                return "IPv6 not supported on the host.";
-            }
-        }
+        public string SkipReason => "IPv6 not supported on the host.";
 
         private static bool CanBindToIPv6Address()
         {


### PR DESCRIPTION
#1363

The problem is the collection with theory data must not be empty. If there are no scope ID addresses the test fails.

This is not an issue with `ConditionalTheory`. The test also fails when changed to `Theory`.