### PR TITLE
Speed up RequestLine Parsing

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -1193,13 +1193,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             throw BadHttpRequestException.GetException(reason, value);
         }
 
-        private void RejectRequestLine(Span<byte> requestLine)
+        private BadHttpRequestException GetRequestLineRejectionException(Span<byte> target)
         {
-            Debug.Assert(Log.IsEnabled(LogLevel.Information) == true, "Use RejectRequest instead to improve inlining when log is disabled");
+            if (!Log.IsEnabled(LogLevel.Information))
+            {
+                return BadHttpRequestException.GetException(RequestRejectionReason.InvalidRequestLine);
+            }
 
-            const int MaxRequestLineError = 32;
-            var line = requestLine.GetAsciiStringEscaped(MaxRequestLineError);
-            throw BadHttpRequestException.GetException(RequestRejectionReason.InvalidRequestLine, line);
+            const int MaxTargetLengthError = 32;
+
+            var line = target.GetRequestLineAsciiStringEscaped(Method, HttpVersion, MaxTargetLengthError);
+
+            return BadHttpRequestException.GetException(RequestRejectionReason.InvalidRequestLine, line);
+        }
+
+        private void RejectRequestLine(Span<byte> target)
+        {
+            throw GetRequestLineRejectionException(target);
         }
 
         public void SetBadRequestState(RequestRejectionReason reason)
@@ -1239,9 +1249,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             Log.ApplicationError(ConnectionId, ex);
         }
 
-        public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, Span<byte> line, bool pathEncoded)
+        public void OnStartLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod)
         {
             Debug.Assert(target.Length != 0, "Request target must be non-zero length");
+
+            var method = parseInfo.HttpMethod;
+            Method = method != HttpMethod.Custom
+                ? HttpUtilities.MethodToString(method) ?? string.Empty
+                : customMethod.GetAsciiStringNonNullCharacters();
+
+            HttpVersion = HttpUtilities.VersionToString(parseInfo.HttpVersion);
 
             var ch = target[0];
             if (ch == ByteForwardSlash)
@@ -1249,7 +1266,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 // origin-form.
                 // The most common form of request-target.
                 // https://tools.ietf.org/html/rfc7230#section-5.3.1
-                OnOriginFormTarget(method, version, target, path, query, customMethod, pathEncoded);
+                OnOriginFormTarget(parseInfo, target, queryLength);
             }
             else if (ch == ByteAsterisk && target.Length == 1)
             {
@@ -1257,21 +1274,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
             else if (target.GetKnownHttpScheme(out var scheme))
             {
-                OnAbsoluteFormTarget(target, query, line);
+                OnAbsoluteFormTarget(target, queryLength, parseInfo.DoesPathContainDots);
             }
             else
             {
                 // Assume anything else is considered authority form.
                 // FYI: this should be an edge case. This should only happen when
-                // a client mistakenly things this server is a proxy server.
+                // a client mistakenly thinks this server is a proxy server.
 
-                OnAuthorityFormTarget(method, target, line);
+                OnAuthorityFormTarget(method, target);
             }
-
-            Method = method != HttpMethod.Custom
-                ? HttpUtilities.MethodToString(method) ?? string.Empty
-                : customMethod.GetAsciiStringNonNullCharacters();
-            HttpVersion = HttpUtilities.VersionToString(version);
 
             Debug.Assert(RawTarget != null, "RawTarget was not set");
             Debug.Assert(Method != null, "Method was not set");
@@ -1280,7 +1292,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             Debug.Assert(HttpVersion != "HttpVersion was not set");
         }
 
-        private void OnOriginFormTarget(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
+        private void OnOriginFormTarget(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength)
         {
             Debug.Assert(target[0] == ByteForwardSlash, "Should only be called when path starts with /");
 
@@ -1288,39 +1300,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             // Multibyte Internationalized Resource Identifiers (IRIs) are first converted to utf8;
             // then encoded/escaped to ASCII  https://www.ietf.org/rfc/rfc3987.txt "Mapping of IRIs to URIs"
             string requestUrlPath;
-            string rawTarget;
-            if (pathEncoded)
+            if (parseInfo.IsPathEncoded)
             {
                 // Read raw target before mutating memory.
-                rawTarget = target.GetAsciiStringNonNullCharacters();
+                RawTarget = target.GetAsciiStringNonNullCharacters();
 
                 // URI was encoded, unescape and then parse as utf8
-                int pathLength = UrlEncoder.Decode(path, path);
-                requestUrlPath = GetUtf8String(path.Slice(0, pathLength));
+                requestUrlPath = GetUtf8String(target, target.Length - queryLength);
             }
             else
             {
-                // URI wasn't encoded, parse as ASCII
-                requestUrlPath = path.GetAsciiStringNonNullCharacters();
-
-                if (query.Length == 0)
+                if (queryLength == 0)
                 {
+                    // No query, don't slice - raw target same
                     // No need to allocate an extra string if the path didn't need
                     // decoding and there's no query string following it.
-                    rawTarget = requestUrlPath;
+                    RawTarget = requestUrlPath = target.GetAsciiStringNonNullCharacters();
                 }
                 else
                 {
-                    rawTarget = target.GetAsciiStringNonNullCharacters();
+                    RawTarget = target.GetAsciiStringNonNullCharacters();
+                    requestUrlPath = target.Slice(0, target.Length - queryLength).GetAsciiStringNonNullCharacters();
                 }
             }
 
-            QueryString = query.GetAsciiStringNonNullCharacters();
-            RawTarget = rawTarget;
-            SetNormalizedPath(requestUrlPath);
+            if (queryLength >= 0)
+            {
+                QueryString = target.Slice(target.Length - queryLength, queryLength).GetAsciiStringNonNullCharacters();
+            }
+            else
+            {
+                QueryString = String.Empty;
+            }
+
+            SetNormalizedPath(requestUrlPath, parseInfo.DoesPathContainDots);
         }
 
-        private void OnAuthorityFormTarget(HttpMethod method, Span<byte> target, Span<byte> line)
+        private void OnAuthorityFormTarget(HttpMethod method, Span<byte> target)
         {
             // TODO Validate that target is a correct host[:port] string.
             // Reject as 400 if not. This is just a quick scan for invalid characters
@@ -1330,12 +1346,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 var ch = target[i];
                 if (!UriUtilities.IsValidAuthorityCharacter(ch))
                 {
-                    if (Log.IsEnabled(LogLevel.Information))
-                    {
-                        RejectRequestLine(line);
-                    }
-
-                    throw BadHttpRequestException.GetException(RequestRejectionReason.InvalidRequestLine);
+                    RejectRequestLine(target);
                 }
             }
 
@@ -1377,7 +1388,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             QueryString = string.Empty;
         }
 
-        private void OnAbsoluteFormTarget(Span<byte> target, Span<byte> query, Span<byte> line)
+        private void OnAbsoluteFormTarget(Span<byte> target, int queryLength, bool doesPathContainDots)
         {
             // absolute-form
             // https://tools.ietf.org/html/rfc7230#section-5.3.2
@@ -1396,22 +1407,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             if (!Uri.TryCreate(RawTarget, UriKind.Absolute, out var uri))
             {
-                if (Log.IsEnabled(LogLevel.Information))
-                {
-                    RejectRequestLine(line);
-                }
-
-                throw BadHttpRequestException.GetException(RequestRejectionReason.InvalidRequestLine);
+                RejectRequestLine(target);
             }
 
-            SetNormalizedPath(uri.LocalPath);
+            SetNormalizedPath(uri.LocalPath, doesPathContainDots);
             // don't use uri.Query because we need the unescaped version
-            QueryString = query.GetAsciiStringNonNullCharacters();
+            QueryString = target.Slice(target.Length - queryLength, queryLength).GetAsciiStringNonNullCharacters();
         }
 
-        private void SetNormalizedPath(string requestPath)
+        private void SetNormalizedPath(string requestPath, bool doesPathContainDots)
         {
-            var normalizedTarget = PathNormalizer.RemoveDotSegments(requestPath);
+            var normalizedTarget = !doesPathContainDots ? requestPath : PathNormalizer.RemoveDotSegments(requestPath);
             if (RequestUrlStartsWithPathBase(normalizedTarget, out bool caseMatches))
             {
                 PathBase = caseMatches ? _pathBase : normalizedTarget.Substring(0, _pathBase.Length);
@@ -1423,16 +1429,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
         }
 
-        private unsafe static string GetUtf8String(Span<byte> path)
+        private unsafe static string GetUtf8String(Span<byte> target, int encodedPathLength)
         {
+            var path = target.Slice(0, encodedPathLength);
+            int pathLength = UrlEncoder.Decode(path, path);
+            path = path.Slice(0, pathLength);
+#if NET451
             // .NET 451 doesn't have pointer overloads for Encoding.GetString so we
             // copy to an array
-#if NET451
             return Encoding.UTF8.GetString(path.ToArray());
 #else
             fixed (byte* pointer = &path.DangerousGetPinnableReference())
             {
-                return Encoding.UTF8.GetString(pointer, path.Length);
+                return Encoding.UTF8.GetString(pointer, pathLength);
             }
 #endif
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -1249,7 +1249,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             Log.ApplicationError(ConnectionId, ex);
         }
 
-        public void OnStartLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod)
+        public void OnRequestLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod)
         {
             Debug.Assert(target.Length != 0, "Request target must be non-zero length");
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/Frame.cs
@@ -1257,6 +1257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             Method = HttpUtilities.MethodToString(method) ?? GetCustomMethodString(customMethod);
 
             HttpVersion = HttpUtilities.VersionToString(parseInfo.HttpVersion);
+
             var ch = target[0];
             if (ch == ByteForwardSlash)
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/HttpMethod.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/HttpMethod.cs
@@ -3,18 +3,18 @@
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
-    public enum HttpMethod: byte
+    public enum HttpMethod
     {
-        Get,
-        Put,
-        Delete,
-        Post,
-        Head,
-        Trace,
-        Patch,
-        Connect,
-        Options,
+        Get = 0,
+        Put = 1,
+        Delete = 2,
+        Post = 3,
+        Head = 4,
+        Trace = 5,
+        Patch = 6,
+        Connect = 7,
+        Options = 8,
 
-        Custom,
+        Custom = 9,
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/HttpRequestLineParseInfo.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/HttpRequestLineParseInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
@@ -33,10 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
-                if (((uint)value & 1u) != (uint)value)
-                {
-                    RejectRequestUnrecognizedHTTPVersion();
-                }
+                Debug.Assert(((uint)value & 1u) == (uint)value);
                 // Clear and set version
                 _details = (_details & ~1u) | (uint)value;
             }
@@ -114,29 +112,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
-                var val = (uint)value;
-                if (val > 0x1ffffff)
-                {
-                    // Definately too long
-                    RejectRequestRequestLineTooLong();
-                }
-                _details = (_details & ~QueryLengthMask) | val << 7;
+                Debug.Assert((uint)value <= 0x1ffffff);
+                _details = (_details & ~QueryLengthMask) | ((uint)value) << 7;
             }
-        }
-
-        private static void RejectRequestRequestLineTooLong()
-        {
-            throw RejectRequest(RequestRejectionReason.RequestLineTooLong);
-        }
-
-        private static void RejectRequestUnrecognizedHTTPVersion()
-        {
-            throw RejectRequest(RequestRejectionReason.UnrecognizedHTTPVersion);
-        }
-
-        private static BadHttpRequestException RejectRequest(RequestRejectionReason reason)
-        {
-            return BadHttpRequestException.GetException(reason);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/HttpRequestLineParseInfo.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/HttpRequestLineParseInfo.cs
@@ -1,0 +1,103 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
+{
+    public struct HttpRequestLineParseInfo
+    {
+        // Http10 = 0,
+        // Http11 = 1,
+        // HttpMethod: 2 - 32
+        private const int PathEncoded = 64;
+        private const int PathContainsDots = 128;
+
+        private int _details;
+
+        public HttpRequestLineParseInfo(HttpMethod method)
+        {
+            _details = ((int)method << 1);
+        }
+
+        public HttpVersion HttpVersion
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                // Get version (Note does not work with Unknown version; which is -1)
+                // The parser should throw for Unknown. Could throw in the set
+                // but the parser's throw will contain more context.
+                return (HttpVersion)(_details & 1);
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                // Clear and set version
+                _details = (_details & ~1) | (int)value;
+            }
+        }
+
+        public HttpMethod HttpMethod
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                // HttpMethod is shifted up one bit; shift down and mask
+                return (HttpMethod)((_details >> 1) & 0xF);
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                // HttpMethod is shifted up one bit; clear and shift up and set
+                _details = (_details & ~0x1E) | (int)value << 1;
+            }
+        }
+        public bool IsPathEncoded
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                // Check flag
+                return (_details & PathEncoded) != 0;
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                if (value)
+                {
+                    // Set flag
+                    _details |= PathEncoded;
+                }
+                else
+                {
+                    // Clear flag
+                    _details &= ~PathEncoded;
+                }
+            }
+        }
+        public bool DoesPathContainDots
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                // Check flag
+                return (_details & PathContainsDots) != 0;
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                if (value)
+                {
+                    // Set flag
+                    _details |= PathContainsDots;
+                }
+                else
+                {
+                    // Clear flag
+                    _details &= ~PathContainsDots;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IHttpRequestLineHandler.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IHttpRequestLineHandler.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
     public interface IHttpRequestLineHandler
     {
-        void OnStartLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod);
+        void OnRequestLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IHttpRequestLineHandler.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IHttpRequestLineHandler.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
     public interface IHttpRequestLineHandler
     {
-        void OnRequestLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod);
+        void OnRequestLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, Span<byte> customMethod);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IHttpRequestLineHandler.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/IHttpRequestLineHandler.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
     public interface IHttpRequestLineHandler
     {
-        void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, Span<byte> line, bool pathEncoded);
+        void OnStartLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
 
             var targetBuffer = new Span<byte>(data + pathStart, offset - pathStart);
-            var queryLength = offset - queryStart;
+            parseInfo.QueryLength = offset - queryStart;
 
             // Consume space
             offset++;
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 RejectRequestLine(data, length);
             }
 
-            handler.OnRequestLine(parseInfo, targetBuffer, queryLength, customMethod);
+            handler.OnRequestLine(parseInfo, targetBuffer, customMethod);
         }
 
         public unsafe bool ParseHeaders<T>(T handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private const byte ByteCR = (byte)'\r';
         private const byte ByteLF = (byte)'\n';
         private const byte ByteColon = (byte)':';
+        private const byte ByteDot = (byte)'.';
         private const byte ByteSpace = (byte)' ';
         private const byte ByteTab = (byte)'\t';
         private const byte ByteQuestionMark = (byte)'?';
@@ -69,34 +70,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 customMethod = GetUnknownMethod(data, length, out offset);
             }
 
+            var parseInfo = new HttpRequestLineParseInfo(method);
+
             // Skip space
             offset++;
 
             byte ch = 0;
             // Target = Path and Query
-            var pathEncoded = false;
             var pathStart = -1;
             for (; offset < length; offset++)
             {
                 ch = data[offset];
                 if (ch == ByteSpace)
                 {
-                    if (pathStart == -1)
-                    {
-                        // Empty path is illegal
-                        RejectRequestLine(data, length);
-                    }
-
                     break;
                 }
                 else if (ch == ByteQuestionMark)
                 {
-                    if (pathStart == -1)
-                    {
-                        // Empty path is illegal
-                        RejectRequestLine(data, length);
-                    }
-
                     break;
                 }
                 else if (ch == BytePercentage)
@@ -104,10 +94,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     if (pathStart == -1)
                     {
                         // Path starting with % is illegal
-                        RejectRequestLine(data, length);
+                        break;
                     }
 
-                    pathEncoded = true;
+                    parseInfo.IsPathEncoded = true;
+                }
+                else if (ch == ByteDot)
+                {
+                    if (pathStart == -1)
+                    {
+                        pathStart = offset;
+                    }
+
+                    parseInfo.DoesPathContainDots = true;
                 }
                 else if (pathStart == -1)
                 {
@@ -117,11 +116,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
             if (pathStart == -1)
             {
-                // End of path not found
+                // Start of path not found, or empty path
                 RejectRequestLine(data, length);
             }
 
-            var pathBuffer = new Span<byte>(data + pathStart, offset - pathStart);
+            var pathLength = offset - pathStart;
 
             var queryStart = offset;
             // Query string
@@ -139,7 +138,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
 
             var targetBuffer = new Span<byte>(data + pathStart, offset - pathStart);
-            var query = new Span<byte>(data + queryStart, offset - queryStart);
+            var queryLength = offset - queryStart;
 
             // Consume space
             offset++;
@@ -151,15 +150,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 RejectUnknownVersion(data, length, offset);
             }
 
+            parseInfo.HttpVersion = httpVersion;
+
             //  After version 8 bytes and cr 1 byte, expect lf
             if (data[offset + 8 + 1] != ByteLF)
             {
                 RejectRequestLine(data, length);
             }
 
-            var line = new Span<byte>(data, length);
-
-            handler.OnStartLine(method, httpVersion, targetBuffer, pathBuffer, query, customMethod, line, pathEncoded);
+            handler.OnStartLine(parseInfo, targetBuffer, queryLength, customMethod);
         }
 
         public unsafe bool ParseHeaders<T>(T handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -61,10 +61,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         private unsafe void ParseRequestLine<T>(T handler, byte* data, int length) where T : IHttpRequestLineHandler
         {
-            int offset;
             Span<byte> customMethod;
             // Get Method and set the offset
-            var method = HttpUtilities.GetKnownMethod(data, length, out offset);
+            var method = HttpUtilities.GetKnownMethod(data, length, out int offset);
             if (method == HttpMethod.Custom)
             {
                 customMethod = GetUnknownMethod(data, length, out offset);

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/KestrelHttpParser.cs
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 RejectRequestLine(data, length);
             }
 
-            handler.OnStartLine(parseInfo, targetBuffer, queryLength, customMethod);
+            handler.OnRequestLine(parseInfo, targetBuffer, queryLength, customMethod);
         }
 
         public unsafe bool ParseHeaders<T>(T handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
@@ -392,19 +392,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
             return false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string VersionToString(HttpVersion httpVersion)
         {
-            switch (httpVersion)
+            Debug.Assert(httpVersion == HttpVersion.Http11 || httpVersion == HttpVersion.Http10);
+
+            if (httpVersion == HttpVersion.Http11)
             {
-                case HttpVersion.Http10:
-                    return Http10Version;
-                case HttpVersion.Http11:
-                    return Http11Version;
-                default:
-                    return null;
+                return Http11Version;
             }
+            return Http10Version;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string MethodToString(HttpMethod method)
         {
             // Pattern to avoid addtional range check since we are prechecking

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Infrastructure/HttpUtilities.cs
@@ -397,11 +397,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         {
             Debug.Assert(httpVersion == HttpVersion.Http11 || httpVersion == HttpVersion.Http10);
 
-            if (httpVersion == HttpVersion.Http11)
-            {
-                return Http11Version;
-            }
-            return Http10Version;
+            return (httpVersion == HttpVersion.Http11) ? Http11Version : Http10Version;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerLimits.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServerLimits.cs
@@ -96,6 +96,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), "Value must be a positive integer.");
                 }
+                // See HttpRequestLineParseInfo QueryLength
+                if (value > 0x1ffffff)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Value must be less than 32 MB.");
+                }
                 _maxRequestLineSize = value;
             }
         }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverhead.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverhead.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                     HttpVersion = HttpVersion.Http11
                 };
 
-                handler.OnStartLine(parseInfo, new Span<byte>(_target), 0, Span<byte>.Empty);
+                handler.OnRequestLine(parseInfo, new Span<byte>(_target), 0, Span<byte>.Empty);
 
                 consumed = buffer.Start;
                 examined = buffer.End;

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverhead.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverhead.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                     HttpVersion = HttpVersion.Http11
                 };
 
-                handler.OnRequestLine(parseInfo, new Span<byte>(_target), 0, Span<byte>.Empty);
+                handler.OnRequestLine(parseInfo, new Span<byte>(_target), Span<byte>.Empty);
 
                 consumed = buffer.Start;
                 examined = buffer.End;

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverhead.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverhead.cs
@@ -120,14 +120,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             public bool ParseRequestLine<T>(T handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler
             {
-                handler.OnStartLine(HttpMethod.Get,
-                    HttpVersion.Http11,
-                    new Span<byte>(_target),
-                    new Span<byte>(_target),
-                    Span<byte>.Empty,
-                    Span<byte>.Empty,
-                    new Span<byte>(_startLine),
-                    false);
+                var parseInfo = new HttpRequestLineParseInfo()
+                {
+                    HttpMethod = HttpMethod.Get,
+                    HttpVersion = HttpVersion.Http11
+                };
+
+                handler.OnStartLine(parseInfo, new Span<byte>(_target), 0, Span<byte>.Empty);
 
                 consumed = buffer.Start;
                 examined = buffer.End;

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KestrelHttpParser.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KestrelHttpParser.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             }
         }
 
-        public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, Span<byte> line, bool pathEncoded)
+        public void OnStartLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod)
         {
         }
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KestrelHttpParser.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KestrelHttpParser.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             }
         }
 
-        public void OnRequestLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod)
+        public void OnRequestLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, Span<byte> customMethod)
         {
         }
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KestrelHttpParser.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/KestrelHttpParser.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             }
         }
 
-        public void OnStartLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod)
+        public void OnRequestLine(HttpRequestLineParseInfo parseInfo, Span<byte> target, int queryLength, Span<byte> customMethod)
         {
         }
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
@@ -46,14 +46,14 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 .Setup(handler => handler.OnRequestLine(
                     It.IsAny<HttpRequestLineParseInfo>(),
                     It.IsAny<Span<byte>>(),
-                    It.IsAny<int>(),
                     It.IsAny<Span<byte>>()))
-                .Callback<HttpRequestLineParseInfo, Span<byte>, int, Span<byte>> ((parseDetails, target, queryLength, customMethod) =>
+                .Callback<HttpRequestLineParseInfo, Span<byte>, Span<byte>> ((parseDetails, target, customMethod) =>
                 {
                     var method = parseDetails.HttpMethod;
                     parsedMethod = method != HttpMethod.Custom ? HttpUtilities.MethodToString(method) : customMethod.GetAsciiStringNonNullCharacters();
                     parsedVersion = HttpUtilities.VersionToString(parseDetails.HttpVersion);
                     parsedRawTarget = target.GetAsciiStringNonNullCharacters();
+                    var queryLength = parseDetails.QueryLength;
                     parsedRawPath = target.Slice(0, target.Length - queryLength).GetAsciiStringNonNullCharacters();
                     parsedQuery = target.Slice(target.Length - queryLength, queryLength).GetAsciiStringNonNullCharacters();
                 });

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             string parsedQuery = null;
             var requestLineHandler = new Mock<IHttpRequestLineHandler>();
             requestLineHandler
-                .Setup(handler => handler.OnStartLine(
+                .Setup(handler => handler.OnRequestLine(
                     It.IsAny<HttpRequestLineParseInfo>(),
                     It.IsAny<Span<byte>>(),
                     It.IsAny<int>(),

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerLimitsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerLimitsTests.cs
@@ -75,6 +75,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [InlineData(int.MinValue)]
         [InlineData(-1)]
         [InlineData(0)]
+        [InlineData(0x1ffffff + 1)]
+        [InlineData(int.MaxValue)]
         public void MaxRequestLineSizeInvalid(int value)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
@@ -85,7 +87,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         [Theory]
         [InlineData(1)]
-        [InlineData(int.MaxValue)]
+        [InlineData(0x1ffffff)]
         public void MaxRequestLineSizeValid(int value)
         {
             var o = new KestrelServerLimits();

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         [Theory]
         [InlineData(1, 2)]
-        [InlineData(int.MaxValue - 1, int.MaxValue)]
+        [InlineData(0x1ffffff - 1, 0x1ffffff)]
         public void StartWithMaxRequestBufferSizeLessThanMaxRequestLineSizeThrows(long maxRequestBufferSize, int maxRequestLineSize)
         {
             var testLogger = new TestApplicationErrorLogger { ThrowOnCriticalErrors = false };


### PR DESCRIPTION
Rational
--
According to the [ABI (Application Binary Interface)](https://github.com/dotnet/coreclr/blob/master/Documentation/botr/clr-abi.md) you can pass 4 parameters in registers RCX, RDX, R8 & R9. After which the parameters are passed via stack (ignoring floats and vectors).

For instance methods `this` takes `RCX` so that leaves 3 params that can be passed by register.

Currently `OnStartLine` takes  

`this, byte, int, Span<byte>, Span<byte>, Span<byte>, Span<byte>, Span<byte>, bool`

Which for fast-span would be 14 arguments (19 for slow span)

`this, byte, int, (ptr, int), (ptr, int), (ptr, int), (ptr, int), (ptr, int), bool`

Which is way way passed the register count. However, the same amount of info can still be passed using less parameters; as most of the parameters are contained in each other; or can be reconstructed if needed (e.g. for exception detail).

This change reduces it to

`this, uint, Span<byte>, Span<byte>`

Which for fast span should be:

`this, uint, (ptr, int), (ptr, int)` 6 arguments

The first 4 passed via register and the final span by stack. The final span is `customMethod` and isn't commonly used.

So all the "hot" arguments for fast span should be passed via register. (Slow span some still would go via stack)

@jkotas would this be how fast-span would decompose via argument? (see below https://github.com/aspnet/KestrelHttpServer/pull/1479#issuecomment-285875907)

Other changes
---
Change `OnStartLine` ->  `OnRequestLine` - naming consistency 

Don't rescan to determine if path contains dots; as can precheck during first scan

Move all the exception processing to the right of the `throw` so its out of flow