### PR TITLE
Single span fast paths

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
@@ -143,9 +143,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
                 Frame.Reset();
 
-                ReadCursor consumed;
-                ReadCursor examined;
-                if (!Frame.TakeStartLine(readableBuffer, out consumed, out examined))
+                if (!Frame.TakeStartLine(readableBuffer, out var consumed, out var examined))
                 {
                     ThrowInvalidStartLine();
                 }


### PR DESCRIPTION
This change adds single span fast paths for header and start line parsing. The downside is that the header parsing's outer loop is duplicated with the multi buffer path (we should look at fixing that). Parsing individual headers is shared between both routines.

/cc @benaadams 