### PR TITLE
Don't require framework when running CodeGenerator

### DIFF
--- a/tools/CodeGenerator/CodeGenerator.csproj
+++ b/tools/CodeGenerator/CodeGenerator.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Same as #1410 but for `feature/dev-si`.