### PR TITLE
Update libuv package

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
     <CoreFxLabsVersion>0.1.0-*</CoreFxLabsVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.0.0-*</InternalAspNetCoreSdkVersion>
-    <LibUvVersion>1.9.1</LibUvVersion>
+    <LibUvVersion>1.10.0-*</LibUvVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.1</MoqVersion>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/Dockerfile
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/Dockerfile
@@ -3,10 +3,6 @@ FROM microsoft/dotnet-nightly:2.0-runtime-deps
 # The "container" environment variable is read by systemd.
 ENV container=docker
 
-# We're copying assets from an ubuntu machine over the container make the RID
-# match
-ENV DOTNET_RUNTIME_ID=ubuntu.14.04-x64
-
 # This is required by systemd and won't work without "dotnet run --privileged".
 VOLUME ["/sys/fs/cgroup"]
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/activate-kestrel.service
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/activate-kestrel.service
@@ -5,4 +5,3 @@ Requires=activate-kestrel.socket
 ExecStart=/usr/bin/dotnet SampleApp.dll
 WorkingDirectory=/publish
 NonBlocking=true
-Environment="DOTNET_RUNTIME_ID=ubuntu.14.04-x64"


### PR DESCRIPTION
- The latest libuv package has a new linux RID that should
let us remove the work around with setting the RID
in the docker file and systemd service (though there's still a bug in corehost see https://github.com/dotnet/core-setup/issues/1903)