### PR TITLE
Fix CopyTo implementation in benchmark.

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Microsoft.AspNetCore.Server.Kestrel.Performance.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Microsoft.AspNetCore.Server.Kestrel.Performance.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\build\common.props" />
 
@@ -6,6 +6,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsing.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         private void InsertData(byte[] bytes)
         {
             var buffer = Pipe.Writer.Alloc(2048);
-            buffer.Write(bytes);
+            buffer.WriteFast(bytes);
             // There should not be any backpressure and task completes immediately
             buffer.FlushAsync().GetAwaiter().GetResult();
         }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/WritableBufferExtensions.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/WritableBufferExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         private unsafe static void CopyToFast(this ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (destination.Length >= source.Length)
+            if (destination.Length < source.Length)
             {
                 throw new InvalidOperationException();
             }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/WritableBufferExtensions.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/WritableBufferExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    internal static class WritableBufferExtensions
+    {
+        public static void WriteFast(this WritableBuffer buffer, ReadOnlySpan<byte> source)
+        {
+            if (buffer.Memory.IsEmpty)
+            {
+                buffer.Ensure();
+            }
+
+            // Fast path, try copying to the available memory directly
+            if (source.Length <= buffer.Memory.Length)
+            {
+                source.CopyToFast(buffer.Memory.Span);
+                buffer.Advance(source.Length);
+                return;
+            }
+
+            var remaining = source.Length;
+            var offset = 0;
+
+            while (remaining > 0)
+            {
+                var writable = Math.Min(remaining, buffer.Memory.Length);
+
+                buffer.Ensure(writable);
+
+                if (writable == 0)
+                {
+                    continue;
+                }
+
+                source.Slice(offset, writable).CopyToFast(buffer.Memory.Span);
+
+                remaining -= writable;
+                offset += writable;
+
+                buffer.Advance(writable);
+            }
+        }
+
+        private unsafe static void CopyToFast(this ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            if (destination.Length >= source.Length)
+            {
+                throw new InvalidOperationException();
+            }
+
+            // Assume it fits
+            fixed (byte* pSource = &source.DangerousGetPinnableReference())
+            fixed (byte* pDest = &destination.DangerousGetPinnableReference())
+            {
+                Buffer.MemoryCopy(pSource, pDest, destination.Length, source.Length);
+            }
+        }
+    }
+}


### PR DESCRIPTION
See https://github.com/dotnet/corefx/issues/16840. Once we switch over, I'll change it back.