### PR TITLE
Stub out IServer.Dispose

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
@@ -227,6 +227,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             }
         }
 
+        public void Stop()
+        {
+            Dispose();
+        }
+
         public void Dispose()
         {
             if (_disposables != null)


### PR DESCRIPTION
https://github.com/aspnet/Hosting/pull/995

This is a minimal implementation of the interface that achieves the basic behavior (gracefully stopping the server). I'll file a followup issue to separate out Dispose as an abortive shutdown.