### PR TITLE
Log rejected request targets

### DIFF
--- a/KestrelHttpServer.sln
+++ b/KestrelHttpServer.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26222.1
+VisualStudioVersion = 15.0.26228.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7972A5D6-3385-4127-9277-428506DD44FF}"
 	ProjectSection(SolutionItems) = preProject
@@ -29,6 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{0EF2AC
 		test\shared\MockSocketOutput.cs = test\shared\MockSocketOutput.cs
 		test\shared\MockSystemClock.cs = test\shared\MockSystemClock.cs
 		test\shared\SocketInputExtensions.cs = test\shared\SocketInputExtensions.cs
+		test\shared\StringExtensions.cs = test\shared\StringExtensions.cs
 		test\shared\TestApp.cs = test\shared\TestApp.cs
 		test\shared\TestApplicationErrorLogger.cs = test\shared\TestApplicationErrorLogger.cs
 		test\shared\TestConnection.cs = test\shared\TestConnection.cs

--- a/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/BadHttpRequestException.cs
@@ -87,31 +87,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             return ex;
         }
 
-        internal static BadHttpRequestException GetException(RequestRejectionReason reason, string value)
+        internal static BadHttpRequestException GetException(RequestRejectionReason reason, string detail)
         {
             BadHttpRequestException ex;
             switch (reason)
             {
                 case RequestRejectionReason.InvalidRequestLine:
-                    ex = new BadHttpRequestException($"Invalid request line: '{value}'", StatusCodes.Status400BadRequest);
+                    ex = new BadHttpRequestException($"Invalid request line: '{detail}'", StatusCodes.Status400BadRequest);
+                    break;
+                case RequestRejectionReason.InvalidRequestTarget:
+                    ex = new BadHttpRequestException($"Invalid request target: '{detail}'", StatusCodes.Status400BadRequest);
                     break;
                 case RequestRejectionReason.InvalidRequestHeader:
-                    ex = new BadHttpRequestException($"Invalid request header: '{value}'", StatusCodes.Status400BadRequest);
+                    ex = new BadHttpRequestException($"Invalid request header: '{detail}'", StatusCodes.Status400BadRequest);
                     break;
                 case RequestRejectionReason.InvalidContentLength:
-                    ex = new BadHttpRequestException($"Invalid content length: {value}", StatusCodes.Status400BadRequest);
+                    ex = new BadHttpRequestException($"Invalid content length: {detail}", StatusCodes.Status400BadRequest);
                     break;
                 case RequestRejectionReason.UnrecognizedHTTPVersion:
-                    ex = new BadHttpRequestException($"Unrecognized HTTP version: {value}", StatusCodes.Status505HttpVersionNotsupported);
+                    ex = new BadHttpRequestException($"Unrecognized HTTP version: '{detail}'", StatusCodes.Status505HttpVersionNotsupported);
                     break;
                 case RequestRejectionReason.FinalTransferCodingNotChunked:
-                    ex = new BadHttpRequestException($"Final transfer coding is not \"chunked\": \"{value}\"", StatusCodes.Status400BadRequest);
+                    ex = new BadHttpRequestException($"Final transfer coding is not \"chunked\": \"{detail}\"", StatusCodes.Status400BadRequest);
                     break;
                 case RequestRejectionReason.LengthRequired:
-                    ex = new BadHttpRequestException($"{value} request contains no Content-Length or Transfer-Encoding header", StatusCodes.Status411LengthRequired);
+                    ex = new BadHttpRequestException($"{detail} request contains no Content-Length or Transfer-Encoding header", StatusCodes.Status411LengthRequired);
                     break;
                 case RequestRejectionReason.LengthRequiredHttp10:
-                    ex = new BadHttpRequestException($"{value} request contains no Content-Length header", StatusCodes.Status400BadRequest);
+                    ex = new BadHttpRequestException($"{detail} request contains no Content-Length header", StatusCodes.Status400BadRequest);
                     break;
                 default:
                     ex = new BadHttpRequestException("Bad request.", StatusCodes.Status400BadRequest);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
@@ -50,12 +50,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                         }
                         catch (InvalidOperationException)
                         {
-                            switch (_requestProcessingStatus)
+                            if (_requestProcessingStatus == RequestProcessingStatus.ParsingHeaders)
                             {
-                                case RequestProcessingStatus.ParsingRequestLine:
-                                    throw BadHttpRequestException.GetException(RequestRejectionReason.InvalidRequestLine);
-                                case RequestProcessingStatus.ParsingHeaders:
-                                    throw BadHttpRequestException.GetException(RequestRejectionReason.MalformedRequestInvalidHeaders);
+                                throw BadHttpRequestException.GetException(RequestRejectionReason.MalformedRequestInvalidHeaders);
                             }
                             throw;
                         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IHttpRequestLineHandler.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IHttpRequestLineHandler.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
     public interface IHttpRequestLineHandler
     {
-        void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, Span<byte> line, bool pathEncoded);
+        void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/RequestRejectionReason.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         BadChunkSuffix,
         BadChunkSizeData,
         ChunkedRequestIncomplete,
+        InvalidRequestTarget,
         InvalidCharactersInHeaderName,
         RequestLineTooLong,
         HeadersExceedMaxTotalSize,

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/Constants.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/Constants.cs
@@ -10,6 +10,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
     {
         public const int ListenBacklog = 128;
 
+        public const int MaxExceptionDetailSize = 128;
+
         public const int EOF = -4095;
         public static readonly int? ECONNRESET = GetECONNRESET();
         public static readonly int? EADDRINUSE = GetEADDRINUSE();

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
@@ -126,8 +126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         {
             var sb = new StringBuilder();
 
-            int i;
-            for (i = 0; i < Math.Min(span.Length, maxChars); ++i)
+            for (var i = 0; i < Math.Min(span.Length, maxChars); i++)
             {
                 var ch = span[i];
                 sb.Append(ch < 0x20 || ch >= 0x7F ? $"\\x{ch:X2}" : ((char)ch).ToString());
@@ -137,6 +136,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
             {
                 sb.Append("...");
             }
+
             return sb.ToString();
         }
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/BadHttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/BadHttpRequestTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             return TestBadRequest(
                 $"GET / {httpVersion}\r\n",
                 "505 HTTP Version Not Supported",
-                $"Unrecognized HTTP version: {httpVersion}");
+                $"Unrecognized HTTP version: '{httpVersion}'");
         }
 
         [Theory]
@@ -149,27 +149,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 var data = new TheoryData<string, string>();
 
-                string Escape(string line)
-                {
-                    return line
-                        .Replace("\r", @"\x0D")
-                        .Replace("\n", @"\x0A")
-                        .Replace("\0", @"\x00");
-                }
-
                 foreach (var requestLine in HttpParsingData.RequestLineInvalidData)
                 {
-                    data.Add(requestLine, $"Invalid request line: '{Escape(requestLine)}'");
+                    data.Add(requestLine, $"Invalid request line: '{requestLine.EscapeNonPrintable()}'");
                 }
 
-                foreach (var requestLine in HttpParsingData.RequestLineWithEncodedNullCharInTargetData)
+                foreach (var target in HttpParsingData.TargetWithEncodedNullCharData)
                 {
-                    data.Add(requestLine, "Invalid request line.");
+                    data.Add($"GET {target} HTTP/1.1\r\n", $"Invalid request target: '{target.EscapeNonPrintable()}'");
                 }
 
-                foreach (var requestLine in HttpParsingData.RequestLineWithNullCharInTargetData)
+                foreach (var target in HttpParsingData.TargetWithNullCharData)
                 {
-                    data.Add(requestLine, $"Invalid request line.");
+                    data.Add($"GET {target} HTTP/1.1\r\n", $"Invalid request target: '{target.EscapeNonPrintable()}'");
                 }
 
                 return data;

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverhead.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverhead.cs
@@ -126,7 +126,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                     new Span<byte>(_target),
                     Span<byte>.Empty,
                     Span<byte>.Empty,
-                    new Span<byte>(_startLine),
                     false);
 
                 consumed = buffer.Start;

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KestrelHttpParser.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KestrelHttpParser.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             }
         }
 
-        public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, Span<byte> line, bool pathEncoded)
+        public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
         {
         }
 

--- a/test/shared/HttpParsingData.cs
+++ b/test/shared/HttpParsingData.cs
@@ -112,113 +112,144 @@ namespace Microsoft.AspNetCore.Testing
             "GET / HTTP/1.1\r",
         };
 
-        public static IEnumerable<string> RequestLineInvalidData => new[]
+        public static IEnumerable<string> RequestLineInvalidData
         {
-            "G\r\n",
-            "GE\r\n",
-            "GET\r\n",
-            "GET \r\n",
-            "GET /\r\n",
-            "GET / \r\n",
-            "GET/HTTP/1.1\r\n",
-            "GET /HTTP/1.1\r\n",
-            " \r\n",
-            "  \r\n",
-            "/ HTTP/1.1\r\n",
-            " / HTTP/1.1\r\n",
-            "/ \r\n",
-            "GET  \r\n",
-            "GET  HTTP/1.0\r\n",
-            "GET  HTTP/1.1\r\n",
-            "GET / \n",
-            "GET / HTTP/1.0\n",
-            "GET / HTTP/1.1\n",
-            "GET / HTTP/1.0\rA\n",
-            "GET / HTTP/1.1\ra\n",
-            "GET? / HTTP/1.1\r\n",
-            "GET ? HTTP/1.1\r\n",
-            "GET /a?b=cHTTP/1.1\r\n",
-            "GET /a%20bHTTP/1.1\r\n",
-            "GET /a%20b?c=dHTTP/1.1\r\n",
-            "GET %2F HTTP/1.1\r\n",
-            "GET %00 HTTP/1.1\r\n",
-            "CUSTOM \r\n",
-            "CUSTOM /\r\n",
-            "CUSTOM / \r\n",
-            "CUSTOM /HTTP/1.1\r\n",
-            "CUSTOM  \r\n",
-            "CUSTOM  HTTP/1.0\r\n",
-            "CUSTOM  HTTP/1.1\r\n",
-            "CUSTOM / \n",
-            "CUSTOM / HTTP/1.0\n",
-            "CUSTOM / HTTP/1.1\n",
-            "CUSTOM / HTTP/1.0\rA\n",
-            "CUSTOM / HTTP/1.1\ra\n",
-            "CUSTOM ? HTTP/1.1\r\n",
-            "CUSTOM /a?b=cHTTP/1.1\r\n",
-            "CUSTOM /a%20bHTTP/1.1\r\n",
-            "CUSTOM /a%20b?c=dHTTP/1.1\r\n",
-            "CUSTOM %2F HTTP/1.1\r\n",
-            "CUSTOM %00 HTTP/1.1\r\n",
+            get
+            {
+                return new[]
+                {
+                    "G\r\n",
+                    "GE\r\n",
+                    "GET\r\n",
+                    "GET \r\n",
+                    "GET /\r\n",
+                    "GET / \r\n",
+                    "GET/HTTP/1.1\r\n",
+                    "GET /HTTP/1.1\r\n",
+                    " \r\n",
+                    "  \r\n",
+                    "/ HTTP/1.1\r\n",
+                    " / HTTP/1.1\r\n",
+                    "/ \r\n",
+                    "GET  \r\n",
+                    "GET  HTTP/1.0\r\n",
+                    "GET  HTTP/1.1\r\n",
+                    "GET / \n",
+                    "GET / HTTP/1.0\n",
+                    "GET / HTTP/1.1\n",
+                    "GET / HTTP/1.0\rA\n",
+                    "GET / HTTP/1.1\ra\n",
+                    "GET? / HTTP/1.1\r\n",
+                    "GET ? HTTP/1.1\r\n",
+                    "GET /a?b=cHTTP/1.1\r\n",
+                    "GET /a%20bHTTP/1.1\r\n",
+                    "GET /a%20b?c=dHTTP/1.1\r\n",
+                    "GET %2F HTTP/1.1\r\n",
+                    "GET %00 HTTP/1.1\r\n",
+                    "CUSTOM \r\n",
+                    "CUSTOM /\r\n",
+                    "CUSTOM / \r\n",
+                    "CUSTOM /HTTP/1.1\r\n",
+                    "CUSTOM  \r\n",
+                    "CUSTOM  HTTP/1.0\r\n",
+                    "CUSTOM  HTTP/1.1\r\n",
+                    "CUSTOM / \n",
+                    "CUSTOM / HTTP/1.0\n",
+                    "CUSTOM / HTTP/1.1\n",
+                    "CUSTOM / HTTP/1.0\rA\n",
+                    "CUSTOM / HTTP/1.1\ra\n",
+                    "CUSTOM ? HTTP/1.1\r\n",
+                    "CUSTOM /a?b=cHTTP/1.1\r\n",
+                    "CUSTOM /a%20bHTTP/1.1\r\n",
+                    "CUSTOM /a%20b?c=dHTTP/1.1\r\n",
+                    "CUSTOM %2F HTTP/1.1\r\n",
+                    "CUSTOM %00 HTTP/1.1\r\n",
+                }.Concat(MethodWithNonTokenCharData.Select(method => $"{method} / HTTP/1.0\r\n"));
+            }
+        }
+
+        // Bad HTTP Methods (invalid according to RFC)
+        public static IEnumerable<string> MethodWithNonTokenCharData
+        {
+            get
+            {
+                return new[]
+                {
+                    "(",
+                    ")",
+                    "<",
+                    ">",
+                    "@",
+                    ",",
+                    ";",
+                    ":",
+                    "\\",
+                    "\"",
+                    "/",
+                    "[",
+                    "]",
+                    "?",
+                    "=",
+                    "{",
+                    "}",
+                    "get@",
+                    "post=",
+                }.Concat(MethodWithNullCharData);
+            }
+        }
+
+        public static IEnumerable<string> MethodWithNullCharData => new[]
+        {
             // Bad HTTP Methods (invalid according to RFC)
-            "( / HTTP/1.0\r\n",
-            ") / HTTP/1.0\r\n",
-            "< / HTTP/1.0\r\n",
-            "> / HTTP/1.0\r\n",
-            "@ / HTTP/1.0\r\n",
-            ", / HTTP/1.0\r\n",
-            "; / HTTP/1.0\r\n",
-            ": / HTTP/1.0\r\n",
-            "\\ / HTTP/1.0\r\n",
-            "\" / HTTP/1.0\r\n",
-            "/ / HTTP/1.0\r\n",
-            "[ / HTTP/1.0\r\n",
-            "] / HTTP/1.0\r\n",
-            "? / HTTP/1.0\r\n",
-            "= / HTTP/1.0\r\n",
-            "{ / HTTP/1.0\r\n",
-            "} / HTTP/1.0\r\n",
-            "get@ / HTTP/1.0\r\n",
-            "post= / HTTP/1.0\r\n",
+            "\0",
+            "\0GET",
+            "G\0T",
+            "GET\0",
         };
 
-        public static IEnumerable<string> RequestLineWithEncodedNullCharInTargetData => new[]
+        public static IEnumerable<string> TargetWithEncodedNullCharData => new[]
         {
-            "GET /%00 HTTP/1.1\r\n",
-            "GET /%00%00 HTTP/1.1\r\n",
-            "GET /%E8%00%84 HTTP/1.1\r\n",
-            "GET /%E8%85%00 HTTP/1.1\r\n",
-            "GET /%F3%00%82%86 HTTP/1.1\r\n",
-            "GET /%F3%85%00%82 HTTP/1.1\r\n",
-            "GET /%F3%85%82%00 HTTP/1.1\r\n",
-            "GET /%E8%01%00 HTTP/1.1\r\n",
+            "/%00",
+            "/%00%00",
+            "/%E8%00%84",
+            "/%E8%85%00",
+            "/%F3%00%82%86",
+            "/%F3%85%00%82",
+            "/%F3%85%82%00",
         };
 
-        public static TheoryData<string> RequestLineWithInvalidRequestTarget => new TheoryData<string>
+        public static TheoryData<string, string> TargetInvalidData
         {
-            // Invalid absolute-form requests
-            "GET http:// HTTP/1.1\r\n",
-            "GET http:/ HTTP/1.1\r\n",
-            "GET https:/ HTTP/1.1\r\n",
-            "GET http:/// HTTP/1.1\r\n",
-            "GET https:// HTTP/1.1\r\n",
-            "GET http://// HTTP/1.1\r\n",
-            "GET http://:80 HTTP/1.1\r\n",
-            "GET http://:80/abc HTTP/1.1\r\n",
-            "GET http://user@ HTTP/1.1\r\n",
-            "GET http://user@/abc HTTP/1.1\r\n",
-            "GET http://abc%20xyz/abc HTTP/1.1\r\n",
-            "GET http://%20/abc?query=%0A HTTP/1.1\r\n",
-            // Valid absolute-form but with unsupported schemes
-            "GET otherscheme://host/ HTTP/1.1\r\n",
-            "GET ws://host/ HTTP/1.1\r\n",
-            "GET wss://host/ HTTP/1.1\r\n",
-            // Must only have one asterisk
-            "OPTIONS ** HTTP/1.1\r\n",
-            // Relative form
-            "GET ../../ HTTP/1.1\r\n",
-            "GET ..\\. HTTP/1.1\r\n",
-        };
+            get
+            {
+                var data = new TheoryData<string, string>();
+
+                // Invalid absolute-form
+                data.Add("GET", "http://");
+                data.Add("GET", "http:/");
+                data.Add("GET", "https:/");
+                data.Add("GET", "http:///");
+                data.Add("GET", "https://");
+                data.Add("GET", "http:////");
+                data.Add("GET", "http://:80");
+                data.Add("GET", "http://:80/abc");
+                data.Add("GET", "http://user@");
+                data.Add("GET", "http://user@/abc");
+                data.Add("GET", "http://abc%20xyz/abc");
+                data.Add("GET", "http://%20/abc?query=%0A");
+                // Valid absolute-form but with unsupported schemes
+                data.Add("GET", "otherscheme://host/");
+                data.Add("GET", "ws://host/");
+                data.Add("GET", "wss://host/");
+                // Must only have one asterisk
+                data.Add("OPTIONS", "**");
+                // Relative form
+                data.Add("GET", "../../");
+                data.Add("GET", "..\\.");
+
+                return data;
+            }
+        }
 
         public static TheoryData<string, HttpMethod> MethodNotAllowedRequestLine
         {
@@ -234,36 +265,44 @@ namespace Microsoft.AspNetCore.Testing
                     "TRACE",
                     "PATCH",
                     "CONNECT",
-                    //"OPTIONS",
+                    "OPTIONS",
                     "CUSTOM",
                 };
 
-                var theoryData = new TheoryData<string, HttpMethod>();
-                foreach (var line in methods
-                    .Select(m => Tuple.Create($"{m} * HTTP/1.1\r\n", HttpMethod.Options))
-                    .Concat(new[]
-                    {
-                        // CONNECT required for authority-form targets
-                        Tuple.Create("GET http:80 HTTP/1.1\r\n", HttpMethod.Connect),
-                        Tuple.Create("GET http: HTTP/1.1\r\n", HttpMethod.Connect),
-                        Tuple.Create("GET https: HTTP/1.1\r\n", HttpMethod.Connect),
-                        Tuple.Create("GET . HTTP/1.1\r\n", HttpMethod.Connect),
-                    }))
+                var data = new TheoryData<string, HttpMethod>();
+
+                foreach (var method in methods.Except(new[] { "OPTIONS" }))
                 {
-                    theoryData.Add(line.Item1, line.Item2);
+                    data.Add($"{method} * HTTP/1.1\r\n", HttpMethod.Options);
                 }
 
-                return theoryData;
+                foreach (var method in methods.Except(new[] { "CONNECT" }))
+                {
+                    data.Add($"{method} www.example.com:80 HTTP/1.1\r\n", HttpMethod.Connect);
+                }
+
+                return data;
             }
         }
 
-        public static IEnumerable<string> RequestLineWithNullCharInTargetData => new[]
+        public static IEnumerable<string> TargetWithNullCharData
         {
-            // TODO re-enable after we get both #1469 and #1470 merged
-            // "GET \0 HTTP/1.1\r\n",
-            "GET /\0 HTTP/1.1\r\n",
-            "GET /\0\0 HTTP/1.1\r\n",
-            "GET /%C8\0 HTTP/1.1\r\n",
+            get
+            {
+                return new[]
+                {
+                    "\0",
+                    "/\0",
+                    "/\0\0",
+                    "/%C8\0",
+                }.Concat(QueryStringWithNullCharData);
+            }
+        }
+
+        public static IEnumerable<string> QueryStringWithNullCharData => new[]
+        {
+            "/?\0=a",
+            "/?a=\0",
         };
 
         public static TheoryData<string> UnrecognizedHttpVersionData => new TheoryData<string>

--- a/test/shared/StringExtensions.cs
+++ b/test/shared/StringExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    public static class StringExtensions
+    {
+        public static string EscapeNonPrintable(this string s)
+        {
+            var ellipsis = s.Length > 128
+                ? "..."
+                : string.Empty;
+            return s.Substring(0, Math.Min(128, s.Length))
+                .Replace("\r", @"\x0D")
+                .Replace("\n", @"\x0A")
+                .Replace("\0", @"\x00")
+                + ellipsis;
+        }
+    }
+}


### PR DESCRIPTION
Instead of logging only `Invalid request line`.

A similar change is not necessary for bad chars in custom methods, since this already handled. Same thing for the query string, since we throw on bad chars when getting the raw target string. But I still added frame tests to verify methods and query strings, since the order in which we do things there could change.

~~Note: currently based on `cesarbs/single-bad-header-log`, will rebase to `dev` once that one is merged.~~