### PR TITLE
Avoid unobserved exceptions (dev)

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -34,6 +35,11 @@ namespace SampleApp
 
         public static void Main(string[] args)
         {
+            TaskScheduler.UnobservedTaskException += (sender, e) =>
+            {
+                Console.WriteLine("Unobserved exception: {0}", e.Exception);
+            };
+
             var host = new WebHostBuilder()
                 .UseKestrel(options =>
                 {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/AdaptedPipeline.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/AdaptedPipeline.cs
@@ -63,7 +63,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal
                 catch (Exception ex)
                 {
                     Input.Writer.Complete(ex);
-                    throw;
+
+                    // Don't rethrow the exception. It should be handled by the Pipeline consumer.
+                    return;
                 }
             } while (bytesRead != 0);
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Connection.cs
@@ -119,10 +119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         public Task StopAsync()
         {
-            _frame.StopAsync();
-            _frame.Input.Reader.CancelPendingRead();
-
-            return _socketClosedTcs.Task;
+            return Task.WhenAll(_frame.StopAsync(), _socketClosedTcs.Task);
         }
 
         public virtual Task AbortAsync(Exception error = null)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -402,10 +402,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         /// </summary>
         public Task StopAsync()
         {
-            if (!_requestProcessingStopping)
-            {
-                _requestProcessingStopping = true;
-            }
+            _requestProcessingStopping = true;
+            Input.Reader.CancelPendingRead();
 
             return _requestProcessingTask ?? TaskCache.CompletedTask;
         }


### PR DESCRIPTION
- Don't throw from AdaptedPipeline.ReadInputAsync
- Watch for unobserved exceptions in SampleApp