### PR TITLE
Fix the invalid usages of Span<T>

### DIFF
--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpUtilitiesTest.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpUtilitiesTest.cs
@@ -120,11 +120,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             });
         }
 
-        private void TestKnownStringsInterning(string input, string expected, Func<Span<byte>, string> action)
+        private void TestKnownStringsInterning(string input, string expected, Func<byte[], string> action)
         {
             // Act
-            var knownString1 = action(new Span<byte>(Encoding.ASCII.GetBytes(input)));
-            var knownString2 = action(new Span<byte>(Encoding.ASCII.GetBytes(input)));
+            var knownString1 = action(Encoding.ASCII.GetBytes(input));
+            var knownString2 = action(Encoding.ASCII.GetBytes(input));
 
             // Assert
             Assert.Equal(knownString1, expected);


### PR DESCRIPTION
Found while converting to netcoreapp2.0. Doing it separately because we need to fix other things in that branch.

/cc @kichalla 