### PR TITLE
SocketOutput WriteReq

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
 
             int bytesProduced, buffersIncluded;
-            BytesBetween(_lastStart, end, out bytesProduced, out buffersIncluded);
+            BytesBetween(ref _lastStart, ref end, out bytesProduced, out buffersIncluded);
 
             lock (_contextLock)
             {
@@ -356,10 +356,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 ScheduleWrite();
             }
 
-            if (writingContext != null)
-            {
-                writingContext.DoWriteIfNeeded();
-            }
+            writingContext?.DoWriteIfNeeded();
         }
 
         // This may called on the libuv event loop
@@ -387,7 +384,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             if (error == null)
             {
-                CompleteFinishedWrites(status);
+                CompleteFinishedWrites();
                 _log.ConnectionWriteCallback(_connectionId, status);
             }
             else
@@ -452,7 +449,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
         }
 
-        private void CompleteFinishedWrites(int status)
+        private void CompleteFinishedWrites()
         {
             if (!_maxBytesPreCompleted.HasValue)
             {
@@ -554,7 +551,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             return WriteAsync(_emptyData, cancellationToken);
         }
 
-        private static void BytesBetween(MemoryPoolIterator start, MemoryPoolIterator end, out int bytes, out int buffers)
+        private static void BytesBetween(ref MemoryPoolIterator start, ref MemoryPoolIterator end, out int bytes, out int buffers)
         {
             if (start.Block == end.Block)
             {
@@ -598,9 +595,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             
             private readonly SocketOutput Self;
             private SocketOutputWriteReq _writeReq;
-            private MemoryPoolIterator _lockedStart;
-            private MemoryPoolIterator _lockedEnd;
-            private int _bufferCount;
+            internal MemoryPoolIterator _lockedStart;
+            internal MemoryPoolIterator _lockedEnd;
+            internal int _bufferCount;
 
             public int ByteCount;
             public bool SocketShutdownSend;
@@ -634,7 +631,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                 _writeReq = Self._writeReqPool.Allocate();
 
-                _writeReq.Write(Self._socket, _lockedStart, _lockedEnd, _bufferCount, this);
+                _writeReq.Write(Self._socket, this);
             }
 
             public void WriteCallback(int status, Exception error)
@@ -793,7 +790,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 _lockedStart = new MemoryPoolIterator(head, head.Start);
                 _lockedEnd = new MemoryPoolIterator(tail, tail.End);
 
-                BytesBetween(_lockedStart, _lockedEnd, out ByteCount, out _bufferCount);
+                BytesBetween(ref _lockedStart, ref _lockedEnd, out ByteCount, out _bufferCount);
             }
 
             public void Reset()

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
@@ -597,7 +597,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             private SocketOutputWriteReq _writeReq;
             internal MemoryPoolIterator _lockedStart;
             internal MemoryPoolIterator _lockedEnd;
-            internal int _bufferCount;
+            private int _bufferCount;
 
             public int ByteCount;
             public bool SocketShutdownSend;
@@ -631,7 +631,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                 _writeReq = Self._writeReqPool.Allocate();
 
-                _writeReq.Write(Self._socket, this);
+                _writeReq.Write(Self._socket, this, _bufferCount);
             }
 
             public void WriteCallback(int status, Exception error)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/WriteReqPool.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/WriteReqPool.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         private const int _maxPooledWriteReqs = 1024;
 
         private readonly KestrelThread _thread;
-        private readonly Queue<UvWriteReq> _pool = new Queue<UvWriteReq>(_maxPooledWriteReqs);
+        private readonly Queue<SocketOutputWriteReq> _pool = new Queue<SocketOutputWriteReq>(_maxPooledWriteReqs);
         private readonly IKestrelTrace _log;
         private bool _disposed;
 
@@ -19,28 +19,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
             _log = log;
         }
 
-        public UvWriteReq Allocate()
+        public SocketOutputWriteReq Allocate()
         {
             if (_disposed)
             {
                 throw new ObjectDisposedException(GetType().Name);
             }
 
-            UvWriteReq req;
+            SocketOutputWriteReq req;
             if (_pool.Count > 0)
             {
                 req = _pool.Dequeue();
             }
             else
             {
-                req = new UvWriteReq(_log);
+                req = new SocketOutputWriteReq(_log);
                 req.Init(_thread.Loop);
             }
 
             return req;
         }
 
-        public void Return(UvWriteReq req)
+        public void Return(SocketOutputWriteReq req)
         {
             if (_disposed)
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/SocketOutputWriteReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/SocketOutputWriteReq.cs
@@ -15,15 +15,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
     /// </summary>
     public class SocketOutputWriteReq : UvRequest
     {
+        private const int BUFFER_COUNT = 4;
         private readonly static Libuv.uv_write_cb _uv_write_cb = 
             (IntPtr ptr, int status) => FromIntPtr<SocketOutputWriteReq>(ptr).UvWriteCallback(status);
 
-        private IntPtr _bufs;
-
-        private SocketOutput.WriteContext _writeContext;
-        private const int BUFFER_COUNT = 4;
-
         private readonly List<GCHandle> _pins = new List<GCHandle>(BUFFER_COUNT + 1);
+
+        private IntPtr _bufs;
+        private SocketOutput.WriteContext _writeContext;
 
         public SocketOutputWriteReq(IKestrelTrace logger) : base(logger)
         {
@@ -42,11 +41,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 
         public unsafe void Write(
             UvStreamHandle handle,
-            SocketOutput.WriteContext context)
+            SocketOutput.WriteContext context,
+            int bufferCount)
         {
             try
             {
-                var bufferCount = context._bufferCount;
                 // add GCHandle to keeps this SafeHandle alive while request processing
                 _pins.Add(GCHandle.Alloc(this, GCHandleType.Normal));
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/SocketOutputWriteReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/SocketOutputWriteReq.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
+{
+    /// <summary>
+    /// Summary description for SocketOutputWriteReq
+    /// </summary>
+    public class SocketOutputWriteReq : UvRequest
+    {
+        private readonly static Libuv.uv_write_cb _uv_write_cb = 
+            (IntPtr ptr, int status) => FromIntPtr<SocketOutputWriteReq>(ptr).UvWriteCallback(status);
+
+        private IntPtr _bufs;
+
+        private SocketOutput.WriteContext _writeContext;
+        private const int BUFFER_COUNT = 4;
+
+        private readonly List<GCHandle> _pins = new List<GCHandle>(BUFFER_COUNT + 1);
+
+        public SocketOutputWriteReq(IKestrelTrace logger) : base(logger)
+        {
+        }
+
+        public void Init(UvLoopHandle loop)
+        {
+            var requestSize = loop.Libuv.req_size(Libuv.RequestType.WRITE);
+            var bufferSize = Marshal.SizeOf<Libuv.uv_buf_t>() * BUFFER_COUNT;
+            CreateMemory(
+                loop.Libuv,
+                loop.ThreadId,
+                requestSize + bufferSize);
+            _bufs = handle + requestSize;
+        }
+
+        public unsafe void Write(
+            UvStreamHandle handle,
+            MemoryPoolIterator start,
+            MemoryPoolIterator end,
+            int nBuffers,
+            SocketOutput.WriteContext writeContext)
+        {
+            try
+            {
+                // add GCHandle to keeps this SafeHandle alive while request processing
+                _pins.Add(GCHandle.Alloc(this, GCHandleType.Normal));
+
+                var pBuffers = (Libuv.uv_buf_t*)_bufs;
+                if (nBuffers > BUFFER_COUNT)
+                {
+                    // create and pin buffer array when it's larger than the pre-allocated one
+                    var bufArray = new Libuv.uv_buf_t[nBuffers];
+                    var gcHandle = GCHandle.Alloc(bufArray, GCHandleType.Pinned);
+                    _pins.Add(gcHandle);
+                    pBuffers = (Libuv.uv_buf_t*)gcHandle.AddrOfPinnedObject();
+                }
+
+                var block = start.Block;
+                for (var index = 0; index < nBuffers; index++)
+                {
+                    var blockStart = block == start.Block ? start.Index : block.Data.Offset;
+                    var blockEnd = block == end.Block ? end.Index : block.Data.Offset + block.Data.Count;
+
+                    // create and pin each segment being written
+                    pBuffers[index] = Libuv.buf_init(
+                        block.DataArrayPtr + blockStart,
+                        blockEnd - blockStart);
+
+                    block = block.Next;
+                }
+
+                _writeContext = writeContext;
+                _uv.write(this, handle, pBuffers, nBuffers, _uv_write_cb);
+            }
+            catch
+            {
+                _writeContext = null;
+                UnpinGcHandles();
+                throw;
+            }
+        }
+
+        private void UnpinGcHandles()
+        {
+            var count = _pins.Count;
+            for (var i = 0; i < count; i++)
+            {
+                _pins[i].Free();
+            }
+            _pins.Clear();
+        }
+
+        private void UvWriteCallback(int status)
+        {
+            UnpinGcHandles();
+
+            var writeContext = _writeContext;
+            _writeContext = null;
+
+            Exception error = null;
+            if (status < 0)
+            {
+                Libuv.Check(status, out error);
+            }
+
+            try
+            {
+                writeContext.WriteCallback(status, error);
+            }
+            catch (Exception ex)
+            {
+                _log.LogError(0, ex, "UvWriteCallback");
+                throw;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvWriteReq.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private object _state;
         private const int BUFFER_COUNT = 4;
 
-        private List<GCHandle> _pins = new List<GCHandle>(BUFFER_COUNT + 1);
+        private readonly List<GCHandle> _pins = new List<GCHandle>(BUFFER_COUNT + 1);
 
         public UvWriteReq(IKestrelTrace logger) : base(logger)
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Networking/UvWriteReq.cs
@@ -14,7 +14,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
     /// </summary>
     public class UvWriteReq : UvRequest
     {
-        private readonly static Libuv.uv_write_cb _uv_write_cb = (IntPtr ptr, int status) => UvWriteCb(ptr, status);
+        private readonly static Libuv.uv_write_cb _uv_write_cb = 
+            (IntPtr ptr, int status) => FromIntPtr<UvWriteReq>(ptr).UvWriteCb(status);
 
         private IntPtr _bufs;
 
@@ -84,7 +85,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             {
                 _callback = null;
                 _state = null;
-                Unpin(this);
+                UnpinGcHandles();
                 throw;
             }
         }
@@ -159,44 +160,44 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
             {
                 _callback = null;
                 _state = null;
-                Unpin(this);
+                UnpinGcHandles();
                 throw;
             }
         }
 
-        private static void Unpin(UvWriteReq req)
+        private void UnpinGcHandles()
         {
-            foreach (var pin in req._pins)
+            var count = _pins.Count;
+            for (var i = 0; i < count; i++)
             {
-                pin.Free();
+                _pins[i].Free();
             }
-            req._pins.Clear();
+            _pins.Clear();
         }
 
-        private static void UvWriteCb(IntPtr ptr, int status)
+        private void UvWriteCb(int status)
         {
-            var req = FromIntPtr<UvWriteReq>(ptr);
-            Unpin(req);
+            UnpinGcHandles();
 
-            var callback = req._callback;
-            req._callback = null;
+            var callback = _callback;
+            _callback = null;
 
-            var state = req._state;
-            req._state = null;
+            var state = _state;
+            _state = null;
 
             Exception error = null;
             if (status < 0)
             {
-                req.Libuv.Check(status, out error);
+                Libuv.Check(status, out error);
             }
 
             try
             {
-                callback(req, status, error, state);
+                callback(this, status, error, state);
             }
             catch (Exception ex)
             {
-                req._log.LogError(0, ex, "UvWriteCb");
+                _log.LogError(0, ex, "UvWriteCb");
                 throw;
             }
         }


### PR DESCRIPTION
* Extract SocketOutput WriteReq from WriteReq and simplify
* Reduce parameter passing (less on stack passing)
* List indexer for clearing rather than heavier List enumerator
* Resolve this pointer in Action to simplify functions (drop `req.`)
* Move some functions that were all `Self.` into SocketOutput
