### PR TITLE
Convert TakeStartLine and TakeMessageHeaders to be state machines

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -16,20 +17,20 @@ namespace SampleApp
     {
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
-            loggerFactory.AddConsole(LogLevel.Trace);
-            var logger = loggerFactory.CreateLogger("Default");
+            // loggerFactory.AddConsole(LogLevel.Trace);
+            // var logger = loggerFactory.CreateLogger("Default");
 
+            var buffer = Encoding.UTF8.GetBytes($"hello, world{Environment.NewLine}");
             app.Run(async context =>
             {
-                var connectionFeature = context.Connection;
-                logger.LogDebug($"Peer: {connectionFeature.RemoteIpAddress?.ToString()}:{connectionFeature.RemotePort}"
-                    + $"{Environment.NewLine}"
-                    + $"Sock: {connectionFeature.LocalIpAddress?.ToString()}:{connectionFeature.LocalPort}");
+                //var connectionFeature = context.Connection;
+                //logger.LogDebug($"Peer: {connectionFeature.RemoteIpAddress?.ToString()}:{connectionFeature.RemotePort}"
+                //    + $"{Environment.NewLine}"
+                //    + $"Sock: {connectionFeature.LocalIpAddress?.ToString()}:{connectionFeature.LocalPort}");
 
-                var response = $"hello, world{Environment.NewLine}";
-                context.Response.ContentLength = response.Length;
+                context.Response.ContentLength = buffer.Length;
                 context.Response.ContentType = "text/plain";
-                await context.Response.WriteAsync(response);
+                await context.Response.Body.WriteAsync(buffer, 0, buffer.Length);
             });
         }
 

--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -17,20 +16,20 @@ namespace SampleApp
     {
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
-            // loggerFactory.AddConsole(LogLevel.Trace);
-            // var logger = loggerFactory.CreateLogger("Default");
+            loggerFactory.AddConsole(LogLevel.Trace);
+            var logger = loggerFactory.CreateLogger("Default");
 
-            var buffer = Encoding.UTF8.GetBytes($"hello, world{Environment.NewLine}");
             app.Run(async context =>
             {
-                //var connectionFeature = context.Connection;
-                //logger.LogDebug($"Peer: {connectionFeature.RemoteIpAddress?.ToString()}:{connectionFeature.RemotePort}"
-                //    + $"{Environment.NewLine}"
-                //    + $"Sock: {connectionFeature.LocalIpAddress?.ToString()}:{connectionFeature.LocalPort}");
+                var connectionFeature = context.Connection;
+                logger.LogDebug($"Peer: {connectionFeature.RemoteIpAddress?.ToString()}:{connectionFeature.RemotePort}"
+                    + $"{Environment.NewLine}"
+                    + $"Sock: {connectionFeature.LocalIpAddress?.ToString()}:{connectionFeature.LocalPort}");
 
-                context.Response.ContentLength = buffer.Length;
+                var response = $"hello, world{Environment.NewLine}";
+                context.Response.ContentLength = response.Length;
                 context.Response.ContentType = "text/plain";
-                await context.Response.Body.WriteAsync(buffer, 0, buffer.Length);
+                await context.Response.WriteAsync(response);
             });
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -1257,21 +1257,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             return true;
         }
 
-        private int MinNonZero(int v1, int v2)
-        {
-            v1 = v1 == -1 ? int.MaxValue : v1;
-            v2 = v2 == -1 ? int.MaxValue : v2;
-            return Math.Min(v1, v2);
-        }
-
-        private int MinNonZero(int v1, int v2, int v3)
-        {
-            v1 = v1 == -1 ? int.MaxValue : v1;
-            v2 = v2 == -1 ? int.MaxValue : v2;
-            v3 = v3 == -1 ? int.MaxValue : v3;
-            return Math.Min(Math.Min(v1, v2), v3);
-        }
-
         private void RejectRequestLine(ReadCursor start, ReadCursor end)
         {
             const int MaxRequestLineError = 32;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -1085,8 +1085,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             var pathEnd = -1;
 
             // TODO: State machineify
-
-
             fixed (byte* data = &span.DangerousGetPinnableReference())
             {
                 int length = span.Length;

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -572,6 +572,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [InlineData("GET  HTTP/1.1\r\n", "Invalid request line: GET  HTTP/1.1<0x0D><0x0A>")]
         [InlineData("GET / HTTP/1.1\n", "Invalid request line: GET / HTTP/1.1<0x0A>")]
         [InlineData("GET / \r\n", "Invalid request line: GET / <0x0D><0x0A>")]
+        [InlineData("GET ? HTTP/1.1\r\n", "Invalid request line: GET ? HTTP/1.1<0x0D><0x0A>")]
         [InlineData("GET / HTTP/1.1\ra\n", "Invalid request line: GET / HTTP/1.1<0x0D>a<0x0A>")]
         public async Task TakeStartLineThrowsWhenInvalid(string requestLine, string expectedExceptionMessage)
         {


### PR DESCRIPTION
- Convert TakeStartLine and TakeMessageHeaders to be state machines
- Use pointers to parse byte by byte instead of span indexer to access bytes

Results:

https://gist.github.com/davidfowl/c487ad4b49f013b6e9d4fc1ccc84bbf2#file-results-md

Seems to be the best implementation so far. Still a way to go to get back to 1.2M for pipelined but it looks like progress. 

/cc @benaadams 