### PR TITLE
Fix write size in benchmark

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
@@ -121,8 +121,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         private void InsertData(byte[] bytes)
         {
+            var buffer = Pipe.Writer.Alloc(2048);
+            buffer.Write(bytes);
             // There should not be any backpressure and task completes immediately
-            Pipe.Writer.WriteAsync(bytes).GetAwaiter().GetResult();
+            buffer.FlushAsync().GetAwaiter().GetResult();
         }
 
         private void ParseData()


### PR DESCRIPTION
feature/dev-si uses a 2K minimum block to write to. Making that same adjustment here so things are more similar.