### PR TITLE
More pointers

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
@@ -319,23 +320,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 var headerBuffer = buffer.Slice(consumed, lineEnd);
                 var span = headerBuffer.ToSpan();
 
-                if (!TakeSingleHeader(span, out var nameStart, out var nameEnd, out var valueStart, out var valueEnd))
+                fixed (byte* pHeader = &span.DangerousGetPinnableReference())
                 {
-                    return false;
+                    if (!TakeSingleHeader(pHeader, span.Length, out var nameStart, out var nameEnd, out var valueStart, out var valueEnd))
+                    {
+                        return false;
+                    }
+
+                    // Skip the reader forward past the header line
+                    reader.Skip(span.Length);
+                    // REVIEW: Removed usage of ReadableBufferReader.Cursor, because it's broken when the buffer is
+                    // sliced and doesn't start at the start of a segment. We should probably fix this.
+                    //consumed = reader.Cursor;
+                    consumed = buffer.Move(consumed, span.Length);
+                    consumedBytes += span.Length;
+
+                    var nameBuffer = span.Slice(nameStart, nameEnd - nameStart);
+                    var valueBuffer = span.Slice(valueStart, valueEnd - valueStart);
+
+                    handler.OnHeader(nameBuffer, valueBuffer);
                 }
-
-                // Skip the reader forward past the header line
-                reader.Skip(span.Length);
-                // REVIEW: Removed usage of ReadableBufferReader.Cursor, because it's broken when the buffer is
-                // sliced and doesn't start at the start of a segment. We should probably fix this.
-                //consumed = reader.Cursor;
-                consumed = buffer.Move(consumed, span.Length);
-                consumedBytes += span.Length;
-
-                var nameBuffer = span.Slice(nameStart, nameEnd - nameStart);
-                var valueBuffer = span.Slice(valueStart, valueEnd - valueStart);
-
-                handler.OnHeader(nameBuffer, valueBuffer);
             }
         }
 
@@ -344,16 +348,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             consumedBytes = 0;
             var length = headersSpan.Length;
 
-            fixed (byte* data = &headersSpan.DangerousGetPinnableReference())
+            fixed (byte* pHeaders = &headersSpan.DangerousGetPinnableReference())
             {
                 while (consumedBytes < length)
                 {
-                    var ch1 = data[consumedBytes];
+                    var ch1 = pHeaders[consumedBytes];
                     var ch2 = -1;
 
                     if (consumedBytes + 1 < length)
                     {
-                        ch2 = data[consumedBytes + 1];
+                        ch2 = pHeaders[consumedBytes + 1];
                     }
 
                     if (ch1 == ByteCR)
@@ -377,32 +381,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                         RejectRequest(RequestRejectionReason.HeaderLineMustNotStartWithWhitespace);
                     }
 
-                    var lineEnd = IndexOf(data, consumedBytes, headersSpan.Length, ByteLF);
+                    var lineEnd = IndexOf(pHeaders, consumedBytes, length, ByteLF);
 
                     if (lineEnd == -1)
                     {
                         return false;
                     }
 
-                    var span = new Span<byte>(data + consumedBytes, (lineEnd - consumedBytes + 1));
+                    var pHeader = pHeaders + consumedBytes;
+                    var headerLength = (lineEnd - consumedBytes + 1);
 
-                    if (!TakeSingleHeader(span, out var nameStart, out var nameEnd, out var valueStart, out var valueEnd))
+                    if (!TakeSingleHeader(pHeader, headerLength, out var nameStart, out var nameEnd, out var valueStart, out var valueEnd))
                     {
                         return false;
                     }
 
-                    consumedBytes += span.Length;
-
-                    var nameBuffer = span.Slice(nameStart, nameEnd - nameStart);
-                    var valueBuffer = span.Slice(valueStart, valueEnd - valueStart);
+                    var nameBuffer = new Span<byte>(pHeader + nameStart, nameEnd - nameStart);
+                    var valueBuffer = new Span<byte>(pHeader + valueStart, valueEnd - valueStart);
 
                     handler.OnHeader(nameBuffer, valueBuffer);
+
+                    consumedBytes += headerLength;
                 }
             }
 
             return false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe int IndexOf(byte* data, int index, int length, byte value)
         {
             for (int i = index; i < length; i++)
@@ -415,127 +421,124 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             return -1;
         }
 
-        private unsafe bool TakeSingleHeader(Span<byte> span, out int nameStart, out int nameEnd, out int valueStart, out int valueEnd)
+        private unsafe bool TakeSingleHeader(byte* pHeader, int headerLength, out int nameStart, out int nameEnd, out int valueStart, out int valueEnd)
         {
             nameStart = 0;
             nameEnd = -1;
             valueStart = -1;
             valueEnd = -1;
-            var headerLineLength = span.Length;
             var nameHasWhitespace = false;
             var previouslyWhitespace = false;
 
             int i = 0;
             var done = false;
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+
+            switch (HeaderState.Name)
             {
-                switch (HeaderState.Name)
-                {
-                    case HeaderState.Name:
-                        for (; i < headerLineLength; i++)
+                case HeaderState.Name:
+                    for (; i < headerLength; i++)
+                    {
+                        var ch = pHeader[i];
+                        if (ch == ByteColon)
                         {
-                            var ch = data[i];
-                            if (ch == ByteColon)
+                            if (nameHasWhitespace)
                             {
-                                if (nameHasWhitespace)
-                                {
-                                    RejectRequest(RequestRejectionReason.WhitespaceIsNotAllowedInHeaderName);
-                                }
-                                nameEnd = i;
-
-                                // Consume space
-                                i++;
-
-                                goto case HeaderState.Whitespace;
+                                RejectRequest(RequestRejectionReason.WhitespaceIsNotAllowedInHeaderName);
                             }
+                            nameEnd = i;
 
-                            if (ch == ByteSpace || ch == ByteTab)
-                            {
-                                nameHasWhitespace = true;
-                            }
-                        }
-                        RejectRequest(RequestRejectionReason.NoColonCharacterFoundInHeaderLine);
+                            // Consume space
+                            i++;
 
-                        break;
-                    case HeaderState.Whitespace:
-                        for (; i < headerLineLength; i++)
-                        {
-                            var ch = data[i];
-                            var whitespace = ch == ByteTab || ch == ByteSpace || ch == ByteCR;
-
-                            if (!whitespace)
-                            {
-                                // Mark the first non whitespace char as the start of the
-                                // header value and change the state to expect to the header value
-                                valueStart = i;
-
-                                goto case HeaderState.ExpectValue;
-                            }
-                            // If we see a CR then jump to the next state directly
-                            else if (ch == ByteCR)
-                            {
-                                goto case HeaderState.ExpectValue;
-                            }
+                            goto case HeaderState.Whitespace;
                         }
 
-                        RejectRequest(RequestRejectionReason.MissingCRInHeaderLine);
-
-                        break;
-                    case HeaderState.ExpectValue:
-                        for (; i < headerLineLength; i++)
+                        if (ch == ByteSpace || ch == ByteTab)
                         {
-                            var ch = data[i];
-                            var whitespace = ch == ByteTab || ch == ByteSpace;
-
-                            if (whitespace)
-                            {
-                                if (!previouslyWhitespace)
-                                {
-                                    // If we see a whitespace char then maybe it's end of the
-                                    // header value
-                                    valueEnd = i;
-                                }
-                            }
-                            else if (ch == ByteCR)
-                            {
-                                // If we see a CR and we haven't ever seen whitespace then
-                                // this is the end of the header value
-                                if (valueEnd == -1)
-                                {
-                                    valueEnd = i;
-                                }
-
-                                // We never saw a non whitespace character before the CR
-                                if (valueStart == -1)
-                                {
-                                    valueStart = valueEnd;
-                                }
-
-                                // Consume space
-                                i++;
-
-                                goto case HeaderState.ExpectNewLine;
-                            }
-                            else
-                            {
-                                // If we find a non whitespace char that isn't CR then reset the end index
-                                valueEnd = -1;
-                            }
-
-                            previouslyWhitespace = whitespace;
+                            nameHasWhitespace = true;
                         }
-                        RejectRequest(RequestRejectionReason.MissingCRInHeaderLine);
-                        break;
-                    case HeaderState.ExpectNewLine:
-                        if (data[i] != ByteLF)
+                    }
+                    RejectRequest(RequestRejectionReason.NoColonCharacterFoundInHeaderLine);
+
+                    break;
+                case HeaderState.Whitespace:
+                    for (; i < headerLength; i++)
+                    {
+                        var ch = pHeader[i];
+                        var whitespace = ch == ByteTab || ch == ByteSpace || ch == ByteCR;
+
+                        if (!whitespace)
                         {
-                            RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                            // Mark the first non whitespace char as the start of the
+                            // header value and change the state to expect to the header value
+                            valueStart = i;
+
+                            goto case HeaderState.ExpectValue;
                         }
-                        goto case HeaderState.Complete;
-                    case HeaderState.Complete:
-                        done = true;
-                        break;
-                }
+                        // If we see a CR then jump to the next state directly
+                        else if (ch == ByteCR)
+                        {
+                            goto case HeaderState.ExpectValue;
+                        }
+                    }
+
+                    RejectRequest(RequestRejectionReason.MissingCRInHeaderLine);
+
+                    break;
+                case HeaderState.ExpectValue:
+                    for (; i < headerLength; i++)
+                    {
+                        var ch = pHeader[i];
+                        var whitespace = ch == ByteTab || ch == ByteSpace;
+
+                        if (whitespace)
+                        {
+                            if (!previouslyWhitespace)
+                            {
+                                // If we see a whitespace char then maybe it's end of the
+                                // header value
+                                valueEnd = i;
+                            }
+                        }
+                        else if (ch == ByteCR)
+                        {
+                            // If we see a CR and we haven't ever seen whitespace then
+                            // this is the end of the header value
+                            if (valueEnd == -1)
+                            {
+                                valueEnd = i;
+                            }
+
+                            // We never saw a non whitespace character before the CR
+                            if (valueStart == -1)
+                            {
+                                valueStart = valueEnd;
+                            }
+
+                            // Consume space
+                            i++;
+
+                            goto case HeaderState.ExpectNewLine;
+                        }
+                        else
+                        {
+                            // If we find a non whitespace char that isn't CR then reset the end index
+                            valueEnd = -1;
+                        }
+
+                        previouslyWhitespace = whitespace;
+                    }
+                    RejectRequest(RequestRejectionReason.MissingCRInHeaderLine);
+                    break;
+                case HeaderState.ExpectNewLine:
+                    if (pHeader[i] != ByteLF)
+                    {
+                        RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                    }
+                    goto case HeaderState.Complete;
+                case HeaderState.Complete:
+                    done = true;
+                    break;
             }
 
             return done;


### PR DESCRIPTION
- Pass pointers further down to TakeSingleHeader.
- Replace `span.Slice` with new `Span<byte>` to avoid bounds checks

## dev

|                             Method |      Mean |    StdErr |    StdDev | Scaled | Scaled-StdDev |        RPS |  Gen 0 | Allocated |
|----------------------------------- |---------- |---------- |---------- |------- |-------------- |----------- |------- |---------- |
|          ParsePlaintextTechEmpower | 2.6467 us | 0.0223 us | 0.1223 us |   1.00 |          0.00 | 377,835.86 |      - |     350 B |
| ParsePipelinedPlaintextTechEmpower | 2.6323 us | 0.0193 us | 0.1059 us |   1.00 |          0.06 | 379,891.41 |      - |     350 B |
|                    ParseLiveAspNet | 6.2356 us | 0.0924 us | 0.5062 us |   2.36 |          0.22 | 160,369.65 |      - |   1.12 kB |
|           ParsePipelinedLiveAspNet | 7.6393 us | 0.0600 us | 0.3286 us |   2.89 |          0.18 | 130,902.06 |      - |   1.12 kB |
|                       ParseUnicode |12.3045 us | 0.0978 us | 0.5355 us |   4.66 |          0.29 |  81,270.87 |      - |   1.97 kB |
|              ParseUnicodePipelined |15.2304 us | 0.0564 us | 0.3091 us |   5.77 |          0.28 |  65,658.24 | 0.0099 |   1.97 kB |



## davidfowl/more-pointers 

|                             Method |      Mean |    StdErr |    StdDev | Scaled | Scaled-StdDev |        RPS |  Gen 0 | Allocated |
|----------------------------------- |---------- |---------- |---------- |------- |-------------- |----------- |------- |---------- |
|          ParsePlaintextTechEmpower | 2.5530 us | 0.0094 us | 0.0514 us |   1.00 |          0.00 | 391,694.37 |      - |     350 B |
| ParsePipelinedPlaintextTechEmpower | 2.6083 us | 0.0252 us | 0.1378 us |   1.02 |          0.06 | 383,386.03 |      - |     350 B |
|                    ParseLiveAspNet | 6.1137 us | 0.0688 us | 0.3770 us |   2.40 |          0.15 | 163,567.54 |      - |   1.12 kB |
|           ParsePipelinedLiveAspNet | 7.5028 us | 0.0339 us | 0.1855 us |   2.94 |          0.09 | 133,283.91 |      - |   1.12 kB |
|                       ParseUnicode |12.1608 us | 0.0579 us | 0.3170 us |   4.77 |          0.15 |  82,231.66 |      - |   1.97 kB |
|              ParseUnicodePipelined |14.9371 us | 0.0709 us | 0.3883 us |   5.85 |          0.19 |  66,947.58 | 0.0137 |   1.97 kB |

PS: After adding those headers to the micro benchmarks, things look worse for pipelining in general (not sure why).