### PR TITLE
Add VSCode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ packages/
 artifacts/
 PublishProfiles/
 .vs/
-.vscode/
 *.user
 *.suo
 *.cache
@@ -26,8 +25,6 @@ nuget.exe
 *.ncrunchsolution
 *.*sdf
 *.ipch
-project.lock.json
-runtimes/
 .build/
 .testPublish/
 launchSettings.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "ms-vscode.csharp",
+    "EditorConfig.EditorConfig",
+    "k--kato.docomment",
+    "PeterJausovec.vscode-docker"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,75 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach: .NET Core",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    },
+    {
+      "name": "Debug: SampleApp",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "Compile: solution",
+      "program": "${workspaceRoot}/samples/SampleApp/bin/Debug/netcoreapp1.1/SampleApp.dll",
+      "args": [],
+      "cwd": "${workspaceRoot}/samples/SampleApp",
+      "console": "internalConsole",
+      "stopAtEntry": false,
+      "internalConsoleOptions": "openOnSessionStart",
+      "launchBrowser": {
+        "enabled": true,
+        "args": "${auto-detect-url}",
+        "windows": {
+          "command": "cmd.exe",
+          "args": "/C start ${auto-detect-url}"
+        },
+        "osx": {
+          "command": "open"
+        },
+        "linux": {
+          "command": "xdg-open"
+        }
+      }
+    },
+    {
+      "name": "Debug: LargeResponseApp",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "Compile: solution",
+      "program": "${workspaceRoot}/samples/LargeResponseApp/bin/Debug/netcoreapp1.1/LargeResponseApp.dll",
+      "args": [],
+      "cwd": "${workspaceRoot}/samples/LargeResponseApp",
+      "console": "internalConsole",
+      "stopAtEntry": false,
+      "internalConsoleOptions": "openOnSessionStart",
+      "launchBrowser": {
+        "enabled": true,
+        "args": "${auto-detect-url}",
+        "windows": {
+          "command": "cmd.exe",
+          "args": "/C start ${auto-detect-url}"
+        },
+        "osx": {
+          "command": "open"
+        },
+        "linux": {
+          "command": "xdg-open"
+        }
+      }
+    },
+    {
+      "name": "Debug: CodeGenerator",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "Compile: CodeGenerator",
+      "program": "${workspaceRoot}/tools/CodeGenerator/bin/Debug/netcoreapp1.1/CodeGenerator.dll",
+      "args": [],
+      "cwd": "${workspaceRoot}",
+      "console": "internalConsole",
+      "stopAtEntry": true,
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "[json]": {
+    "editor.tabSize": 2
+  },
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.associations": {
+    "*.props": "xml",
+    "*.targets": "xml"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,87 @@
+{
+  "version": "2.0.0",
+  "options": {
+    "env": {
+      "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "true"
+    }
+  },
+  "tasks": [
+    {
+      "taskName": "Restore: solution",
+      "command": "dotnet",
+      "args": [
+        "restore"
+      ]
+    },
+    {
+      "taskName": "Compile: solution",
+      "isBuildCommand": true,
+      "command": "dotnet",
+      "args": [
+        "build",
+        "${workspaceRoot}/KestrelHttpServer.sln"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "taskName": "Compile: CodeGenerator",
+      "command": "dotnet",
+      "args": [
+        "build"
+      ],
+      "options": {
+        "cwd": "${workspaceRoot}/tools/CodeGenerator/"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "taskName": "Run: CodeGenerator",
+      "command": "dotnet",
+      "args": [
+        "run"
+      ],
+      "options": {
+        "cwd": "${workspaceRoot}/tools/CodeGenerator/"
+      }
+    },
+    {
+      "taskName": "Run: Benchmarks",
+      "command": "dotnet",
+      "args": [
+        "run",
+        "-c",
+        "Release"
+      ],
+      "options": {
+        "cwd": "${workspaceRoot}/test/Microsoft.AspNetCore.Server.Kestrel.Performance/"
+      }
+    },
+    {
+      "taskName": "Test: KestrelTests",
+      "isTestCommand": true,
+      "command": "dotnet",
+      "args": [
+        "test",
+        "-f",
+        "netcoreapp1.1"
+      ],
+      "options": {
+        "cwd": "${workspaceRoot}/test/Microsoft.AspNetCore.Server.KestrelTests"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "taskName": "Test: FunctionalTests",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "-f",
+        "netcoreapp1.1"
+      ],
+      "options": {
+        "cwd": "${workspaceRoot}/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests"
+      },
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}


### PR DESCRIPTION
Two new categories of editor setting:

1. ~~Editor config. It's awesome, IMO should be used in all aspnet repos.~~ See https://github.com/aspnet/Universe/issues/500
2. VS Code settings.

~~VS 2017 already supports .editorconfig files. Future updates of Roslyn will actually enforce coding rules in the editorconfig file.~~

Got tired of re-writing my VSCode settings every time I forget to filter the .vscode folder when running git clean -xfd. Can we add here