### PR TITLE
Switch non-printable char representation in log messages from <0xXX>to \xXX

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
             for (i = 0; i < Math.Min(span.Length, maxChars); ++i)
             {
                 var ch = span[i];
-                sb.Append(ch < 0x20 || ch >= 0x7F ? $"<0x{ch:X2}>" : ((char)ch).ToString());
+                sb.Append(ch < 0x20 || ch >= 0x7F ? $"\\x{ch:X2}" : ((char)ch).ToString());
             }
 
             if (span.Length > maxChars)

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/BadHttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/BadHttpRequestTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 foreach (var requestLine in HttpParsingData.RequestLineInvalidData)
                 {
-                    data.Add(requestLine, $"Invalid request line: {requestLine.Replace("\r", "<0x0D>").Replace("\n", "<0x0A>")}");
+                    data.Add(requestLine, $"Invalid request line: {requestLine.Replace("\r", "\\x0D").Replace("\n", "\\x0A")}");
                 }
 
                 foreach (var requestLine in HttpParsingData.RequestLineWithEncodedNullCharInTargetData)

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var exception = Assert.Throws<BadHttpRequestException>(() =>
                 parser.ParseRequestLine(Mock.Of<IHttpRequestLineHandler>(), buffer, out var consumed, out var examined));
 
-            Assert.Equal($"Invalid request line: {requestLine.Replace("\r", "<0x0D>").Replace("\n", "<0x0A>")}", exception.Message);
+            Assert.Equal($"Invalid request line: {requestLine.Replace("\r", "\\x0D").Replace("\n", "\\x0A")}", exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, (exception as BadHttpRequestException).StatusCode);
         }
 


### PR DESCRIPTION
As discussed with @davidfowl.

Reason: it's shorter.