### PR TITLE
Sanitize

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
@@ -25,9 +25,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 case RequestRejectionReason.HeadersCorruptedInvalidHeaderSequence:
                     ex = new BadHttpRequestException("Headers corrupted, invalid header sequence.", StatusCodes.Status400BadRequest);
                     break;
-                case RequestRejectionReason.HeaderLineMustNotStartWithWhitespace:
-                    ex = new BadHttpRequestException("Header line must not start with whitespace.", StatusCodes.Status400BadRequest);
-                    break;
                 case RequestRejectionReason.NoColonCharacterFoundInHeaderLine:
                     ex = new BadHttpRequestException("No ':' character found in header line.", StatusCodes.Status400BadRequest);
                     break;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -427,7 +427,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             if (headerStart[valueEnd + 2] != ByteLF)
             {
-                RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                goto headerValueContainsCR;
             }
             if (headerStart[valueEnd + 1] != ByteCR)
             {
@@ -446,7 +446,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 }
                 else if (ch == ByteCR)
                 {
-                    RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                    goto headerValueContainsCR;
                 }
             }
 
@@ -463,7 +463,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     {
                         if (!Vector<byte>.Zero.Equals(Vector.Equals(vByteCR, Unsafe.Read<Vector<byte>>(headerStart + i))))
                         {
-                            RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                            goto headerValueContainsCR;
                         }
 
                         i += Vector<byte>.Count;
@@ -477,7 +477,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 var ch = headerStart[i];
                 if (ch == ByteCR)
                 {
-                    RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                    goto headerValueContainsCR;
                 }
             }
 
@@ -495,6 +495,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             var valueBuffer = new Span<byte>(headerStart + valueStart, valueEnd - valueStart + 1);
 
             handler.OnHeader(nameBuffer, valueBuffer);
+            return;
+        headerValueContainsCR:
+            RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
         }
 
         private static bool IsValidTokenChar(char c)

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
@@ -7,7 +7,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
     {
         UnrecognizedHTTPVersion,
         HeadersCorruptedInvalidHeaderSequence,
-        HeaderLineMustNotStartWithWhitespace,
         NoColonCharacterFoundInHeaderLine,
         WhitespaceIsNotAllowedInHeaderName,
         HeaderValueMustNotContainCR,

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -200,7 +200,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var exception = Assert.Throws<BadHttpRequestException>(() => _frame.TakeMessageHeaders(readableBuffer, out _consumed, out _examined));
             _socketInput.Reader.Advance(_consumed, _examined);
 
-            Assert.Equal("Header line must not start with whitespace.", exception.Message);
+            Assert.Equal("Whitespace is not allowed in header name.", exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
         }
 

--- a/test/shared/HttpParsingData.cs
+++ b/test/shared/HttpParsingData.cs
@@ -254,10 +254,10 @@ namespace Microsoft.AspNetCore.Testing
 
                 return new[]
                 {
-                    Tuple.Create(headersWithLineFolding,"Header line must not start with whitespace."),
+                    Tuple.Create(headersWithLineFolding,"Whitespace is not allowed in header name."),
                     Tuple.Create(headersWithCRInValue,"Header value must not contain CR characters."),
                     Tuple.Create(headersWithMissingColon,"No ':' character found in header line."),
-                    Tuple.Create(headersStartingWithWhitespace, "Header line must not start with whitespace."),
+                    Tuple.Create(headersStartingWithWhitespace, "Whitespace is not allowed in header name."),
                     Tuple.Create(headersWithWithspaceInName,"Whitespace is not allowed in header name."),
                     Tuple.Create(headersNotEndingInCrLfLine, "Headers corrupted, invalid header sequence.")
                 }


### PR DESCRIPTION
Made `IndexOfNameEnd` use less variables and be more understandable
Made `TakeSingleHeader` use less variables and be more understandable
Cleaned up a bad exception pattern
Removed usused `enum HeaderState`
Made some things static
Added `AggressiveInlining` to `TakeSingleHeader` as its always run

Vectorized CR checking in ` TakeSingleHeader`

Added some failure gotos to slim loop and reduce codegen