### PR TITLE
Avoid unobserved exceptions

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -34,6 +35,11 @@ namespace SampleApp
 
         public static void Main(string[] args)
         {
+            TaskScheduler.UnobservedTaskException += (sender, e) =>
+            {
+                Console.WriteLine("Unobserved exception: {0}", e.Exception);
+            };
+
             var host = new WebHostBuilder()
                 .UseKestrel(options =>
                 {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/AdaptedPipeline.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/AdaptedPipeline.cs
@@ -52,7 +52,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal
                 catch (Exception ex)
                 {
                     SocketInput.IncomingComplete(0, ex);
-                    throw;
+
+                    // Don't rethrow the exception. It should be handled by the SocketInput consumer.
+                    return;
                 }
 
                 SocketInput.IncomingComplete(bytesRead, error: null);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -106,10 +106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         public Task StopAsync()
         {
-            _frame.StopAsync();
-            _frame.Input.CompleteAwaiting();
-
-            return _socketClosedTcs.Task;
+            return Task.WhenAll(_frame.StopAsync(), _socketClosedTcs.Task);
         }
 
         public virtual Task AbortAsync(Exception error = null)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -404,10 +404,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         /// </summary>
         public Task StopAsync()
         {
-            if (!_requestProcessingStopping)
-            {
-                _requestProcessingStopping = true;
-            }
+            _requestProcessingStopping = true;
+            Input.CompleteAwaiting();
 
             return _requestProcessingTask ?? TaskCache.CompletedTask;
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketInput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketInput.cs
@@ -332,6 +332,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private void SetConnectionError(Exception error)
         {
             _tcs.TrySetException(error);
+            // Prevent UnobservedTaskException
+            var ignore = _tcs.Task.Exception;
         }
 
         private void FinReceived()


### PR DESCRIPTION
- Don't throw from AdaptedPipeline.ReadInputAsync
- Observe exception in SocketInput
- Watch for unobserved exceptions in SampleApp