### PR TITLE
Remove deprecated property KestrelServerOptions.MaxRequestBufferSize (#1027)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerOptions.cs
@@ -35,32 +35,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         public IServiceProvider ApplicationServices { get; set; }
 
         /// <summary>
-        /// <para>
-        /// This property is obsolete and will be removed in a future version.
-        /// Use <c>Limits.MaxRequestBufferSize</c> instead.
-        /// </para>
-        /// <para>
-        /// Gets or sets the maximum size of the request buffer.
-        /// </para>
-        /// </summary>
-        /// <remarks>
-        /// When set to null, the size of the request buffer is unlimited.
-        /// Defaults to 1,048,576 bytes (1 MB).
-        /// </remarks>
-        [Obsolete("This property is obsolete and will be removed in a future version. Use Limits.MaxRequestBufferSize instead.")]
-        public long? MaxRequestBufferSize
-        {
-            get
-            {
-                return Limits.MaxRequestBufferSize;
-            }
-            set
-            {
-                Limits.MaxRequestBufferSize = value;
-            }
-        }
-
-        /// <summary>
         /// Provides access to request limit options.
         /// </summary>
         public KestrelServerLimits Limits { get; } = new KestrelServerLimits();

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerOptionsTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq;
 using System.Net;
-using System.Reflection;
 using Microsoft.AspNetCore.Server.Kestrel;
 using Xunit;
 
@@ -12,34 +9,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 {
     public class KestrelServerOptionsTests
     {
-#pragma warning disable CS0618
-        [Fact]
-        public void MaxRequestBufferSizeIsMarkedObsolete()
-        {
-            Assert.NotNull(typeof(KestrelServerOptions)
-                .GetProperty(nameof(KestrelServerOptions.MaxRequestBufferSize))
-                .GetCustomAttributes(false)
-                .OfType<ObsoleteAttribute>()
-                .SingleOrDefault());
-        }
-
-        [Fact]
-        public void MaxRequestBufferSizeGetsLimitsProperty()
-        {
-            var o = new KestrelServerOptions();
-            o.Limits.MaxRequestBufferSize = 42;
-            Assert.Equal(42, o.MaxRequestBufferSize);
-        }
-
-        [Fact]
-        public void MaxRequestBufferSizeSetsLimitsProperty()
-        {
-            var o = new KestrelServerOptions();
-            o.MaxRequestBufferSize = 42;
-            Assert.Equal(42, o.Limits.MaxRequestBufferSize);
-        }
-#pragma warning restore CS0612
-
         [Fact]
         public void NoDelayDefaultsToTrue()
         {


### PR DESCRIPTION
#1027