### PR TITLE
Added fast path for single memory ReadableBuffer

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/StreamSocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Adapter/Internal/StreamSocketOutput.cs
@@ -109,10 +109,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Adapter.Internal
                             await _outputStream.FlushAsync();
                         }
 
-                        foreach (var memory in buffer)
+                        if (buffer.IsSingleSpan)
                         {
-                            var array = memory.GetArray();
+                            var array = buffer.First.GetArray();
                             await _outputStream.WriteAsync(array.Array, array.Offset, array.Count);
+                        }
+                        else
+                        {
+                            foreach (var memory in buffer)
+                            {
+                                var array = memory.GetArray();
+                                await _outputStream.WriteAsync(array.Array, array.Offset, array.Count);
+                            }
                         }
                     }
                     finally


### PR DESCRIPTION


## dev

```
Method |                       Type |      Mean |    StdDev |      Op/s | Allocated |
------- |--------------------------- |---------- |---------- |---------- |---------- |
 Output |                 LiveAspNet | 4.2506 us | 0.1189 us | 235261.79 |      69 B |
 Output |           PlaintextChunked | 2.4414 us | 0.0656 us | 409598.35 |      66 B |
 Output | PlaintextChunkedWithCookie | 3.1850 us | 0.1519 us | 313976.19 |      72 B |
 Output |        PlaintextWithCookie | 3.4107 us | 0.1431 us | 293194.98 |      72 B |
 Output |       TechEmpowerPlaintext | 2.7918 us | 0.1253 us | 358190.58 |      67 B |
 ```

## PR

```
  Method |                       Type |      Mean |    StdDev |      Op/s | Allocated |
------- |--------------------------- |---------- |---------- |---------- |---------- |
 Output |                 LiveAspNet | 4.0172 us | 0.2005 us | 248929.42 |      69 B |
 Output |           PlaintextChunked | 2.3485 us | 0.0878 us | 425802.79 |      66 B |
 Output | PlaintextChunkedWithCookie | 2.9458 us | 0.0977 us | 339465.57 |      71 B |
 Output |        PlaintextWithCookie | 3.1588 us | 0.1286 us | 316577.63 |      72 B |
 Output |       TechEmpowerPlaintext | 2.4686 us | 0.0777 us | 405082.32 |      67 B |
 ```