### PR TITLE
Fix 'No data found for...' errors in CI test runs

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -442,6 +442,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     dataset.Add($"http://[{ip}]:0/", GetTestUrls);
                 }
 
+                // There may be no addresses with scope IDs and we need at least one data item in the
+                // collection, otherwise xUnit fails the test run because a theory has no data.
+                dataset.Add("http://[::1]:0", GetTestUrls);
+
                 return dataset;
             }
         }


### PR DESCRIPTION
xUnit complains about empty data even when we have skip conditions. This is because the data is evaluated before we evaluate our skip conditions, an an error happens if the data is empty:

https://github.com/xunit/xunit/blob/1b69df1378cb9d6b589d55ce23ab544458169485/src/xunit.execution/Sdk/Frameworks/TheoryDiscoverer.cs#L242

We could fix this in our Testing package (https://github.com/aspnet/Testing/issues/254), but the fix is ugly. We'd have to override `Discover` in `ConditionalTheoryDiscoverer`, call the base, check that the results contain any `ExecutionErrorTestCase` instances with messages starting with `No data found for` and remove those from the collection.