### PR TITLE
Optimized parsing GET verb and version

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolIteratorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/MemoryPoolIteratorExtensions.cs
@@ -27,8 +27,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         private readonly static ulong _httpOptionsMethodLong = GetAsciiStringAsLong("OPTIONS ");
         private readonly static ulong _httpTraceMethodLong = GetAsciiStringAsLong("TRACE \0\0");
 
-        private readonly static ulong _http10VersionLong = GetAsciiStringAsLong("HTTP/1.0");
-        private readonly static ulong _http11VersionLong = GetAsciiStringAsLong("HTTP/1.1");
+        private const ulong _http10VersionLong = 3471766442030158920; // GetAsciiStringAsLong("HTTP/1.0"); const results in better codegen
+        private const ulong _http11VersionLong = 3543824036068086856; // GetAsciiStringAsLong("HTTP/1.1"); const results in better codegen
 
         private readonly static ulong _mask8Chars = GetMaskAsLong(new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff });
         private readonly static ulong _mask7Chars = GetMaskAsLong(new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00 });

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KnownStrings.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KnownStrings.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    public class KnownStrings
+    {
+        static byte[] _method = Encoding.UTF8.GetBytes("GET ");
+        static byte[] _version = Encoding.UTF8.GetBytes("HTTP/1.1\r\n");
+        const int loops = 1000;
+
+        [Benchmark(OperationsPerInvoke = loops * 10)]
+        public int GetKnownMethod_GET()
+        {
+            int len = 0;
+            string method;
+            Span<byte> data = _method;
+            for (int i = 0; i < loops; i++) {
+                data.GetKnownMethod(out method);
+                len += method.Length;
+                data.GetKnownMethod(out method);
+                len += method.Length;
+                data.GetKnownMethod(out method);
+                len += method.Length;
+                data.GetKnownMethod(out method);
+                len += method.Length;
+                data.GetKnownMethod(out method);
+                len += method.Length;
+                data.GetKnownMethod(out method);
+                len += method.Length;
+                data.GetKnownMethod(out method);
+                len += method.Length;
+                data.GetKnownMethod(out method);
+                len += method.Length;
+                data.GetKnownMethod(out method);
+                len += method.Length;
+                data.GetKnownMethod(out method);
+                len += method.Length;
+            }
+            return len;
+        }
+
+        [Benchmark(OperationsPerInvoke = loops * 10)]
+        public int GetKnownVersion_HTTP1_1()
+        {
+            int len = 0;
+            string version;
+            Span<byte> data = _version;
+            for (int i = 0; i < loops; i++) {
+                data.GetKnownVersion(out version);
+                len += version.Length;
+                data.GetKnownVersion(out version);
+                len += version.Length;
+                data.GetKnownVersion(out version);
+                len += version.Length;
+                data.GetKnownVersion(out version);
+                len += version.Length;
+                data.GetKnownVersion(out version);
+                len += version.Length;
+                data.GetKnownVersion(out version);
+                len += version.Length;
+                data.GetKnownVersion(out version);
+                len += version.Length;
+                data.GetKnownVersion(out version);
+                len += version.Length;
+                data.GetKnownVersion(out version);
+                len += version.Length;
+                data.GetKnownVersion(out version);
+                len += version.Length;
+            }
+            return len;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Program.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Program.cs
@@ -40,6 +40,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             {
                 BenchmarkRunner.Run<PipeThroughput>();
             }
+            if (type.HasFlag(BenchmarkType.KnownStrings)) 
+            {
+                BenchmarkRunner.Run<KnownStrings>();
+            }
         }
     }
 
@@ -49,6 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         RequestParsing = 1,
         Writing = 2,
         Throughput = 4,
+        KnownStrings = 8,
         // add new ones in powers of two - e.g. 2,4,8,16...
 
         All = uint.MaxValue


### PR DESCRIPTION
### Before
```
                   Method |          Mean |     StdDev | Scaled | Scaled-StdDev |          RPS | Allocated |
------------------------- |-------------- |----------- |------- |-------------- |------------- |---------- |
           ParsePlaintext | 1,079.6836 ns |  8.1507 ns |   1.00 |          0.00 |   926,197.25 |     168 B |
  ParsePipelinedPlaintext |   877.8646 ns |  7.3689 ns |   0.81 |          0.01 | 1,139,127.77 |     168 B |
          ParseLiveAspNet | 3,826.8063 ns | 15.9470 ns |   3.54 |          0.03 |   261,314.51 |   2.02 kB |
 ParsePipelinedLiveAspNet | 3,828.8495 ns | 29.7095 ns |   3.55 |          0.04 |   261,175.06 |   2.02 kB |
             ParseUnicode | 6,870.2153 ns | 33.0606 ns |   6.36 |          0.06 |   145,555.85 |   3.41 kB |
    ParseUnicodePipelined | 6,944.8703 ns | 24.7683 ns |   6.43 |          0.05 |   143,991.17 |   3.41 kB |
```

### After
```
                   Method |          Mean |     StdDev | Scaled | Scaled-StdDev |          RPS | Allocated |
------------------------- |-------------- |----------- |------- |-------------- |------------- |---------- |
           ParsePlaintext | 1,061.8108 ns |  8.9208 ns |   1.00 |          0.00 |   941,787.34 |     168 B |
  ParsePipelinedPlaintext |   865.3721 ns |  6.0690 ns |   0.82 |          0.01 | 1,155,572.27 |     168 B |
          ParseLiveAspNet | 3,882.7252 ns | 85.4559 ns |   3.66 |          0.08 |   257,551.06 |   2.02 kB |
 ParsePipelinedLiveAspNet | 3,866.2318 ns | 21.6853 ns |   3.64 |          0.04 |   258,649.78 |   2.02 kB |
             ParseUnicode | 6,857.4925 ns | 67.3531 ns |   6.46 |          0.08 |   145,825.90 |   3.41 kB |
    ParseUnicodePipelined | 7,009.4501 ns | 39.9254 ns |   6.60 |          0.07 |   142,664.54 |   3.41 kB |
```

Wow, my home machine is faster than the one I have at work! 900K rps vs ~500K