### PR TITLE
Seal safehandles to devirtualize

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/Libuv.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/Libuv.cs
@@ -302,10 +302,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             handle.Validate();
             ThrowIfErrored(_uv_write(req, handle, bufs, nbufs, cb));
         }
+        unsafe public void write(UvWriteReq req, UvStreamHandle handle, uv_buf_t* bufs, int nbufs, uv_write_cb cb)
+        {
+            req.Validate();
+            handle.Validate();
+            ThrowIfErrored(_uv_write(req, handle, bufs, nbufs, cb));
+        }
 
         unsafe protected delegate int uv_write2_func(UvRequest req, UvStreamHandle handle, uv_buf_t* bufs, int nbufs, UvStreamHandle sendHandle, uv_write_cb cb);
         protected uv_write2_func _uv_write2;
         unsafe public void write2(UvRequest req, UvStreamHandle handle, Libuv.uv_buf_t* bufs, int nbufs, UvStreamHandle sendHandle, uv_write_cb cb)
+        {
+            req.Validate();
+            handle.Validate();
+            ThrowIfErrored(_uv_write2(req, handle, bufs, nbufs, sendHandle, cb));
+        }
+        unsafe public void write2(UvWriteReq req, UvStreamHandle handle, Libuv.uv_buf_t* bufs, int nbufs, UvStreamHandle sendHandle, uv_write_cb cb)
         {
             req.Validate();
             handle.Validate();

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvAsyncHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvAsyncHandle.cs
@@ -8,7 +8,8 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
-    public class UvAsyncHandle : UvHandle
+    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
+    public sealed class UvAsyncHandle : UvHandle
     {
         private static readonly Libuv.uv_close_cb _destroyMemory = (handle) => DestroyMemory(handle);
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvConnectRequest.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvConnectRequest.cs
@@ -10,7 +10,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
     /// <summary>
     /// Summary description for UvWriteRequest
     /// </summary>
-    public class UvConnectRequest : UvRequest
+    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
+    public sealed class UvConnectRequest : UvRequest
     {
         private readonly static Libuv.uv_connect_cb _uv_connect_cb = (req, status) => UvConnectCb(req, status);
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvException.cs
@@ -5,7 +5,8 @@ using System;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
-    public class UvException : Exception
+    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
+    public sealed class UvException : Exception
     {
         public UvException(string message, int statusCode) : base(message)
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvLoopHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvLoopHandle.cs
@@ -7,8 +7,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
-    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
-    public sealed class UvLoopHandle : UvMemory
+    public class UvLoopHandle : UvMemory
     {
         public UvLoopHandle(IKestrelTrace logger) : base(logger)
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvLoopHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvLoopHandle.cs
@@ -7,7 +7,8 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
-    public class UvLoopHandle : UvMemory
+    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
+    public sealed class UvLoopHandle : UvMemory
     {
         public UvLoopHandle(IKestrelTrace logger) : base(logger)
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvPipeHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvPipeHandle.cs
@@ -6,7 +6,8 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
-    public class UvPipeHandle : UvStreamHandle
+    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
+    public sealed class UvPipeHandle : UvStreamHandle
     {
         public UvPipeHandle(IKestrelTrace logger) : base(logger)
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvShutdownReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvShutdownReq.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
     /// <summary>
     /// Summary description for UvShutdownRequest
     /// </summary>
-    public class UvShutdownReq : UvRequest
+    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
+    public sealed class UvShutdownReq : UvRequest
     {
         private readonly static Libuv.uv_shutdown_cb _uv_shutdown_cb = UvShutdownCb;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvStreamHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvStreamHandle.cs
@@ -127,8 +127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         {
             var stream = FromIntPtr<UvStreamHandle>(handle);
 
-            Exception error;
-            stream.Libuv.Check(status, out error);
+            stream.Libuv.Check(status, out Exception error);
 
             try
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvTcpHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvTcpHandle.cs
@@ -8,8 +8,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
-    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
-    public sealed class UvTcpHandle : UvStreamHandle
+    public class UvTcpHandle : UvStreamHandle
     {
         public UvTcpHandle(IKestrelTrace logger) : base(logger)
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvTcpHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvTcpHandle.cs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
-    public class UvTcpHandle : UvStreamHandle
+    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
+    public sealed class UvTcpHandle : UvStreamHandle
     {
         public UvTcpHandle(IKestrelTrace logger) : base(logger)
         {
@@ -32,16 +32,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 
         public void Bind(IPEndPoint endPoint)
         {
-            SockAddr addr;
             var addressText = endPoint.Address.ToString();
 
-            Exception error1;
-            _uv.ip4_addr(addressText, endPoint.Port, out addr, out error1);
+            _uv.ip4_addr(addressText, endPoint.Port, out SockAddr addr, out Exception error1);
 
             if (error1 != null)
             {
-                Exception error2;
-                _uv.ip6_addr(addressText, endPoint.Port, out addr, out error2);
+                _uv.ip6_addr(addressText, endPoint.Port, out addr, out Exception error2);
                 if (error2 != null)
                 {
                     throw error1;
@@ -53,18 +50,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 
         public IPEndPoint GetPeerIPEndPoint()
         {
-            SockAddr socketAddress;
             int namelen = Marshal.SizeOf<SockAddr>();
-            _uv.tcp_getpeername(this, out socketAddress, ref namelen);
+            _uv.tcp_getpeername(this, out SockAddr socketAddress, ref namelen);
 
             return socketAddress.GetIPEndPoint();
         }
 
         public IPEndPoint GetSockIPEndPoint()
         {
-            SockAddr socketAddress;
             int namelen = Marshal.SizeOf<SockAddr>();
-            _uv.tcp_getsockname(this, out socketAddress, ref namelen);
+            _uv.tcp_getsockname(this, out SockAddr socketAddress, ref namelen);
 
             return socketAddress.GetIPEndPoint();
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvTimerHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvTimerHandle.cs
@@ -7,7 +7,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
-    public class UvTimerHandle : UvHandle
+    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
+    public sealed class UvTimerHandle : UvHandle
     {
         private readonly static Libuv.uv_timer_cb _uv_timer_cb = UvTimerCb;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvWriteReq.cs
@@ -12,7 +12,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
     /// <summary>
     /// Summary description for UvWriteRequest
     /// </summary>
-    public class UvWriteReq : UvRequest
+    // Seal to devirtualize the virtuals https://github.com/dotnet/coreclr/pull/9230
+    public sealed class UvWriteReq : UvRequest
     {
         private readonly static Libuv.uv_write_cb _uv_write_cb = (IntPtr ptr, int status) => UvWriteCb(ptr, status);
 


### PR DESCRIPTION
Seal the bottom level of safehandles to allow devirtualization of the safehandle calls https://github.com/dotnet/coreclr/pull/9230

Much as I don't like `sealed`; this does now have advantages and some of them are hot methods... And not sure they will be expected to be further derived?

```
Devirtualized call to SafeHandle:get_IsInvalid to directly call SafeFindHandle:get_IsInvalid
Devirtualized call to SafeHandle:Dispose to directly call SafeHandle:Dispose
Devirtualized call to UvRequest:Pin to directly call UvRequest:Pin
Devirtualized call to UvRequest:Unpin to directly call UvRequest:Unpin
Devirtualized call to SafeHandle:Dispose to directly call SafeHandle:Dispose
Devirtualized call to SafeHandle:Dispose to directly call SafeHandle:Dispose
Devirtualized call to SafeHandle:Dispose to directly call SafeHandle:Dispose
Devirtualized call to UvRequest:Unpin to directly call UvRequest:Unpin
Devirtualized call to SafeHandle:Dispose to directly call SafeHandle:Dispose
```

/cc @davidfowl 