### PR TITLE
Specify StringComparison when calling string.StartsWith

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/ServerAddress.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/ServerAddress.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         {
             get
             {
-                return Host.StartsWith(Constants.UnixPipeHostPrefix);
+                return Host.StartsWith(Constants.UnixPipeHostPrefix, StringComparison.Ordinal);
             }
         }
 


### PR DESCRIPTION
StartsWith does a culture-sensitive comparison by default. An ordinal comparison makes more sense here.