### PR TITLE
Added a new benchmark

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
@@ -23,6 +23,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         private const string plaintextRequest = "GET /plaintext HTTP/1.1\r\nHost: www.example.com\r\n\r\n";
 
+        private const string plaintextTechEmpower = "GET /plaintext HTTP/1.1\r\n" +
+            "Host: localhost\r\n" +
+            "Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7\r\n" +
+            "Connection: keep-alive\r\n\r\n";
+
         private const string liveaspnetRequest = "GET https://live.asp.net/ HTTP/1.1\r\n" +
             "Host: live.asp.net\r\n" +
             "Connection: keep-alive\r\n" +
@@ -51,7 +56,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         private static readonly byte[] _plaintextPipelinedRequests = Encoding.ASCII.GetBytes(string.Concat(Enumerable.Repeat(plaintextRequest, Pipelining)));
         private static readonly byte[] _plaintextRequest = Encoding.ASCII.GetBytes(plaintextRequest);
-
+        private static readonly byte[] _plaintextTechEmpower = Encoding.ASCII.GetBytes(plaintextTechEmpower);
+        
         private static readonly byte[] _liveaspnentPipelinedRequests = Encoding.ASCII.GetBytes(string.Concat(Enumerable.Repeat(liveaspnetRequest, Pipelining)));
         private static readonly byte[] _liveaspnentRequest = Encoding.ASCII.GetBytes(liveaspnetRequest);
 
@@ -67,6 +73,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             for (var i = 0; i < InnerLoopCount; i++)
             {
                 InsertData(_plaintextRequest);
+                ParseData();
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        public void ParsePlaintextTechEmpower()
+        {
+            for (var i = 0; i < InnerLoopCount; i++) {
+                InsertData(_plaintextTechEmpower);
                 ParseData();
             }
         }


### PR DESCRIPTION
This adds a new benchmark that corresponds better to plaintext tech empower.
The results are significantly different:

``` ini

BenchmarkDotNet=v0.10.2.376-develop, OS=Microsoft Windows 10.0.14393
Processor=Intel(R) Core(TM) i7-6700 CPU 3.40GHz, ProcessorCount=8
Frequency=3328130 Hz, Resolution=300.4690 ns, Timer=TSC
dotnet cli version=1.0.0
  [Host]     : .NET Core 4.6.25009.03, 64bit RyuJIT
  Job-LJJNXU : .NET Core 4.6.25009.03, 64bit RyuJIT

RemoveOutliers=False  Runtime=Core  Server=True  
LaunchCount=3  RunStrategy=Throughput  TargetCount=10  
WarmupCount=5  

```
 |                    Method |                                                          ParserType |          Mean |      StdDev |        Median | Scaled | Scaled-StdDev |          RPS | Allocated |
 |-------------------------- |-------------------------------------------------------------------- |-------------- |------------ |-------------- |------- |-------------- |------------- |---------- |
 |            ParsePlaintext | Microsoft.AspNetCore.Server.Kestrel.Internal.Http.KestrelHttpParser | 1,111.1238 ns |  17.9054 ns | 1,109.9805 ns |   1.00 |          0.00 |   899,989.73 |     105 B |
 |   ParsePipelinedPlaintext | Microsoft.AspNetCore.Server.Kestrel.Internal.Http.KestrelHttpParser |   934.3919 ns |  29.3728 ns |   922.2015 ns |   0.84 |          0.03 | 1,070,214.72 |     105 B |
 | ParsePlaintextTechEmpower | Microsoft.AspNetCore.Server.Kestrel.Internal.Http.KestrelHttpParser | 1,566.5328 ns |  67.7703 ns | 1,540.1096 ns |   1.41 |          0.06 |   638,352.43 |     301 B |
 |           ParseLiveAspNet | Microsoft.AspNetCore.Server.Kestrel.Internal.Http.KestrelHttpParser | 4,166.3727 ns | 178.1786 ns | 4,119.7391 ns |   3.75 |          0.17 |   240,016.93 |   1.12 kB |
 |  ParsePipelinedLiveAspNet | Microsoft.AspNetCore.Server.Kestrel.Internal.Http.KestrelHttpParser | 4,271.9683 ns |  72.6725 ns | 4,248.3105 ns |   3.85 |          0.09 |   234,084.13 |   1.12 kB |
 |              ParseUnicode | Microsoft.AspNetCore.Server.Kestrel.Internal.Http.KestrelHttpParser | 7,545.8150 ns |  91.2033 ns | 7,526.5936 ns |   6.79 |          0.13 |   132,523.79 |   1.97 kB |
 |     ParseUnicodePipelined | Microsoft.AspNetCore.Server.Kestrel.Internal.Http.KestrelHttpParser | 8,261.9919 ns | 263.6573 ns | 8,129.5133 ns |   7.44 |          0.26 |   121,036.19 |   1.97 kB |
```
```
BTW, should we trim the names of the "parser type"? The table got very wide.