### PR TITLE
Re-add .NET Framework to tests and other cleanup

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,9 +1,14 @@
 <Project>
   <PropertyGroup>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <AspNetCoreVersion>1.2.0-*</AspNetCoreVersion>
+    <CoreFxLabsPipelinesVersion>0.1.0-*</CoreFxLabsPipelinesVersion>
+    <CoreFxLabsVersion>0.1.0-*</CoreFxLabsVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <LibUvVersion>1.9.1</LibUvVersion>
-    <CoreFxLabsVersion>0.1.0-*</CoreFxLabsVersion>
-    <CoreFxLabsPipelinesVersion>0.1.0-*</CoreFxLabsPipelinesVersion>
+    <JsonNetVersion>9.0.1</JsonNetVersion>
+    <MoqVersion>4.7.1</MoqVersion>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <TestSdkVersion>15.0.0</TestSdkVersion>
+    <XunitVersion>2.2.0</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/samples/LargeResponseApp/LargeResponseApp.csproj
+++ b/samples/LargeResponseApp/LargeResponseApp.csproj
@@ -4,9 +4,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
-    <OutputType>Exe</OutputType>
-    <!-- TODO remove rid when https://github.com/dotnet/sdk/issues/396 is resolved -->
-    <RuntimeIdentifier Condition="'$(TargetFramework)'!='netcoreapp1.1'">win7-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -4,9 +4,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
-    <OutputType>Exe</OutputType>
-    <!-- TODO remove rid when https://github.com/dotnet/sdk/issues/396 is resolved -->
-    <RuntimeIdentifier Condition="'$(TargetFramework)'!='netcoreapp1.1'">win7-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -19,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.2.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Https/Microsoft.AspNetCore.Server.Kestrel.Https.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Https/Microsoft.AspNetCore.Server.Kestrel.Https.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="1.2.0-*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Microsoft.AspNetCore.Server.Kestrel.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Microsoft.AspNetCore.Server.Kestrel.csproj
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="Libuv" Version="$(LibUvVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="1.2.0-*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="System.Numerics.Vectors" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(CoreFxLabsPipelinesVersion)" />

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
@@ -3,10 +3,9 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
-    <!-- TODO remove rid when https://github.com/dotnet/sdk/issues/396 is resolved -->
-    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp1.1'">win7-x64</RuntimeIdentifier>
+    <PlatformTarget Condition="'$(TargetFramework)' == 'net46'">x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,19 +18,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
-    <PackageReference Include="Moq" Version="4.6.36-*" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
-    <PackageReference Include="xunit" Version="2.2.0-*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System.Net.Http" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Microsoft.AspNetCore.Server.Kestrel.Performance.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Microsoft.AspNetCore.Server.Kestrel.Performance.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.3" />
-    <PackageReference Include="Moq" Version="4.6.36-*" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameRequestStreamTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameRequestStreamTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             await Assert.ThrowsAsync<NotSupportedException>(() => stream.WriteAsync(new byte[1], 0, 1));
         }
 
-#if NET452
+#if NET46
         [Fact]
         public void BeginWriteThrows()
         {

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseStreamTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameResponseStreamTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             await Assert.ThrowsAsync<NotSupportedException>(() => stream.ReadAsync(new byte[1], 0, 1));
         }
 
-#if NET452
+#if NET46
         [Fact]
         public void BeginReadThrows()
         {

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/Microsoft.AspNetCore.Server.KestrelTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/Microsoft.AspNetCore.Server.KestrelTests.csproj
@@ -3,11 +3,10 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
+    <PlatformTarget Condition="'$(TargetFramework)' == 'net46'">x64</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- TODO remove rid when https://github.com/dotnet/sdk/issues/396 is resolved -->
-    <RuntimeIdentifier Condition="'$(TargetFramework)'!='netcoreapp1.1'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,16 +19,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
-    <PackageReference Include="Moq" Version="4.6.36-*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
-    <PackageReference Include="xunit" Version="2.2.0-*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System.Net.Http" />
+    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/Microsoft.AspNetCore.Server.KestrelTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/Microsoft.AspNetCore.Server.KestrelTests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="..\shared\**\*.cs" />
     <Content Include="..\shared\TestResources\testCert.pfx" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var t = Task.Run(async () =>
             {
                 var socket = TestConnection.CreateConnectedLoopbackSocket(port);
-#if NET452
+#if NET46
                 await Task.Factory.FromAsync(
                     socket.BeginSend,
                     socket.EndSend,
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var t = Task.Run(async () =>
             {
                 var socket = TestConnection.CreateConnectedLoopbackSocket(port);
-#if NET452
+#if NET46
                 await Task.Factory.FromAsync(
                     socket.BeginSend,
                     socket.EndSend,
@@ -221,7 +221,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                 var buffer = new ArraySegment<byte>(new byte[2048]);
                 while (true)
                 {
-#if NET452
+#if NET46
                     var count = await Task.Factory.FromAsync(
                         socket.BeginReceive,
                         socket.EndReceive,

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/xunit.runner.json
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/xunit.runner.schema",
+  "appDomain": "denied"
+}

--- a/test/shared/TestResources.cs
+++ b/test/shared/TestResources.cs
@@ -9,8 +9,8 @@ namespace Microsoft.AspNetCore.Testing
     public static class TestResources
     {
         private static readonly string _testCertificatePath =
-#if NET452
-            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.pfx");
+#if NET46
+            Path.Combine(Directory.GetCurrentDirectory(), "testCert.pfx");
 #else
             Path.Combine(AppContext.BaseDirectory, "testCert.pfx");
 #endif

--- a/tools/CodeGenerator/CodeGenerator.csproj
+++ b/tools/CodeGenerator/CodeGenerator.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.2.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Re-add .NET Framework testing. Resolves #1490 
Remove workarounds
Unify dependencies versions