### PR TITLE
Don't update consumed if we didn't see a new line

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/KestrelHttpParser.cs
@@ -41,10 +41,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 consumed = buffer.Move(consumed, lineIndex + 1);
                 span = span.Slice(0, lineIndex + 1);
             }
-            else if (buffer.IsSingleSpan || !TryGetNewLineSpan(ref buffer, ref span, out consumed))
+            else if (buffer.IsSingleSpan)
             {
                 // No request line end
                 return false;
+            }
+            else
+            {
+                if (TryGetNewLine(ref buffer, out var found))
+                {
+                    span = buffer.Slice(consumed, found).ToSpan();
+                    consumed = found;
+                }
+                else
+                {
+                    // No request line end
+                    return false;
+                }
             }
 
             // Fix and parse the span
@@ -429,16 +442,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             return true;
         }
 
-
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static bool TryGetNewLineSpan(ref ReadableBuffer buffer, ref Span<byte> span, out ReadCursor end)
+        private static bool TryGetNewLine(ref ReadableBuffer buffer, out ReadCursor found)
         {
             var start = buffer.Start;
-            if (ReadCursorOperations.Seek(start, buffer.End, out end, ByteLF) != -1)
+            if (ReadCursorOperations.Seek(start, buffer.End, out found, ByteLF) != -1)
             {
                 // Move 1 byte past the \n
-                end = buffer.Move(end, 1);
-                span = buffer.Slice(start, end).ToSpan();
+                found = buffer.Move(found, 1);
                 return true;
             }
             return false;

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/KestrelHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/KestrelHttpParser.cs
@@ -46,18 +46,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                 // No request line end
                 return false;
             }
+            else if (TryGetNewLine(ref buffer, out var found))
+            {
+                span = buffer.Slice(consumed, found).ToSpan();
+                consumed = found;
+            }
             else
             {
-                if (TryGetNewLine(ref buffer, out var found))
-                {
-                    span = buffer.Slice(consumed, found).ToSpan();
-                    consumed = found;
-                }
-                else
-                {
-                    // No request line end
-                    return false;
-                }
+                // No request line end
+                return false;
             }
 
             // Fix and parse the span

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
@@ -371,11 +371,9 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var parser = CreateParser(Mock.Of<IKestrelTrace>());
             var buffer = BufferUtilities.CreateBuffer("GET ", "/");
-            var consumed = buffer.Start;
-            var examined = buffer.End;
 
             var requestHandler = new RequestHandler();
-            var result = parser.ParseRequestLine(requestHandler, buffer, out consumed, out examined);
+            var result = parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined);
 
             Assert.False(result);
             Assert.Equal(buffer.Start, consumed);

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/HttpParserTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO.Pipelines;
+using System.IO.Pipelines.Testing;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -363,6 +364,22 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             Assert.Equal("Invalid request header: ''", exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
+        }
+
+        [Fact]
+        public void ParseRequestLineSplitBufferWithoutNewLineDoesNotUpdateConsumed()
+        {
+            var parser = CreateParser(Mock.Of<IKestrelTrace>());
+            var buffer = BufferUtilities.CreateBuffer("GET ", "/");
+            var consumed = buffer.Start;
+            var examined = buffer.End;
+
+            var requestHandler = new RequestHandler();
+            var result = parser.ParseRequestLine(requestHandler, buffer, out consumed, out examined);
+
+            Assert.False(result);
+            Assert.Equal(buffer.Start, consumed);
+            Assert.Equal(buffer.End, examined);
         }
 
         private void VerifyHeader(


### PR DESCRIPTION
- The start line parser incorrectly updated the consumed cursor
when it attempted to find new lines across multi span buffers. This change fixes
that and also removes passing the span by reference (which will be illegal).
- Added a unit test

Fixes #1580

/cc @benaadams 

Perf dropped a little in some cases, will see what I can do:

**EDIT: Seemed like it is noise, a re-run shows comparable results**

## dev


```
                        Method |      Mean |    StdDev |      Op/s | Scaled | Scaled-StdDev | Allocated |
------------------------------ |---------- |---------- |---------- |------- |-------------- |---------- |
          PlaintextTechEmpower | 1.5846 us | 0.0361 us | 631077.18 |   1.00 |          0.00 |     349 B |
          PlaintextAbsoluteUri | 2.5110 us | 0.0664 us | 398243.95 |   1.59 |          0.05 |     573 B |
 PipelinedPlaintextTechEmpower | 1.4053 us | 0.0306 us | 711610.92 |   0.89 |          0.03 |     348 B |
                    LiveAspNet | 3.3238 us | 0.0798 us | 300859.14 |   2.10 |          0.07 |   1.07 kB |
           PipelinedLiveAspNet | 3.2234 us | 0.0707 us | 310235.44 |   2.04 |          0.06 |   1.07 kB |
                       Unicode | 5.1536 us | 0.0998 us | 194038.76 |   3.25 |          0.10 |   1.85 kB |
              UnicodePipelined | 5.5307 us | 0.0982 us | 180809.27 |   3.49 |          0.10 |   1.86 kB |
```


## PR

```
                        Method |      Mean |    StdDev |      Op/s | Scaled | Scaled-StdDev | Allocated |
------------------------------ |---------- |---------- |---------- |------- |-------------- |---------- |
          PlaintextTechEmpower | 1.5814 us | 0.0471 us |  632339.4 |   1.00 |          0.00 |     349 B |
          PlaintextAbsoluteUri | 2.5067 us | 0.0482 us | 398924.18 |   1.59 |          0.05 |     573 B |
 PipelinedPlaintextTechEmpower | 1.4046 us | 0.0408 us | 711938.17 |   0.89 |          0.04 |     348 B |
                    LiveAspNet | 3.2545 us | 0.0559 us | 307264.41 |   2.06 |          0.07 |   1.07 kB |
           PipelinedLiveAspNet | 3.3229 us | 0.0807 us |  300943.8 |   2.10 |          0.08 |   1.07 kB |
                       Unicode | 5.3230 us | 0.1582 us | 187862.97 |   3.37 |          0.14 |   1.85 kB |
              UnicodePipelined | 5.5535 us | 0.1448 us | 180066.23 |   3.51 |          0.14 |   1.86 kB |
```