### PR TITLE
Add Connection as a primary request header

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameHeaders.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameHeaders.Generated.cs
@@ -2661,6 +2661,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 return;
             }
             
+            if ((tempBits & 2L) != 0)
+            {
+                _headers._Connection = default(StringValues);
+                if((tempBits & ~2L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~2L;
+            }
+            
             if ((tempBits & 524288L) != 0)
             {
                 _headers._Accept = default(StringValues);
@@ -2699,16 +2709,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                     return;
                 }
                 tempBits &= ~1L;
-            }
-            
-            if ((tempBits & 2L) != 0)
-            {
-                _headers._Connection = default(StringValues);
-                if((tempBits & ~2L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~2L;
             }
             
             if ((tempBits & 4L) != 0)
@@ -3511,6 +3511,38 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 var stringValue = new StringValues(value);
                 switch (keyLength)
                 {
+                    case 10:
+                        {
+                            if ((((pUL[0] & 16131858542891098079uL) == 5283922227757993795uL) && ((pUS[4] & 57311u) == 20047u)))
+                            {
+                                if ((_bits & 2L) != 0)
+                                {
+                                    _headers._Connection = AppendValue(_headers._Connection, value);
+                                }
+                                else
+                                {
+                                    _bits |= 2L;
+                                    _headers._Connection = stringValue;
+                                }
+                                return;
+                            }
+                        
+                            if ((((pUL[0] & 16131858680330051551uL) == 4992030374873092949uL) && ((pUS[4] & 57311u) == 21582u)))
+                            {
+                                if ((_bits & 549755813888L) != 0)
+                                {
+                                    _headers._UserAgent = AppendValue(_headers._UserAgent, value);
+                                }
+                                else
+                                {
+                                    _bits |= 549755813888L;
+                                    _headers._UserAgent = stringValue;
+                                }
+                                return;
+                            }
+                        }
+                        break;
+                
                     case 6:
                         {
                             if ((((pUI[0] & 3755991007u) == 1162036033u) && ((pUS[2] & 57311u) == 21584u)))
@@ -3541,24 +3573,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                                 {
                                     _bits |= 134217728L;
                                     _headers._Host = stringValue;
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
-                    case 10:
-                        {
-                            if ((((pUL[0] & 16131858680330051551uL) == 4992030374873092949uL) && ((pUS[4] & 57311u) == 21582u)))
-                            {
-                                if ((_bits & 549755813888L) != 0)
-                                {
-                                    _headers._UserAgent = AppendValue(_headers._UserAgent, value);
-                                }
-                                else
-                                {
-                                    _bits |= 549755813888L;
-                                    _headers._UserAgent = stringValue;
                                 }
                                 return;
                             }
@@ -3652,38 +3666,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                         }
                         break;
                 
-                    case 10:
-                        {
-                            if ((((pUL[0] & 16131858542891098079uL) == 5283922227757993795uL) && ((pUS[4] & 57311u) == 20047u)))
-                            {
-                                if ((_bits & 2L) != 0)
-                                {
-                                    _headers._Connection = AppendValue(_headers._Connection, value);
-                                }
-                                else
-                                {
-                                    _bits |= 2L;
-                                    _headers._Connection = stringValue;
-                                }
-                                return;
-                            }
-                        
-                            if ((((pUL[0] & 16131858680330051551uL) == 5281668125874799947uL) && ((pUS[4] & 57311u) == 17750u)))
-                            {
-                                if ((_bits & 8L) != 0)
-                                {
-                                    _headers._KeepAlive = AppendValue(_headers._KeepAlive, value);
-                                }
-                                else
-                                {
-                                    _bits |= 8L;
-                                    _headers._KeepAlive = stringValue;
-                                }
-                                return;
-                            }
-                        }
-                        break;
-                
                     case 4:
                         {
                             if ((((pUI[0] & 3755991007u) == 1163149636u)))
@@ -3710,6 +3692,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                                 {
                                     _bits |= 67108864L;
                                     _headers._From = stringValue;
+                                }
+                                return;
+                            }
+                        }
+                        break;
+                
+                    case 10:
+                        {
+                            if ((((pUL[0] & 16131858680330051551uL) == 5281668125874799947uL) && ((pUS[4] & 57311u) == 17750u)))
+                            {
+                                if ((_bits & 8L) != 0)
+                                {
+                                    _headers._KeepAlive = AppendValue(_headers._KeepAlive, value);
+                                }
+                                else
+                                {
+                                    _bits |= 8L;
+                                    _headers._KeepAlive = stringValue;
                                 }
                                 return;
                             }

--- a/tools/CodeGenerator/KnownHeaders.cs
+++ b/tools/CodeGenerator/KnownHeaders.cs
@@ -128,9 +128,9 @@ namespace CodeGenerator
             var requestPrimaryHeaders = new[]
             {
                 "Accept",
+                "Connection",
                 "Host",
                 "User-Agent"
-
             };
             var responsePrimaryHeaders = new[]
             {


### PR DESCRIPTION
Resolves #1482 
cc @benaadams
**dev**
```
                        Method |      Mean |    StdDev |      Op/s | Scaled | Scaled-StdDev | Allocated |
------------------------------ |---------- |---------- |---------- |------- |-------------- |---------- |
          PlaintextTechEmpower | 1.3681 us | 0.0243 us | 730914.71 |   1.00 |          0.00 |     349 B |
          PlaintextAbsoluteUri | 2.5020 us | 0.0458 us | 399688.23 |   1.83 |          0.05 |     693 B |
 PipelinedPlaintextTechEmpower | 1.2069 us | 0.0307 us | 828549.59 |   0.88 |          0.03 |     348 B |
                    LiveAspNet | 2.7951 us | 0.0431 us | 357770.44 |   2.04 |          0.05 |   1.07 kB |
           PipelinedLiveAspNet | 2.7058 us | 0.0837 us | 369572.14 |   1.98 |          0.07 |   1.07 kB |
                       Unicode | 4.6382 us | 0.0997 us | 215601.91 |   3.39 |          0.09 |   1.85 kB |
              UnicodePipelined | 4.4694 us | 0.0597 us | 223741.73 |   3.27 |          0.07 |   1.86 kB |
```

**namc/primary-header**
```
                        Method |      Mean |    StdDev |      Op/s | Scaled | Scaled-StdDev | Allocated |
------------------------------ |---------- |---------- |---------- |------- |-------------- |---------- |
          PlaintextTechEmpower | 1.3279 us | 0.0262 us | 753046.25 |   1.00 |          0.00 |     349 B |
          PlaintextAbsoluteUri | 2.3808 us | 0.0536 us | 420035.04 |   1.79 |          0.05 |     693 B |
 PipelinedPlaintextTechEmpower | 1.1522 us | 0.0228 us | 867933.06 |   0.87 |          0.02 |     348 B |
                    LiveAspNet | 2.8840 us | 0.4161 us | 346736.69 |   2.17 |          0.31 |   1.07 kB |
           PipelinedLiveAspNet | 2.6187 us | 0.0502 us | 381871.33 |   1.97 |          0.05 |   1.07 kB |
                       Unicode | 4.6840 us | 0.2503 us | 213493.65 |   3.53 |          0.20 |   1.85 kB |
              UnicodePipelined | 4.4318 us | 0.0819 us | 225642.36 |   3.34 |          0.09 |   1.86 kB |
```