### PR TITLE
Use TechEmpower request as baseline for request parsing benchmarks

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
@@ -19,7 +19,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         private const int InnerLoopCount = 512;
         private const int Pipelining = 16;
 
-        private const string plaintextRequest = "GET /plaintext HTTP/1.1\r\nHost: www.example.com\r\n\r\n";
+        private const string plaintextTechEmpowerRequest = "GET /plaintext HTTP/1.1\r\n" +
+            "Host: localhost\r\n" +
+            "Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7\r\n" +
+            "Connection: keep-alive\r\n\r\n";
 
         private const string liveaspnetRequest = "GET https://live.asp.net/ HTTP/1.1\r\n" + 
             "Host: live.asp.net\r\n" + 
@@ -47,8 +50,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             "Pragma: no-cache\r\n" +
             "Cookie: prov=20629ccd-8b0f-e8ef-2935-cd26609fc0bc; __qca=P0-1591065732-1479167353442; _ga=GA1.2.1298898376.1479167354; _gat=1; sgt=id=9519gfde_3347_4762_8762_df51458c8ec2; acct=t=why-is-%e0%a5%a7%e0%a5%a8%e0%a5%a9-numeric&s=why-is-%e0%a5%a7%e0%a5%a8%e0%a5%a9-numeric\r\n\r\n";
 
-        private static readonly byte[] _plaintextPipelinedRequests = Encoding.ASCII.GetBytes(string.Concat(Enumerable.Repeat(plaintextRequest, Pipelining)));
-        private static readonly byte[] _plaintextRequest  = Encoding.ASCII.GetBytes(plaintextRequest);
+        private static readonly byte[] _plaintextTechEmpowerPipelinedRequests = Encoding.ASCII.GetBytes(string.Concat(Enumerable.Repeat(plaintextTechEmpowerRequest, Pipelining)));
+        private static readonly byte[] _plaintextTechEmpowerRequest  = Encoding.ASCII.GetBytes(plaintextTechEmpowerRequest);
 
         private static readonly byte[] _liveaspnentPipelinedRequests = Encoding.ASCII.GetBytes(string.Concat(Enumerable.Repeat(liveaspnetRequest, Pipelining)));
         private static readonly byte[] _liveaspnentRequest = Encoding.ASCII.GetBytes(liveaspnetRequest);
@@ -63,22 +66,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         private Frame<object> Frame;
 
         [Benchmark(Baseline = true, OperationsPerInvoke = InnerLoopCount)]
-        public void ParsePlaintext()
+        public void ParsePlaintextTechEmpower()
         {
             for (var i = 0; i < InnerLoopCount; i++)
             {
-                InsertData(_plaintextRequest);
+                InsertData(_plaintextTechEmpowerRequest);
 
                 ParseData();
             }
         }
 
         [Benchmark(OperationsPerInvoke = InnerLoopCount * Pipelining)]
-        public void ParsePipelinedPlaintext()
+        public void ParsePipelinedPlaintextTechEmpower()
         {
             for (var i = 0; i < InnerLoopCount; i++)
             {
-                InsertData(_plaintextPipelinedRequests);
+                InsertData(_plaintextTechEmpowerPipelinedRequests);
 
                 ParseData();
             }


### PR DESCRIPTION
Same as https://github.com/aspnet/KestrelHttpServer/pull/1439 but for `feature/dev-si`.

cc @KrzysztofCwalina 