### PR TITLE
Fixed regression caused by transport refactoring

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Connection.cs
@@ -80,16 +80,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 // Start socket prior to applying the ConnectionAdapter
                 _socket.ReadStart(_allocCallback, _readCallback, this);
                 _lastTimestamp = Thread.Loop.Now();
-
-                // This *must* happen after socket.ReadStart
-                // The socket output consumer is the only thing that can close the connection. If the 
-                // output pipe is already closed by the time we start then it's fine since, it'll close gracefully afterwards.
-                var ignore = Output.StartWrites();
             }
             catch (Exception e)
             {
                 Log.LogError(0, e, "Connection.StartFrame");
                 throw;
+            }
+            finally
+            {
+                // The socket output consumer is the only thing that can close the connection. If the 
+                // output pipe is already closed by the time we start then it's fine since, it'll close gracefully afterwards.
+                var ignore = Output?.StartWrites();
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Connection.cs
@@ -80,17 +80,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 // Start socket prior to applying the ConnectionAdapter
                 _socket.ReadStart(_allocCallback, _readCallback, this);
                 _lastTimestamp = Thread.Loop.Now();
+
+                // This *must* happen after socket.ReadStart
+                // The socket output consumer is the only thing that can close the connection. If the 
+                // output pipe is already closed by the time we start then it's fine since, it'll close gracefully afterwards.
+                var ignore = Output.StartWrites();
             }
             catch (Exception e)
             {
                 Log.LogError(0, e, "Connection.StartFrame");
                 throw;
-            }
-            finally
-            {
-                // The socket output consumer is the only thing that can close the connection. If the 
-                // output pipe is already closed by the time we start then it's fine since, it'll close gracefully afterwards.
-                var ignore = Output?.StartWrites();
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
@@ -527,6 +527,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             var socket = new MockSocket(_mockLibuv, _kestrelThread.Loop.ThreadId, new TestKestrelTrace());
             var socketOutput = new SocketOutputProducer(pipe.Writer, frame, "0", trace);
             var consumer = new SocketOutputConsumer(pipe.Reader, _kestrelThread, socket, connection ?? new MockConnection(), "0", trace);
+            var ignore = consumer.StartWrites();
 
             return socketOutput;
         }

--- a/test/shared/MockConnection.cs
+++ b/test/shared/MockConnection.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Testing
             return TaskCache.CompletedTask;
         }
 
-        public override void OnSocketClosed()
+        public override void Close()
         {
             _socketClosedTcs.SetResult(null);
         }


### PR DESCRIPTION
- Libuv should not close the socket until it has started it. Before this was enforced
by calling ReadStart before starting the frame but the flow has changed. Now that closing the connection
is communicated via the pipe, we need to start consuming writes after calling ReadStart.
- Renamed OnSocketClosed to Close and moved dispose and logging into that method.

Fixes #1571