### PR TITLE
Fix write after close

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ISocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ISocketOutput.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.IO.Pipelines;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
@@ -18,6 +17,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         Task WriteAsync(ArraySegment<byte> buffer, bool chunk = false, CancellationToken cancellationToken = default(CancellationToken));
         void Flush();
         Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken));
-        WritableBuffer Alloc();
+        void Write<T>(Action<WritableBuffer, T> write, T state);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/SocketOutput.cs
@@ -186,17 +186,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             return WriteAsync(_emptyData, cancellationToken);
         }
 
-        public WritableBuffer Alloc()
+        public void Write<T>(Action<WritableBuffer, T> callback, T state)
         {
             lock (_contextLock)
             {
                 if (_completed)
                 {
-                    // This is broken
-                    return default(WritableBuffer);
+                    return;
                 }
 
-                return _pipe.Writer.Alloc();
+                var buffer = _pipe.Writer.Alloc();
+                callback(buffer, state);
+                buffer.Commit();
             }
         }
 

--- a/test/shared/MockSocketOutput.cs
+++ b/test/shared/MockSocketOutput.cs
@@ -12,12 +12,8 @@ namespace Microsoft.AspNetCore.Testing
 {
     public class MockSocketOutput : ISocketOutput
     {
-        private PipeFactory _factory = new PipeFactory();
-        private IPipeWriter _writer;
-
         public MockSocketOutput()
         {
-            _writer = _factory.Create().Writer;
         }
 
         public void Write(ArraySegment<byte> buffer, bool chunk = false)
@@ -38,9 +34,9 @@ namespace Microsoft.AspNetCore.Testing
             return TaskCache.CompletedTask;
         }
 
-        public WritableBuffer Alloc()
+        public void Write<T>(Action<WritableBuffer, T> write, T state)
         {
-            return _writer.Alloc();
+
         }
     }
 }


### PR DESCRIPTION
- Change Alloc to be a Write with a callback that exposes the WritableBuffer.
This allows the ISocketOutput to implementation to not call the callback if
the underlying socket is dead.
- Added a new functional test

Fixes #1518 