### PR TITLE
Rebasing https://github.com/aspnet/KestrelHttpServer/pull/1455

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -427,7 +427,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             if (headerStart[valueEnd + 2] != ByteLF)
             {
-                RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                goto headerValueContainsCR;
             }
             if (headerStart[valueEnd + 1] != ByteCR)
             {
@@ -446,7 +446,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 }
                 else if (ch == ByteCR)
                 {
-                    RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                    goto headerValueContainsCR;
                 }
             }
 
@@ -463,7 +463,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     {
                         if (!Vector<byte>.Zero.Equals(Vector.Equals(vByteCR, Unsafe.Read<Vector<byte>>(headerStart + i))))
                         {
-                            RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                            goto headerValueContainsCR;
                         }
 
                         i += Vector<byte>.Count;
@@ -477,7 +477,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 var ch = headerStart[i];
                 if (ch == ByteCR)
                 {
-                    RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
+                    goto headerValueContainsCR;
                 }
             }
 
@@ -495,6 +495,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             var valueBuffer = new Span<byte>(headerStart + valueStart, valueEnd - valueStart + 1);
 
             handler.OnHeader(nameBuffer, valueBuffer);
+            return;
+        headerValueContainsCR:
+            RejectRequest(RequestRejectionReason.HeaderValueMustNotContainCR);
         }
 
         private static bool IsValidTokenChar(char c)


### PR DESCRIPTION
Results here map to individual commits

```
BenchmarkDotNet=v0.10.3.0, OS=Ubuntu 16.04.1 LTS
Processor=Intel(R) Xeon(R) CPU E5-2673 v3 2.40GHz, ProcessorCount=4
Frequency=1000000000 Hz, Resolution=1.0000 ns, Timer=UNKNOWN
dotnet cli version=1.0.0-rc4-004883
  [Host]     : .NET Core 4.6.25009.03, 64bit RyuJIT
  Job-YGUZMM : .NET Core 4.6.25009.03, 64bit RyuJIT
```

## dev

|               Method |          Mean |     StdErr |      StdDev | Scaled | Scaled-StdDev |          RPS | Allocated |
|--------------------- |-------------- |----------- |------------ |------- |-------------- |------------- |---------- |
| PlaintextTechEmpower |   912.2706 ns |  3.2722 ns |  17.9228 ns |   1.00 |          0.00 | 1,096,166.00 |     112 B |
|           LiveAspNet | 1,903.3793 ns | 20.7324 ns | 113.5562 ns |   2.09 |          0.13 |   525,381.36 |     112 B |
|              Unicode | 2,706.9107 ns | 21.5603 ns | 118.0906 ns |   2.97 |          0.14 |   369,424.82 |     112 B |


## davidfowl/benadams-sanitize(1)

|               Method |          Mean |     StdDev | Scaled | Scaled-StdDev |          RPS | Allocated |
|--------------------- |-------------- |----------- |------- |-------------- |------------- |---------- |
| PlaintextTechEmpower |   841.7124 ns | 34.5915 ns |   1.00 |          0.00 | 1,188,054.19 |     112 B |
|           LiveAspNet | 1,466.1319 ns | 54.8059 ns |   1.74 |          0.09 |   682,066.87 |     112 B |
|              Unicode | 2,066.0661 ns | 83.9024 ns |   2.46 |          0.14 |   484,011.62 |     112 B |

## davidfowl/benadams-sanitize(2)

|               Method |          Mean |     StdDev | Scaled | Scaled-StdDev |          RPS | Allocated |
|--------------------- |-------------- |----------- |------- |-------------- |------------- |---------- |
| PlaintextTechEmpower |   780.2832 ns | 34.5344 ns |   1.00 |          0.00 | 1,281,585.90 |     112 B |
|           LiveAspNet | 1,308.3783 ns | 54.6983 ns |   1.68 |          0.10 |   764,304.92 |     112 B |
|              Unicode | 1,819.4245 ns | 78.6670 ns |   2.34 |          0.14 |   549,624.33 |     112 B |

## davidfowl/benadams-sanitize(3)

|               Method |          Mean |     StdDev | Scaled | Scaled-StdDev |          RPS | Allocated |
|--------------------- |-------------- |----------- |------- |-------------- |------------- |---------- |
| PlaintextTechEmpower |   787.4098 ns | 32.2922 ns |   1.00 |          0.00 | 1,269,986.74 |     112 B |
|           LiveAspNet | 1,320.7628 ns | 51.9655 ns |   1.68 |          0.09 |   757,138.20 |     112 B |
|              Unicode | 1,777.7391 ns | 75.1740 ns |   2.26 |          0.13 |   562,512.25 |     112 B |

## davidfowl/benadams-sanitize(4)

|               Method |          Mean |     StdErr |     StdDev | Scaled | Scaled-StdDev |          RPS | Allocated |
|--------------------- |-------------- |----------- |----------- |------- |-------------- |------------- |---------- |
| PlaintextTechEmpower |   774.5934 ns |  9.2185 ns | 50.4918 ns |   1.00 |          0.00 | 1,290,999.97 |     112 B |
|           LiveAspNet | 1,346.7364 ns | 15.8170 ns | 86.6331 ns |   1.74 |          0.14 |   742,535.82 |     112 B |
|              Unicode | 1,787.1675 ns | 13.7865 ns | 75.5119 ns |   2.32 |          0.16 |   559,544.64 |     112 B |
