### PR TITLE
More decoupling

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ServerAddressesFeature.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ServerAddressesFeature.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
+{
+    internal class ServerAddressesFeature : IServerAddressesFeature
+    {
+        public ICollection<string> Addresses { get; } = new List<string>();
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ServerAddressesFeature.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ServerAddressesFeature.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -8,5 +11,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
     internal class ServerAddressesFeature : IServerAddressesFeature
     {
         public ICollection<string> Addresses { get; } = new List<string>();
+        public bool PreferHostingUrls { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -13,9 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libuv" Version="$(LibUvVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="System.Numerics.Vectors" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(CoreFxVersion)" />

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Https/Internal/TlsConnectionFeature.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Https/Internal/TlsConnectionFeature.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
+{
+    internal class TlsConnectionFeature : ITlsConnectionFeature
+    {
+        public X509Certificate2 ClientCertificate { get; set; }
+
+        public Task<X509Certificate2> GetClientCertificateAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(ClientCertificate);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Https/Microsoft.AspNetCore.Server.Kestrel.Https.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Https/Microsoft.AspNetCore.Server.Kestrel.Https.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Https/Microsoft.AspNetCore.Server.Kestrel.Https.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Https/Microsoft.AspNetCore.Server.Kestrel.Https.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Microsoft.AspNetCore.Server.Kestrel.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Microsoft.AspNetCore.Server.Kestrel.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Server.Kestrel.Core\Microsoft.AspNetCore.Server.Kestrel.Core.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv\Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- Remove Libuv and Hosting dependency from Kestrel.Core
- Kestrel.Core depends on Hosting.Abstractions