### PR TITLE
Avoid an unnecessary closure allocation in ListenerSecondary

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerSecondary.cs
@@ -109,13 +109,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     {
                         req.Dispose();
 
+                        var innerTcs = (TaskCompletionSource<int>)state;
                         if (ex != null)
                         {
-                            tcs.SetException(ex);
+                            innerTcs.SetException(ex);
                         }
                         else
                         {
-                            tcs.SetResult(0);
+                            innerTcs.SetResult(0);
                         }
                     },
                     tcs);


### PR DESCRIPTION
The tcs is being passed as the state, so use it from the state instead of closing over it.