### PR TITLE
Interleave multispan and single span code path

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -289,13 +289,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                                 ch2 = reader.Take();
                             }
 
-                            if (ch1 == -1)
-                            {
-                                // Reset the reader so we don't consume anything
-                                reader = start;
-                                return false;
-                            }
-
                             if (ch1 == ByteCR)
                             {
                                 // Check for final CRLF.

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -263,8 +263,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 while (!reader.End)
                 {
                     var span = reader.Span;
-                    var length = span.Length;
-                    var remaining = length;
+                    var remaining = span.Length;
 
                     fixed (byte* pBuffer = &span.DangerousGetPinnableReference())
                     {
@@ -292,6 +291,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                             if (ch1 == -1)
                             {
+                                // Reset the reader so we don't consume anything
+                                reader = start;
                                 return false;
                             }
 
@@ -300,6 +301,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                                 // Check for final CRLF.
                                 if (ch2 == -1)
                                 {
+                                    // Reset the reader so we don't consume anything
+                                    reader = start;
                                     return false;
                                 }
                                 else if (ch2 == ByteLF)
@@ -322,7 +325,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                             Span<byte> headerSpan;
 
-                            var endIndex = IndexOf(pBuffer, index, length, ByteLF);
+                            var endIndex = IndexOf(pBuffer, index, remaining, ByteLF);
 
                             if (endIndex != -1)
                             {
@@ -383,11 +386,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         private unsafe int IndexOf(byte* pBuffer, int index, int length, byte value)
         {
-            for (int i = index; i < length; i++)
+            for (int i = 0; i < length; i++, index++)
             {
-                if (pBuffer[i] == value)
+                if (pBuffer[index] == value)
                 {
-                    return i;
+                    return index;
                 }
             }
             return -1;

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -204,6 +204,22 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
         [Fact]
+        public async Task TakeMessageHeadersConsumesBytesCorrectlyAtEnd()
+        {
+            await _socketInput.Writer.WriteAsync(Encoding.ASCII.GetBytes("Header-1: value1\r\n\r"));
+
+            var readableBuffer = (await _socketInput.Reader.ReadAsync()).Buffer;
+            Assert.False(_frame.TakeMessageHeaders(readableBuffer, out _consumed, out _examined));
+            _socketInput.Reader.Advance(_consumed, _examined);
+
+            await _socketInput.Writer.WriteAsync(Encoding.ASCII.GetBytes("\n"));
+
+            readableBuffer = (await _socketInput.Reader.ReadAsync()).Buffer;
+            Assert.True(_frame.TakeMessageHeaders(readableBuffer, out _consumed, out _examined));
+            _socketInput.Reader.Advance(_consumed, _examined);
+        }
+
+        [Fact]
         public async Task TakeMessageHeadersThrowsWhenHeadersExceedTotalSizeLimit()
         {
             const string headerLine = "Header: value\r\n";


### PR DESCRIPTION
This is an adaption of the @shiftylogic's parser idea. It relies on changes in corefxlab to expose the current `Span` and index from the `ReadableBufferReader`. There are some other optimizations that can be made here:
- Use more pointers (will do this after) see (https://github.com/aspnet/KestrelHttpServer/tree/davidfowl/single-header-perf)
- ~Don't pin the same span over and over. The trade off here is simpler code to maintain as a result of a few cheap instructions.~
- Don't slice, just use pointers to parse headers (maybe moot with fast span) see (https://github.com/aspnet/KestrelHttpServer/tree/davidfowl/single-header-perf)

TODO: 
- ~Merge the changes into corefxlab~
- ~Make mirror work @natemcmaster @pranavkm~
- ~Clean up the solution changes~

# Azure VM

## dev

|                             Method |       Mean |    StdErr |    StdDev | Scaled | Scaled-StdDev |        RPS |  Gen 0 | Allocated |
|----------------------------------- |----------- |---------- |---------- |------- |-------------- |----------- |------- |---------- |
|          ParsePlaintextTechEmpower |  2.6021 us | 0.0329 us | 0.1801 us |   1.00 |          0.00 | 384,298.53 |      - |     350 B |
| ParsePipelinedPlaintextTechEmpower |  2.5254 us | 0.0120 us | 0.0655 us |   0.97 |          0.06 | 395,970.94 |      - |     350 B |
|                    ParseLiveAspNet |  5.9584 us | 0.0682 us | 0.3733 us |   2.30 |          0.20 | 167,831.58 |      - |   1.12 kB |
|           ParsePipelinedLiveAspNet |  7.6718 us | 0.0474 us | 0.2595 us |   2.96 |          0.21 | 130,347.94 |      - |   1.12 kB |
|                       ParseUnicode | 12.5011 us | 0.1411 us | 0.7728 us |   4.82 |          0.42 |  79,992.76 |      - |   1.97 kB |
|              ParseUnicodePipelined | 15.1260 us | 0.0683 us | 0.3741 us |   5.84 |          0.38 |  66,111.18 | 0.0130 |   1.97 kB |


## davidfowl/new-reader

|                             Method |       Mean |    StdDev | Scaled | Scaled-StdDev |        RPS |  Gen 0 | Allocated |
|----------------------------------- |----------- |---------- |------- |-------------- |----------- |------- |---------- |
|          ParsePlaintextTechEmpower |  2.5903 us | 0.0643 us |   1.00 |          0.00 | 386,049.47 |      - |     350 B |
| ParsePipelinedPlaintextTechEmpower |  2.3856 us | 0.0909 us |   0.92 |          0.04 | 419,175.07 |      - |     350 B |
|                    ParseLiveAspNet |  5.9754 us | 0.1518 us |   2.31 |          0.08 | 167,352.43 |      - |   1.12 kB |
|           ParsePipelinedLiveAspNet |  5.7275 us | 0.2394 us |   2.21 |          0.11 | 174,597.37 |      - |   1.12 kB |
|                       ParseUnicode | 12.2032 us | 0.3343 us |   4.71 |          0.17 |  81,945.73 |      - |   1.97 kB |
|              ParseUnicodePipelined | 12.1986 us | 0.3692 us |   4.71 |          0.18 |  81,976.80 | 0.0061 |   1.97 kB |