### PR TITLE
Made changes to TakeSingleHeader

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
@@ -25,9 +25,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 case RequestRejectionReason.HeadersCorruptedInvalidHeaderSequence:
                     ex = new BadHttpRequestException("Headers corrupted, invalid header sequence.", StatusCodes.Status400BadRequest);
                     break;
-                case RequestRejectionReason.HeaderLineMustNotStartWithWhitespace:
-                    ex = new BadHttpRequestException("Header line must not start with whitespace.", StatusCodes.Status400BadRequest);
-                    break;
                 case RequestRejectionReason.NoColonCharacterFoundInHeaderLine:
                     ex = new BadHttpRequestException("No ':' character found in header line.", StatusCodes.Status400BadRequest);
                     break;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -426,12 +426,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         private unsafe void TakeSingleHeader<T>(byte* pHeader, int headerLineLength, T handler) where T : IHttpHeadersHandler
         {
-            var nameStart = 0;
             var nameEnd = -1;
             var valueStart = -1;
             var valueEnd = -1;
             var index = 0;
-
             var pCurrent = pHeader + index;
             var pEnd = pHeader + headerLineLength;
 
@@ -515,7 +513,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
 
 
-            var nameBuffer = new Span<byte>(pHeader + nameStart, nameEnd - nameStart);
+            var nameBuffer = new Span<byte>(pHeader, nameEnd);
             var valueBuffer = new Span<byte>(pHeader + valueStart, valueEnd - valueStart);
 
             handler.OnHeader(nameBuffer, valueBuffer);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -329,11 +329,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                                 index = reader.Index;
                             }
 
-                            var endIndex = IndexOf(pBuffer, index, remaining, ByteLF);
+                            var endIndex = new Span<byte>(pBuffer + index, remaining).IndexOfVectorized(ByteLF);
                             var length = 0;
 
                             if (endIndex != -1)
                             {
+                                endIndex += index;
                                 length = (endIndex - index + 1);
                                 var pHeader = pBuffer + index;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -334,8 +334,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
                             if (endIndex != -1)
                             {
-                                endIndex += index;
-                                length = (endIndex - index + 1);
+                                length = endIndex + 1;
                                 var pHeader = pBuffer + index;
 
                                 TakeSingleHeader(pHeader, length, handler);
@@ -354,17 +353,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                                 // Make sure LF is included in lineEnd
                                 lineEnd = buffer.Move(lineEnd, 1);
                                 var headerSpan = buffer.Slice(current, lineEnd).ToSpan();
+                                length = headerSpan.Length;
 
                                 fixed (byte* pHeader = &headerSpan.DangerousGetPinnableReference())
                                 {
-                                    TakeSingleHeader(pHeader, headerSpan.Length, handler);
+                                    TakeSingleHeader(pHeader, length, handler);
                                 }
 
                                 // We're going to the next span after this since we know we crossed spans here
                                 // so mark the remaining as equal to the headerSpan so that we end up at 0
                                 // on the next iteration
-                                remaining = headerSpan.Length;
-                                length = headerSpan.Length;
+                                remaining = length;
                             }
 
                             // Skip the reader forward past the header line
@@ -388,7 +387,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
         }
 
-        private unsafe int IndexOf(byte* pBuffer, int index, int length, byte value)
+        private unsafe static int IndexOf(byte* pBuffer, int index, int length, byte value)
         {
             var pCurrent = pBuffer + index;
             var pEnd = pBuffer + index + length;
@@ -406,7 +405,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             return -1;
         }
 
-        private unsafe int IndexOfAny(byte* pBuffer, int index, int length, byte value, byte value1)
+        private unsafe static int IndexOfAny(byte* pBuffer, int index, int length, byte value, byte value1)
         {
             var pCurrent = pBuffer + index;
             var pEnd = pBuffer + index + length;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
@@ -7,7 +7,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
     {
         UnrecognizedHTTPVersion,
         HeadersCorruptedInvalidHeaderSequence,
-        HeaderLineMustNotStartWithWhitespace,
         NoColonCharacterFoundInHeaderLine,
         WhitespaceIsNotAllowedInHeaderName,
         HeaderValueMustNotContainCR,

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -200,7 +200,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var exception = Assert.Throws<BadHttpRequestException>(() => _frame.TakeMessageHeaders(readableBuffer, out _consumed, out _examined));
             _socketInput.Reader.Advance(_consumed, _examined);
 
-            Assert.Equal("Header line must not start with whitespace.", exception.Message);
+            Assert.Equal("Whitespace is not allowed in header name.", exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
         }
 

--- a/test/shared/HttpParsingData.cs
+++ b/test/shared/HttpParsingData.cs
@@ -254,10 +254,10 @@ namespace Microsoft.AspNetCore.Testing
 
                 return new[]
                 {
-                    Tuple.Create(headersWithLineFolding,"Header line must not start with whitespace."),
+                    Tuple.Create(headersWithLineFolding,"Whitespace is not allowed in header name."),
                     Tuple.Create(headersWithCRInValue,"Header value must not contain CR characters."),
                     Tuple.Create(headersWithMissingColon,"No ':' character found in header line."),
-                    Tuple.Create(headersStartingWithWhitespace, "Header line must not start with whitespace."),
+                    Tuple.Create(headersStartingWithWhitespace, "Whitespace is not allowed in header name."),
                     Tuple.Create(headersWithWithspaceInName,"Whitespace is not allowed in header name."),
                     Tuple.Create(headersNotEndingInCrLfLine, "Headers corrupted, invalid header sequence.")
                 }


### PR DESCRIPTION
- Remove state machine and just parse inplace
- Added IndexOfAny for searching 2 chars at a time
- More pointers
- Don't slice

## RequestParsing benchmark

### dev

|                        Method |       Mean |    StdDev | Scaled | Scaled-StdDev |        RPS |  Gen 0 | Allocated |
|------------------------------ |----------- |---------- |------- |-------------- |----------- |------- |---------- |
|          PlaintextTechEmpower |  2.5691 us | 0.1031 us |   1.00 |          0.00 | 389,246.86 |      - |     353 B |
| PipelinedPlaintextTechEmpower |  2.2885 us | 0.1139 us |   0.89 |          0.05 | 436,959.96 |      - |     351 B |
|                    LiveAspNet |  5.8064 us | 0.2190 us |   2.26 |          0.12 | 172,225.11 |      - |   1.12 kB |
|           PipelinedLiveAspNet |  5.6643 us | 0.1752 us |   2.21 |          0.10 | 176,545.49 |      - |   1.11 kB |
|                       Unicode | 12.3019 us | 0.4957 us |   4.80 |          0.26 |  81,288.54 |      - |   1.99 kB |
|              UnicodePipelined | 11.8838 us | 0.3702 us |   4.63 |          0.22 |  84,148.19 | 0.0099 |   1.98 kB |

### davidfowl/single-header-perf

|                       Method  |       Mean |    StdDev | Scaled | Scaled-StdDev |        RPS |  Gen 0 | Allocated |
|------------------------------ |----------- |---------- |------- |-------------- |----------- |------- |---------- |
|          PlaintextTechEmpower |  2.4826 us | 0.0840 us |   1.00 |          0.00 | 402,797.50 |      - |     353 B |
| PipelinedPlaintextTechEmpower |  2.0533 us | 0.0470 us |   0.83 |          0.03 | 487,016.97 |      - |     351 B |
|                    LiveAspNet |  5.3652 us | 0.2517 us |   2.16 |          0.12 | 186,387.57 |      - |   1.12 kB |
|           PipelinedLiveAspNet |  4.9812 us | 0.2238 us |   2.01 |          0.11 | 200,756.85 |      - |   1.11 kB |
|                       Unicode | 11.3353 us | 0.5430 us |   4.57 |          0.26 |  88,220.17 |      - |   1.99 kB |
|              UnicodePipelined | 11.0917 us | 0.2596 us |   4.47 |          0.18 |  90,157.72 | 0.0168 |   1.98 kB |

## KestrelHttpParser benchmark

## dev

|               Method |      Mean |    StdErr |    StdDev | Scaled | Scaled-StdDev |        RPS | Allocated |
|--------------------- |---------- |---------- |---------- |------- |-------------- |----------- |---------- |
| PlaintextTechEmpower | 1.0719 us | 0.0089 us | 0.0487 us |   1.00 |          0.00 | 932,916.09 |     112 B |
|           LiveAspNet | 2.3803 us | 0.0291 us | 0.1596 us |   2.22 |          0.17 | 420,111.66 |     112 B |
|              Unicode | 3.6295 us | 0.0443 us | 0.2429 us |   3.39 |          0.26 | 275,522.81 |     112 B |


## davidfowl/single-header-perf

|               Method |          Mean |     StdErr |      StdDev | Scaled | Scaled-StdDev |          RPS | Allocated |
|--------------------- |-------------- |----------- |------------ |------- |-------------- |------------- |---------- |
| PlaintextTechEmpower |   934.1457 ns |  9.0302 ns |  49.4607 ns |   1.00 |          0.00 | 1,070,496.77 |     112 B |
|           LiveAspNet | 1,943.4022 ns | 21.2818 ns | 116.5653 ns |   2.09 |          0.16 |   514,561.54 |     112 B |
|              Unicode | 2,714.1540 ns | 21.6340 ns | 118.4945 ns |   2.91 |          0.18 |   368,438.94 |     112 B |