### PR TITLE
Early non ascii reject

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
@@ -67,6 +67,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 case RequestRejectionReason.InvalidCharactersInHeaderName:
                     ex = new BadHttpRequestException("Invalid characters in header name.", StatusCodes.Status400BadRequest);
                     break;
+                case RequestRejectionReason.NonAsciiOrNullCharactersInHeader:
+                    ex = new BadHttpRequestException("Invalid characters in header.", StatusCodes.Status400BadRequest);
+                    break;
                 case RequestRejectionReason.NonAsciiOrNullCharactersInInputString:
                     ex = new BadHttpRequestException("The input string contains non-ASCII or null characters.", StatusCodes.Status400BadRequest);
                     break;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -1289,7 +1289,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             {
                 RejectRequest(RequestRejectionReason.TooManyHeaders);
             }
-            var valueString = value.GetAsciiStringNonNullCharacters();
+            var valueString = value.GetPrevalidatedAsciiString();
 
             FrameRequestHeaders.Append(name, valueString);
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         PathContainsNullCharacters,
         InvalidCharactersInHeaderName,
         NonAsciiOrNullCharactersInInputString,
+        NonAsciiOrNullCharactersInHeader,
         RequestLineTooLong,
         HeadersExceedMaxTotalSize,
         MissingCRInHeaderLine,

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/AsciiUtilities.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/AsciiUtilities.cs
@@ -75,5 +75,61 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
             return isValid;
         }
+
+        public static unsafe void GetPrevalidatedAsciiString(byte* pInput, char* pOutput, int count)
+        {
+            var remaining = count;
+            var input = pInput;
+            var output = pOutput;
+
+            while (remaining - 11 > 0)
+            {
+                remaining -= 12;
+                output[0] = (char)input[0];
+                output[1] = (char)input[1];
+                output[2] = (char)input[2];
+                output[3] = (char)input[3];
+                output[4] = (char)input[4];
+                output[5] = (char)input[5];
+                output[6] = (char)input[6];
+                output[7] = (char)input[7];
+                output[8] = (char)input[8];
+                output[9] = (char)input[9];
+                output[10] = (char)input[10];
+                output[11] = (char)input[11];
+                output += 12;
+                input += 12;
+            }
+            if (remaining - 5 > 0)
+            {
+                remaining -= 6;
+                output[0] = (char)input[0];
+                output[1] = (char)input[1];
+                output[2] = (char)input[2];
+                output[3] = (char)input[3];
+                output[4] = (char)input[4];
+                output[5] = (char)input[5];
+                output += 6;
+                input += 6;
+            }
+            if (remaining - 3 > 0)
+            {
+                remaining -= 4;
+                output[0] = (char)input[0];
+                output[1] = (char)input[1];
+                output[2] = (char)input[2];
+                output[3] = (char)input[3];
+                output += 4;
+                input += 4;
+            }
+
+            while (remaining > 0)
+            {
+                remaining--;
+                output[0] = (char)input[0];
+                output++;
+                input++;
+            }
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
@@ -94,6 +94,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
             }
         }
 
+        public unsafe static string GetPrevalidatedAsciiString(this Span<byte> span)
+        {
+            string asciiString;
+            if (span.IsEmpty)
+            {
+                asciiString = string.Empty;
+            }
+            else
+            {
+                asciiString = new string('\0', span.Length);
+
+                fixed (char* output = asciiString)
+                fixed (byte* buffer = &span.DangerousGetPinnableReference())
+                {
+                    // This version if AsciiUtilities is for where the string has been validated during scan
+                    AsciiUtilities.GetPrevalidatedAsciiString(buffer, output, span.Length);
+                }
+            }
+
+            return asciiString;
+        }
+
         public unsafe static string GetAsciiStringNonNullCharacters(this Span<byte> span)
         {
             if (span.IsEmpty)

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/BadHttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/BadHttpRequestTests.cs
@@ -47,10 +47,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-        [InlineData("Hea\0der: value", "Invalid characters in header name.")]
-        [InlineData("Header: va\0lue", "Malformed request: invalid headers.")]
-        [InlineData("Head\x80r: value", "Invalid characters in header name.")]
-        [InlineData("Header: valu\x80", "Malformed request: invalid headers.")]
+        [InlineData("Hea\0der: value", "Invalid characters in header.")]
+        [InlineData("Header: va\0lue", "Invalid characters in header.")]
+        [InlineData("Head\x80r: value", "Invalid characters in header.")]
+        [InlineData("Header: valu\x80", "Invalid characters in header.")]
         public Task BadRequestWhenHeaderNameContainsNonASCIIOrNullCharacters(string header, string expectedExceptionMessage)
         {
             return TestBadRequest(


### PR DESCRIPTION
Reject non-ascii or nulls in headers early, during seek, rather than when creating string.

(Also makes vector string creation using Vector.Widen when available more straight forward)