### PR TITLE
[dev-si] Fix 'No data found for...' errors in CI test runs

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -442,6 +442,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     dataset.Add($"http://[{ip}]:0/", GetTestUrls);
                 }
 
+                // There may be no addresses with scope IDs and we need at least one data item in the
+                // collection, otherwise xUnit fails the test run because a theory has no data.
+                dataset.Add("http://[::1]:0", GetTestUrls);
+
                 return dataset;
             }
         }


### PR DESCRIPTION
Same as #1381 but for `dev-si`.