### PR TITLE
Streamline CreateResponseHeader

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameHeaders.Generated.cs
@@ -5410,25 +5410,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }
         }
 
-        public void SetRawConnection(StringValues value, byte[] raw)
+        public void SetRawConnection(string value, byte[] raw)
         {
             _bits |= 2L;
             _headers._Connection = value;
             _headers._rawConnection = raw;
         }
-        public void SetRawDate(StringValues value, byte[] raw)
+        public void SetRawDate(string value, byte[] raw)
         {
             _bits |= 4L;
             _headers._Date = value;
             _headers._rawDate = raw;
         }
-        public void SetRawTransferEncoding(StringValues value, byte[] raw)
+        public void SetRawTransferEncoding(string value, byte[] raw)
         {
             _bits |= 64L;
             _headers._TransferEncoding = value;
             _headers._rawTransferEncoding = raw;
         }
-        public void SetRawServer(StringValues value, byte[] raw)
+        public void SetRawServer(string value, byte[] raw)
         {
             _bits |= 33554432L;
             _headers._Server = value;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameRequestHeaders.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameRequestHeaders.cs
@@ -13,6 +13,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
     public partial class FrameRequestHeaders : FrameHeaders
     {
+        public bool HasConnection => HeaderConnection.Count != 0;
+
+        public bool HasTransferEncoding => HeaderTransferEncoding.Count != 0;
+
         private static long ParseContentLength(string value)
         {
             long parsed;

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameResponseHeaders.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameResponseHeaders.cs
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using System.Text;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
@@ -16,6 +16,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
     {
         private static readonly byte[] _CrLf = new[] { (byte)'\r', (byte)'\n' };
         private static readonly byte[] _colonSpace = new[] { (byte)':', (byte)' ' };
+        private static readonly byte[] _bytesConnectionClose = Encoding.ASCII.GetBytes("\r\nConnection: close");
+        private static readonly byte[] _bytesConnectionKeepAlive = Encoding.ASCII.GetBytes("\r\nConnection: keep-alive");
 
         public bool HasConnection => HeaderConnection.Count != 0;
 
@@ -24,6 +26,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         public bool HasServer => HeaderServer.Count != 0;
 
         public bool HasDate => HeaderDate.Count != 0;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void SetConnectionClose()
+        {
+            SetRawConnection("close", _bytesConnectionClose);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void SetConnectionKeepAlive()
+        {
+            SetRawConnection("keep-alive", _bytesConnectionKeepAlive);
+        }
 
         public Enumerator GetEnumerator()
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/MessageBody.cs
@@ -236,9 +236,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             // see also http://tools.ietf.org/html/rfc2616#section-4.4
             var keepAlive = httpVersion != HttpVersion.Http10;
 
-            var connection = headers.HeaderConnection;
-            if (connection.Count > 0)
+            if (headers.HasConnection)
             {
+                var connection = headers.HeaderConnection;
                 var connectionOptions = FrameHeaders.ParseConnection(connection);
 
                 if ((connectionOptions & ConnectionOptions.Upgrade) == ConnectionOptions.Upgrade)
@@ -249,9 +249,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 keepAlive = (connectionOptions & ConnectionOptions.KeepAlive) == ConnectionOptions.KeepAlive;
             }
 
-            var transferEncoding = headers.HeaderTransferEncoding;
-            if (transferEncoding.Count > 0)
+            if (headers.HasTransferEncoding)
             {
+                var transferEncoding = headers.HeaderTransferEncoding;
                 var transferCoding = FrameHeaders.GetFinalTransferCoding(headers.HeaderTransferEncoding);
 
                 // https://tools.ietf.org/html/rfc7230#section-3.3.3

--- a/tools/CodeGenerator/KnownHeaders.cs
+++ b/tools/CodeGenerator/KnownHeaders.cs
@@ -343,7 +343,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             }}")}
         }}")}
 {Each(loop.Headers.Where(header => header.EnhancedSetter), header => $@"
-        public void SetRaw{header.Identifier}(StringValues value, byte[] raw)
+        public void SetRaw{header.Identifier}(string value, byte[] raw)
         {{
             {header.SetBit()};
             _headers._{header.Identifier} = value;


### PR DESCRIPTION
* Use `keepAlive` in register rather than memory location (multi use)
* Use `statusCode` in register rather than memory location (multi use)
* Use `httpVersion` in register rather than memory location (multi use)
* Only set `_canHaveBody` don't use it to test
* Make `StatusCanHaveBody` inlinable for 200OK responses (currently doesn't inline)
* `ReferenceEquals` test `Method` against `HttpMethods.Head` rather than string equals
* Only call `ParseConnection` when required rather than always
* Only call `GetFinalTransferCoding` when required rather than always
