### PR TITLE
Fix benchmarks (broken)

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverheadBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverheadBenchmark.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             var connectionContext = new MockConnection();
             connectionContext.ListenerContext.ServiceContext.HttpParserFactory = frame => NullParser.Instance;
+            connectionContext.ListenerContext.ServiceContext.ServerOptions = new KestrelServerOptions();
 
             _frame = new Frame<object>(application: null, context: connectionContext);
         }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
@@ -9,9 +9,7 @@ using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
-using Moq;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 {
@@ -95,7 +93,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
                 ServerOptions = new KestrelServerOptions(),
-                Log = Mock.Of<IKestrelTrace>()
+                Log = new MockTrace()
             };
             var listenerContext = new ListenerContext(serviceContext)
             {
@@ -105,7 +103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             {
                 Input = socketInput,
                 Output = new MockSocketOutput(),
-                ConnectionControl = Mock.Of<IConnectionControl>()
+                ConnectionControl = new MockConnectionControl()
             };
             connectionContext.ListenerContext.ServiceContext.HttpParserFactory = f => new Internal.Http.KestrelHttpParser(log: null);
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Microsoft.AspNetCore.Server.Kestrel.Performance.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Microsoft.AspNetCore.Server.Kestrel.Performance.csproj
@@ -24,7 +24,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.3" />
-    <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Mocks/MockConnectionControl.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Mocks/MockConnectionControl.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    public class MockConnectionControl : IConnectionControl
+    {
+        public void CancelTimeout() { }
+        public void End(ProduceEndType endType) { }
+        public void Pause() { }
+        public void ResetTimeout(long milliseconds, TimeoutAction timeoutAction) { }
+        public void Resume() { }
+        public void SetTimeout(long milliseconds, TimeoutAction timeoutAction) { }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Mocks/MockTrace.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Mocks/MockTrace.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    public class MockTrace : IKestrelTrace
+    {
+        public void ApplicationError(string connectionId, Exception ex) { }
+        public IDisposable BeginScope<TState>(TState state) => null;
+        public void ConnectionBadRequest(string connectionId, BadHttpRequestException ex) { }
+        public void ConnectionDisconnect(string connectionId) { }
+        public void ConnectionDisconnectedWrite(string connectionId, int count, Exception ex) { }
+        public void ConnectionError(string connectionId, Exception ex) { }
+        public void ConnectionHeadResponseBodyWrite(string connectionId, long count) { }
+        public void ConnectionKeepAlive(string connectionId) { }
+        public void ConnectionPause(string connectionId) { }
+        public void ConnectionRead(string connectionId, int count) { }
+        public void ConnectionReadFin(string connectionId) { }
+        public void ConnectionReset(string connectionId) { }
+        public void ConnectionResume(string connectionId) { }
+        public void ConnectionStart(string connectionId) { }
+        public void ConnectionStop(string connectionId) { }
+        public void ConnectionWrite(string connectionId, int count) { }
+        public void ConnectionWriteCallback(string connectionId, int status) { }
+        public void ConnectionWriteFin(string connectionId) { }
+        public void ConnectionWroteFin(string connectionId, int status) { }
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) { }
+        public void NotAllConnectionsAborted() { }
+        public void NotAllConnectionsClosedGracefully() { }
+        public void RequestProcessingError(string connectionId, Exception ex) { }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             var connectionContext = new MockConnection();
             connectionContext.ListenerContext.ServiceContext.HttpParserFactory = frame => new KestrelHttpParser(frame.ConnectionContext.ListenerContext.ServiceContext.Log);
+            connectionContext.ListenerContext.ServiceContext.ServerOptions = new KestrelServerOptions();
 
             Frame = new Frame<object>(application: null, context: connectionContext);
             PipelineFactory = new PipeFactory();

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeaderCollectionBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeaderCollectionBenchmark.cs
@@ -169,6 +169,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             var connectionContext = new MockConnection();
             connectionContext.ListenerContext.ServiceContext.HttpParserFactory = f => new KestrelHttpParser(f.ConnectionContext.ListenerContext.ServiceContext.Log);
+            connectionContext.ListenerContext.ServiceContext.ServerOptions = new KestrelServerOptions();
             var frame = new Frame<object>(application: null, context: connectionContext);
             frame.Reset();
             frame.InitializeHeaders();

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
-using Moq;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 {
@@ -121,7 +120,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             {
                 DateHeaderValueManager = new DateHeaderValueManager(),
                 ServerOptions = new KestrelServerOptions(),
-                Log = Mock.Of<IKestrelTrace>()
+                Log = new MockTrace()
             };
 
             var listenerContext = new ListenerContext(serviceContext)
@@ -133,7 +132,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             {
                 Input = input,
                 Output = socketOutput,
-                ConnectionControl = Mock.Of<IConnectionControl>()
+                ConnectionControl = new MockConnectionControl()
             };
 
             connectionContext.ListenerContext.ServiceContext.HttpParserFactory = f => new KestrelHttpParser(log: null);

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
@@ -39,6 +39,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             _frame.Reset();
             _frame.StatusCode = 200;
+            _frame.HttpVersionEnum = HttpVersion.Http11;
+            _frame.KeepAlive = true;
 
             Task writeTask = Task.CompletedTask;
             switch (Type)
@@ -135,6 +137,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             };
 
             connectionContext.ListenerContext.ServiceContext.HttpParserFactory = f => new KestrelHttpParser(log: null);
+            connectionContext.ListenerContext.ServiceContext.ServerOptions = new KestrelServerOptions();
 
             var frame = new TestFrame<object>(application: null, context: connectionContext);
             frame.Reset();

--- a/test/shared/TestFrame.cs
+++ b/test/shared/TestFrame.cs
@@ -14,6 +14,18 @@ namespace Microsoft.AspNetCore.Testing
         {
         }
 
+        public HttpVersion HttpVersionEnum
+        {
+            get => _httpVersion;
+            set => _httpVersion = value;
+        }
+
+        public bool KeepAlive
+        {
+            get => _keepAlive;
+            set => _keepAlive = value;
+        }
+
         public Task ProduceEndAsync()
         {
             return ProduceEnd();


### PR DESCRIPTION
Benchmarks are broken and error when run
ResponseHeadersWritingBenchmark isn't testing common path as it doesn't set httpVersion or keepAlive
