### PR TITLE
Remove Kestrel.Core dependency from Transport.Libuv (#1584)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Microsoft.Extensions.Logging;
 
@@ -9,29 +12,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
         void ConnectionStop(string connectionId);
 
-        void ConnectionRead(string connectionId, int count);
-
         void ConnectionPause(string connectionId);
 
         void ConnectionResume(string connectionId);
 
-        void ConnectionReadFin(string connectionId);
-
-        void ConnectionWriteFin(string connectionId);
-
-        void ConnectionWroteFin(string connectionId, int status);
-
         void ConnectionKeepAlive(string connectionId);
 
         void ConnectionDisconnect(string connectionId);
-
-        void ConnectionWrite(string connectionId, int count);
-
-        void ConnectionWriteCallback(string connectionId, int status);
-
-        void ConnectionError(string connectionId, Exception ex);
-
-        void ConnectionReset(string connectionId);
 
         void RequestProcessingError(string connectionId, Exception ex);
 
@@ -40,10 +27,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         void ConnectionHeadResponseBodyWrite(string connectionId, long count);
 
         void ConnectionBadRequest(string connectionId, BadHttpRequestException ex);
-
-        void NotAllConnectionsClosedGracefully();
-
-        void NotAllConnectionsAborted();
 
         void ApplicationError(string connectionId, string traceIdentifier, Exception ex);
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
@@ -18,22 +18,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         private static readonly Action<ILogger, string, Exception> _connectionStop =
             LoggerMessage.Define<string>(LogLevel.Debug, 2, @"Connection id ""{ConnectionId}"" stopped.");
 
-        // ConnectionRead: Reserved: 3
-
         private static readonly Action<ILogger, string, Exception> _connectionPause =
             LoggerMessage.Define<string>(LogLevel.Debug, 4, @"Connection id ""{ConnectionId}"" paused.");
 
         private static readonly Action<ILogger, string, Exception> _connectionResume =
             LoggerMessage.Define<string>(LogLevel.Debug, 5, @"Connection id ""{ConnectionId}"" resumed.");
-
-        private static readonly Action<ILogger, string, Exception> _connectionReadFin =
-            LoggerMessage.Define<string>(LogLevel.Debug, 6, @"Connection id ""{ConnectionId}"" received FIN.");
-
-        private static readonly Action<ILogger, string, Exception> _connectionWriteFin =
-            LoggerMessage.Define<string>(LogLevel.Debug, 7, @"Connection id ""{ConnectionId}"" sending FIN.");
-
-        private static readonly Action<ILogger, string, int, Exception> _connectionWroteFin =
-            LoggerMessage.Define<string, int>(LogLevel.Debug, 8, @"Connection id ""{ConnectionId}"" sent FIN with status ""{Status}"".");
 
         private static readonly Action<ILogger, string, Exception> _connectionKeepAlive =
             LoggerMessage.Define<string>(LogLevel.Debug, 9, @"Connection id ""{ConnectionId}"" completed keep alive response.");
@@ -41,21 +30,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         private static readonly Action<ILogger, string, Exception> _connectionDisconnect =
             LoggerMessage.Define<string>(LogLevel.Debug, 10, @"Connection id ""{ConnectionId}"" disconnecting.");
 
-        // ConnectionWrite: Reserved: 11
-
-        // ConnectionWriteCallback: Reserved: 12
-
         private static readonly Action<ILogger, string, string, Exception> _applicationError =
             LoggerMessage.Define<string, string>(LogLevel.Error, 13, @"Connection id ""{ConnectionId}"", Request id ""{TraceIdentifier}"": An unhandled exception was thrown by the application.");
 
-        private static readonly Action<ILogger, string, Exception> _connectionError =
-            LoggerMessage.Define<string>(LogLevel.Information, 14, @"Connection id ""{ConnectionId}"" communication error.");
-
         private static readonly Action<ILogger, string, int, Exception> _connectionDisconnectedWrite =
             LoggerMessage.Define<string, int>(LogLevel.Debug, 15, @"Connection id ""{ConnectionId}"" write of ""{count}"" bytes to disconnected client.");
-
-        private static readonly Action<ILogger, Exception> _notAllConnectionsClosedGracefully =
-            LoggerMessage.Define(LogLevel.Debug, 16, "Some connections failed to close gracefully during server shutdown.");
 
         private static readonly Action<ILogger, string, string, Exception> _connectionBadRequest =
             LoggerMessage.Define<string, string>(LogLevel.Information, 17, @"Connection id ""{ConnectionId}"" bad request data: ""{message}""");
@@ -63,14 +42,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         private static readonly Action<ILogger, string, long, Exception> _connectionHeadResponseBodyWrite =
             LoggerMessage.Define<string, long>(LogLevel.Debug, 18, @"Connection id ""{ConnectionId}"" write of ""{count}"" body bytes to non-body HEAD response.");
 
-        private static readonly Action<ILogger, string, Exception> _connectionReset =
-            LoggerMessage.Define<string>(LogLevel.Debug, 19, @"Connection id ""{ConnectionId}"" reset.");
-
         private static readonly Action<ILogger, string, Exception> _requestProcessingError =
             LoggerMessage.Define<string>(LogLevel.Information, 20, @"Connection id ""{ConnectionId}"" request processing ended abnormally.");
-
-        private static readonly Action<ILogger, Exception> _notAllConnectionsAborted =
-            LoggerMessage.Define(LogLevel.Debug, 21, "Some connections failed to abort during server shutdown.");
 
         protected readonly ILogger _logger;
 
@@ -89,12 +62,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
             _connectionStop(_logger, connectionId, null);
         }
 
-        public virtual void ConnectionRead(string connectionId, int count)
-        {
-            // Don't log for now since this could be *too* verbose.
-            // Reserved: Event ID 3
-        }
-
         public virtual void ConnectionPause(string connectionId)
         {
             _connectionPause(_logger, connectionId, null);
@@ -103,21 +70,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         public virtual void ConnectionResume(string connectionId)
         {
             _connectionResume(_logger, connectionId, null);
-        }
-
-        public virtual void ConnectionReadFin(string connectionId)
-        {
-            _connectionReadFin(_logger, connectionId, null);
-        }
-
-        public virtual void ConnectionWriteFin(string connectionId)
-        {
-            _connectionWriteFin(_logger, connectionId, null);
-        }
-
-        public virtual void ConnectionWroteFin(string connectionId, int status)
-        {
-            _connectionWroteFin(_logger, connectionId, status, null);
         }
 
         public virtual void ConnectionKeepAlive(string connectionId)
@@ -130,26 +82,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
             _connectionDisconnect(_logger, connectionId, null);
         }
 
-        public virtual void ConnectionWrite(string connectionId, int count)
-        {
-            // Don't log for now since this could be *too* verbose.
-            // Reserved: Event ID 11
-        }
-
-        public virtual void ConnectionWriteCallback(string connectionId, int status)
-        {
-            // Don't log for now since this could be *too* verbose.
-            // Reserved: Event ID 12
-        }
-
         public virtual void ApplicationError(string connectionId, string traceIdentifier, Exception ex)
         {
             _applicationError(_logger, connectionId, traceIdentifier, ex);
-        }
-
-        public virtual void ConnectionError(string connectionId, Exception ex)
-        {
-            _connectionError(_logger, connectionId, ex);
         }
 
         public virtual void ConnectionDisconnectedWrite(string connectionId, int count, Exception ex)
@@ -162,24 +97,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
             _connectionHeadResponseBodyWrite(_logger, connectionId, count, null);
         }
 
-        public virtual void NotAllConnectionsClosedGracefully()
-        {
-            _notAllConnectionsClosedGracefully(_logger, null);
-        }
-
-        public virtual void NotAllConnectionsAborted()
-        {
-            _notAllConnectionsAborted(_logger, null);
-        }
-
         public void ConnectionBadRequest(string connectionId, BadHttpRequestException ex)
         {
             _connectionBadRequest(_logger, connectionId, ex.Message, ex);
-        }
-
-        public virtual void ConnectionReset(string connectionId)
-        {
-            _connectionReset(_logger, connectionId, null);
         }
 
         public virtual void RequestProcessingError(string connectionId, Exception ex)
@@ -188,18 +108,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-        {
-            _logger.Log(logLevel, eventId, state, exception, formatter);
-        }
+            => _logger.Log(logLevel, eventId, state, exception, formatter);
 
-        public virtual bool IsEnabled(LogLevel logLevel)
-        {
-            return _logger.IsEnabled(logLevel);
-        }
+        public virtual bool IsEnabled(LogLevel logLevel) => _logger.IsEnabled(logLevel);
 
-        public virtual IDisposable BeginScope<TState>(TState state)
-        {
-            return _logger.BeginScope(state);
-        }
+        public virtual IDisposable BeginScope<TState>(TState state) => _logger.BeginScope(state);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -56,7 +55,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             Options = options.Value ?? new KestrelServerOptions();
             InternalOptions = new InternalKestrelServerOptions();
             _transportFactory = transportFactory;
-            _logger = loggerFactory.CreateLogger(typeof(KestrelServer).GetTypeInfo().Namespace);
+            _logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel");
             Features = new FeatureCollection();
             _serverAddresses = new ServerAddressesFeature();
             Features.Set(_serverAddresses);

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Connection.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
@@ -59,7 +60,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         public IPipeWriter Input { get; set; }
         public SocketOutputConsumer Output { get; set; }
 
-        private IKestrelTrace Log => ListenerContext.TransportContext.Log;
+        private ILibuvTrace Log => ListenerContext.TransportContext.Log;
         private IConnectionHandler ConnectionHandler => ListenerContext.TransportContext.ConnectionHandler;
         private KestrelThread Thread => ListenerContext.Thread;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Listener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Listener.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
@@ -24,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         protected UvStreamHandle ListenSocket { get; private set; }
 
-        public IKestrelTrace Log => TransportContext.Log;
+        public ILibuvTrace Log => TransportContext.Log;
 
         public Task StartAsync(
             IEndPointInformation endPointInformation,

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/ListenerSecondary.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
@@ -32,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         UvPipeHandle DispatchPipe { get; set; }
 
-        public IKestrelTrace Log => TransportContext.Log;
+        public ILibuvTrace Log => TransportContext.Log;
 
         public Task StartAsync(
             string pipeName,

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/SocketOutputConsumer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/SocketOutputConsumer.cs
@@ -6,6 +6,7 @@ using System.IO.Pipelines;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
@@ -15,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private readonly UvStreamHandle _socket;
         private readonly Connection _connection;
         private readonly string _connectionId;
-        private readonly IKestrelTrace _log;
+        private readonly ILibuvTrace _log;
 
         private readonly WriteReqPool _writeReqPool;
         private readonly IPipeReader _pipe;
@@ -26,7 +27,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             UvStreamHandle socket,
             Connection connection,
             string connectionId,
-            IKestrelTrace log)
+            ILibuvTrace log)
         {
             _pipe = pipe;
             // We need to have empty pipe at this moment so callback

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/ILibuvTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/ILibuvTrace.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure
+{
+    public interface ILibuvTrace : ILogger
+    {
+        void ConnectionRead(string connectionId, int count);
+
+        void ConnectionReadFin(string connectionId);
+
+        void ConnectionWriteFin(string connectionId);
+
+        void ConnectionWroteFin(string connectionId, int status);
+
+        void ConnectionWrite(string connectionId, int count);
+
+        void ConnectionWriteCallback(string connectionId, int status);
+
+        void ConnectionError(string connectionId, Exception ex);
+
+        void ConnectionReset(string connectionId);
+
+        void NotAllConnectionsClosedGracefully();
+
+        void NotAllConnectionsAborted();
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/KestrelThread.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal
@@ -52,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         private bool _stopImmediate = false;
         private bool _initCompleted = false;
         private ExceptionDispatchInfo _closeError;
-        private readonly IKestrelTrace _log;
+        private readonly ILibuvTrace _log;
         private readonly TimeSpan _shutdownTimeout;
         private IntPtr _thisPtr;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/LibuvTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/LibuvTrace.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure
+{
+    public class LibuvTrace : ILibuvTrace
+    {
+        // ConnectionRead: Reserved: 3
+
+        private static readonly Action<ILogger, string, Exception> _connectionReadFin =
+            LoggerMessage.Define<string>(LogLevel.Debug, 6, @"Connection id ""{ConnectionId}"" received FIN.");
+
+        private static readonly Action<ILogger, string, Exception> _connectionWriteFin =
+            LoggerMessage.Define<string>(LogLevel.Debug, 7, @"Connection id ""{ConnectionId}"" sending FIN.");
+
+        private static readonly Action<ILogger, string, int, Exception> _connectionWroteFin =
+            LoggerMessage.Define<string, int>(LogLevel.Debug, 8, @"Connection id ""{ConnectionId}"" sent FIN with status ""{Status}"".");
+
+        // ConnectionWrite: Reserved: 11
+
+        // ConnectionWriteCallback: Reserved: 12
+
+        private static readonly Action<ILogger, string, Exception> _connectionError =
+            LoggerMessage.Define<string>(LogLevel.Information, 14, @"Connection id ""{ConnectionId}"" communication error.");
+
+        private static readonly Action<ILogger, Exception> _notAllConnectionsClosedGracefully =
+            LoggerMessage.Define(LogLevel.Debug, 16, "Some connections failed to close gracefully during server shutdown.");
+
+        private static readonly Action<ILogger, string, Exception> _connectionReset =
+            LoggerMessage.Define<string>(LogLevel.Debug, 19, @"Connection id ""{ConnectionId}"" reset.");
+
+        private static readonly Action<ILogger, Exception> _notAllConnectionsAborted =
+            LoggerMessage.Define(LogLevel.Debug, 21, "Some connections failed to abort during server shutdown.");
+
+        private readonly ILogger _logger;
+
+        public LibuvTrace(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void ConnectionRead(string connectionId, int count)
+        {
+            // Don't log for now since this could be *too* verbose.
+            // Reserved: Event ID 3
+        }
+
+        public void ConnectionReadFin(string connectionId)
+        {
+            _connectionReadFin(_logger, connectionId, null);
+        }
+
+        public void ConnectionWriteFin(string connectionId)
+        {
+            _connectionWriteFin(_logger, connectionId, null);
+        }
+
+        public void ConnectionWroteFin(string connectionId, int status)
+        {
+            _connectionWroteFin(_logger, connectionId, status, null);
+        }
+
+        public void ConnectionWrite(string connectionId, int count)
+        {
+            // Don't log for now since this could be *too* verbose.
+            // Reserved: Event ID 11
+        }
+
+        public void ConnectionWriteCallback(string connectionId, int status)
+        {
+            // Don't log for now since this could be *too* verbose.
+            // Reserved: Event ID 12
+        }
+
+        public void ConnectionError(string connectionId, Exception ex)
+        {
+            _connectionError(_logger, connectionId, ex);
+        }
+
+        public void ConnectionReset(string connectionId)
+        {
+            _connectionReset(_logger, connectionId, null);
+        }
+
+        public void NotAllConnectionsClosedGracefully()
+        {
+            _notAllConnectionsClosedGracefully(_logger, null);
+        }
+
+        public void NotAllConnectionsAborted()
+        {
+            _notAllConnectionsAborted(_logger, null);
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => _logger.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => _logger.IsEnabled(logLevel);
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => _logger.Log(logLevel, eventId, state, exception, formatter);
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/WriteReqPool.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/WriteReqPool.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 {
@@ -10,10 +11,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
         private readonly KestrelThread _thread;
         private readonly Queue<UvWriteReq> _pool = new Queue<UvWriteReq>(_maxPooledWriteReqs);
-        private readonly IKestrelTrace _log;
+        private readonly ILibuvTrace _log;
         private bool _disposed;
 
-        public WriteReqPool(KestrelThread thread, IKestrelTrace log)
+        public WriteReqPool(KestrelThread thread, ILibuvTrace log)
         {
             _thread = thread;
             _log = log;

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvTransportContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvTransportContext.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 {
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
         public IApplicationLifetime AppLifetime { get; set; }
 
-        public IKestrelTrace Log { get; set; }
+        public ILibuvTrace Log { get; set; }
 
         public IConnectionHandler ConnectionHandler { get; set; }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvAsyncHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvAsyncHandle.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -16,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private Action _callback;
         private Action<Action<IntPtr>, IntPtr> _queueCloseHandle;
 
-        public UvAsyncHandle(IKestrelTrace logger) : base(logger)
+        public UvAsyncHandle(ILibuvTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvConnectRequest.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvConnectRequest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
@@ -17,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private Action<UvConnectRequest, int, Exception, object> _callback;
         private object _state;
 
-        public UvConnectRequest(IKestrelTrace logger) : base (logger)
+        public UvConnectRequest(ILibuvTrace logger) : base (logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvHandle.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private static readonly LibuvFunctions.uv_close_cb _destroyMemory = (handle) => DestroyMemory(handle);
         private Action<Action<IntPtr>, IntPtr> _queueCloseHandle;
 
-        protected UvHandle(IKestrelTrace logger) : base (logger)
+        protected UvHandle(ILibuvTrace logger) : base (logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvLoopHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvLoopHandle.cs
@@ -4,12 +4,13 @@
 using System;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
     public class UvLoopHandle : UvMemory
     {
-        public UvLoopHandle(IKestrelTrace logger) : base(logger)
+        public UvLoopHandle(ILibuvTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvMemory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvMemory.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -16,9 +17,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
     {
         protected LibuvFunctions _uv;
         protected int _threadId;
-        protected readonly IKestrelTrace _log;
+        protected readonly ILibuvTrace _log;
 
-        protected UvMemory(IKestrelTrace logger) : base(IntPtr.Zero, true)
+        protected UvMemory(ILibuvTrace logger) : base(IntPtr.Zero, true)
         {
             _log = logger;
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvPipeHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvPipeHandle.cs
@@ -3,12 +3,13 @@
 
 using System;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
     public class UvPipeHandle : UvStreamHandle
     {
-        public UvPipeHandle(IKestrelTrace logger) : base(logger)
+        public UvPipeHandle(ILibuvTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvRequest.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvRequest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -8,7 +9,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
     {
         private GCHandle _pin;
 
-        protected UvRequest(IKestrelTrace logger) : base (logger)
+        protected UvRequest(ILibuvTrace logger) : base (logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvShutdownReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvShutdownReq.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -16,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private Action<UvShutdownReq, int, object> _callback;
         private object _state;
 
-        public UvShutdownReq(IKestrelTrace logger) : base (logger)
+        public UvShutdownReq(ILibuvTrace logger) : base (logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvStreamHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvStreamHandle.cs
@@ -5,6 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
@@ -25,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private object _readState;
         private GCHandle _readVitality;
 
-        protected UvStreamHandle(IKestrelTrace logger) : base(logger)
+        protected UvStreamHandle(ILibuvTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvTcpHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvTcpHandle.cs
@@ -5,12 +5,13 @@ using System;
 using System.Net;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
     public class UvTcpHandle : UvStreamHandle
     {
-        public UvTcpHandle(IKestrelTrace logger) : base(logger)
+        public UvTcpHandle(ILibuvTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvTimerHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvTimerHandle.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 
         private Action<UvTimerHandle> _callback;
 
-        public UvTimerHandle(IKestrelTrace logger) : base(logger)
+        public UvTimerHandle(ILibuvTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvWriteReq.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
@@ -28,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private List<GCHandle> _pins = new List<GCHandle>(BUFFER_COUNT + 1);
         private List<BufferHandle> _handles = new List<BufferHandle>(BUFFER_COUNT + 1);
 
-        public UvWriteReq(IKestrelTrace logger) : base(logger)
+        public UvWriteReq(ILibuvTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/KestrelEngine.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/KestrelEngine.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal
@@ -40,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         public List<KestrelThread> Threads { get; } = new List<KestrelThread>();
 
         public IApplicationLifetime AppLifetime => TransportContext.AppLifetime;
-        public IKestrelTrace Log => TransportContext.Log;
+        public ILibuvTrace Log => TransportContext.Log;
         public LibuvTransportOptions TransportOptions => TransportContext.Options;
 
         public async Task StopAsync()

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/LibuvTransportFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/LibuvTransportFactory.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -34,10 +35,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            // REVIEW: Should we change the logger namespace for transport logs?
-            var logger  = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel");
-            // TODO: Add LibuvTrace
-            var trace = new KestrelTrace(logger);
+            var logger  = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv");
+            var trace = new LibuvTrace(logger);
 
             var threadCount = options.Value.ThreadCount;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Libuv transport for the ASP.NET Core Kestrel cross-platform web server.</Description>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;kestrel</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -13,6 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.ThreadPool" Version="$(CoreFxVersion)" />
     <PackageReference Include="Libuv" Version="$(LibUvVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
@@ -22,11 +24,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions\Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.Threading.ThreadPool" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
@@ -14,11 +14,19 @@
 
   <ItemGroup>
     <PackageReference Include="Libuv" Version="$(LibUvVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.AspNetCore.Server.Kestrel.Core\Microsoft.AspNetCore.Server.Kestrel.Core.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions\Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.ThreadPool" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ConnectionTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         {
                             Thread = thread
                         };
-                        var socket = new MockSocket(mockLibuv, Thread.CurrentThread.ManagedThreadId, serviceContext.Log);
+                        var socket = new MockSocket(mockLibuv, Thread.CurrentThread.ManagedThreadId, serviceContext.TransportContext.Log);
                         var connection = new Connection(listenerContext, socket);
                         connection.Start();
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/LibuvTransportFactoryTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/LibuvTransportFactoryTests.cs
@@ -27,11 +27,11 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         }
 
         [Fact]
-        public void LoggerCategoryNameIsKestrelServerNamespace()
+        public void LoggerCategoryNameIsLibuvTransportNamespace()
         {
             var mockLoggerFactory = new Mock<ILoggerFactory>();
             new LibuvTransportFactory(Options.Create<LibuvTransportOptions>(new LibuvTransportOptions()), new LifetimeNotImplemented(), mockLoggerFactory.Object);
-            mockLoggerFactory.Verify(factory => factory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel"));
+            mockLoggerFactory.Verify(factory => factory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv"));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ListenerPrimaryTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ListenerPrimaryTests.cs
@@ -11,9 +11,11 @@ using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.KestrelTests.TestHelpers;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -116,7 +118,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             // Create a pipe connection and keep it open without sending any data
             var connectTcs = new TaskCompletionSource<object>();
-            var connectionTrace = new TestKestrelTrace();
+            var connectionTrace = new LibuvTrace(Mock.Of<ILogger>());
             var pipe = new UvPipeHandle(connectionTrace);
 
             kestrelThreadPrimary.Post(_ =>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/ListenerPrimaryTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/ListenerPrimaryTests.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructur
 using Microsoft.AspNetCore.Server.KestrelTests.TestHelpers;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -118,7 +117,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             // Create a pipe connection and keep it open without sending any data
             var connectTcs = new TaskCompletionSource<object>();
-            var connectionTrace = new LibuvTrace(Mock.Of<ILogger>());
+            var connectionTrace = new LibuvTrace(new TestApplicationErrorLogger());
             var pipe = new UvPipeHandle(connectionTrace);
 
             kestrelThreadPrimary.Post(_ =>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MultipleLoopTests.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.KestrelTests.TestHelpers;
 using Microsoft.AspNetCore.Testing;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -19,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
     public class MultipleLoopTests
     {
         private readonly LibuvFunctions _uv = new LibuvFunctions();
-        private readonly ILibuvTrace _logger = Mock.Of<ILibuvTrace>();
+        private readonly ILibuvTrace _logger = new LibuvTrace(new TestApplicationErrorLogger());
 
         [Fact]
         public void InitAndCloseServerPipe()

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/MultipleLoopTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/MultipleLoopTests.cs
@@ -7,24 +7,19 @@ using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Microsoft.AspNetCore.Server.Kestrel.Internal;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.KestrelTests.TestHelpers;
 using Microsoft.AspNetCore.Testing;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
 {
     public class MultipleLoopTests
     {
-        private readonly LibuvFunctions _uv;
-        private readonly IKestrelTrace _logger;
-        public MultipleLoopTests()
-        {
-            _uv = new LibuvFunctions();
-            _logger = new TestKestrelTrace();
-        }
+        private readonly LibuvFunctions _uv = new LibuvFunctions();
+        private readonly ILibuvTrace _logger = Mock.Of<ILibuvTrace>();
 
         [Fact]
         public void InitAndCloseServerPipe()
@@ -41,7 +36,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             pipe.Dispose();
             loop.Dispose();
-
         }
 
         [Fact]
@@ -70,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                     return;
                 }
 
-                var writeRequest = new UvWriteReq(new KestrelTrace(new TestKestrelTrace()));
+                var writeRequest = new UvWriteReq(_logger);
                 writeRequest.Init(loop);
 
                 await writeRequest.WriteAsync(
@@ -87,7 +81,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 var loop2 = new UvLoopHandle(_logger);
                 var clientConnectionPipe = new UvPipeHandle(_logger);
-                var connect = new UvConnectRequest(new KestrelTrace(new TestKestrelTrace()));
+                var connect = new UvConnectRequest(_logger);
 
                 loop2.Init(_uv);
                 clientConnectionPipe.Init(loop2, (a, b) => { }, true);
@@ -163,7 +157,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
                 serverConnectionPipeAcceptedEvent.WaitOne();
 
-                var writeRequest = new UvWriteReq(new KestrelTrace(new TestKestrelTrace()));
+                var writeRequest = new UvWriteReq(_logger);
                 writeRequest.Init(loop);
                 writeRequest.Write2(
                     serverConnectionPipe,
@@ -185,7 +179,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             {
                 var loop2 = new UvLoopHandle(_logger);
                 var clientConnectionPipe = new UvPipeHandle(_logger);
-                var connect = new UvConnectRequest(new KestrelTrace(new TestKestrelTrace()));
+                var connect = new UvConnectRequest(_logger);
 
                 loop2.Init(_uv);
                 clientConnectionPipe.Init(loop2, (a, b) => { }, true);

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
@@ -8,9 +8,10 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Internal;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -20,13 +21,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
     /// </summary>
     public class NetworkingTests
     {
-        private readonly LibuvFunctions _uv;
-        private readonly IKestrelTrace _logger;
-        public NetworkingTests()
-        {
-            _uv = new LibuvFunctions();
-            _logger = new TestKestrelTrace();
-        }
+        private readonly LibuvFunctions _uv = new LibuvFunctions();
+        private readonly ILibuvTrace _logger = Mock.Of<ILibuvTrace>();
 
         [Fact]
         public void LoopCanBeInitAndClose()
@@ -69,7 +65,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             loop.Dispose();
         }
 
-
         [Fact]
         public async Task SocketCanListenAndAccept()
         {
@@ -97,7 +92,6 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
             loop.Dispose();
             await t;
         }
-
 
         [Fact]
         public async Task SocketCanRead()
@@ -167,7 +161,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
                         {
                             for (var x = 0; x < 2; x++)
                             {
-                                var req = new UvWriteReq(new KestrelTrace(new TestKestrelTrace()));
+                                var req = new UvWriteReq(_logger);
                                 req.Init(loop);
                                 var block = ReadableBuffer.Create(new byte[] { 65, 66, 67, 68, 69 });
 

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/NetworkingTests.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
@@ -22,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
     public class NetworkingTests
     {
         private readonly LibuvFunctions _uv = new LibuvFunctions();
-        private readonly ILibuvTrace _logger = Mock.Of<ILibuvTrace>();
+        private readonly ILibuvTrace _logger = new LibuvTrace(new TestApplicationErrorLogger());
 
         [Fact]
         public void LoopCanBeInitAndClose()

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/SocketOutputTests.cs
@@ -520,13 +520,12 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         {
             var pipe = _pipeFactory.Create(pipeOptions);
             var serviceContext = new TestServiceContext();
-            var trace = serviceContext.Log;
 
             var frame = new Frame<object>(null, new FrameContext { ServiceContext = serviceContext });
 
-            var socket = new MockSocket(_mockLibuv, _kestrelThread.Loop.ThreadId, new TestKestrelTrace());
-            var socketOutput = new SocketOutputProducer(pipe.Writer, frame, "0", trace);
-            var consumer = new SocketOutputConsumer(pipe.Reader, _kestrelThread, socket, connection ?? new MockConnection(), "0", trace);
+            var socket = new MockSocket(_mockLibuv, _kestrelThread.Loop.ThreadId, serviceContext.TransportContext.Log);
+            var socketOutput = new SocketOutputProducer(pipe.Writer, frame, "0", serviceContext.Log);
+            var consumer = new SocketOutputConsumer(pipe.Reader, _kestrelThread, socket, connection ?? new MockConnection(), "0", serviceContext.TransportContext.Log);
             var ignore = consumer.StartWrites();
 
             return socketOutput;

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockSocket.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/TestHelpers/MockSocket.cs
@@ -1,12 +1,15 @@
-﻿using System;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests.TestHelpers
 {
     class MockSocket : UvStreamHandle
     {
-        public MockSocket(LibuvFunctions uv, int threadId, IKestrelTrace logger) : base(logger)
+        public MockSocket(LibuvFunctions uv, int threadId, ILibuvTrace logger) : base(logger)
         {
             CreateMemory(uv, threadId, IntPtr.Size);
         }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/UvStreamHandleTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/UvStreamHandleTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.KestrelTests.TestHelpers;
 using Moq;
 using Xunit;
@@ -14,12 +14,13 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [Fact]
         public void ReadStopIsIdempotent()
         {
-            var mockKestrelTrace = Mock.Of<IKestrelTrace>();
-            var mockUvLoopHandle = new Mock<UvLoopHandle>(mockKestrelTrace).Object;
+            var mockLibuvTrace = Mock.Of<ILibuvTrace>();
+
+            var mockUvLoopHandle = new Mock<UvLoopHandle>(mockLibuvTrace).Object;
             mockUvLoopHandle.Init(new MockLibuv());
 
             // Need to mock UvTcpHandle instead of UvStreamHandle, since the latter lacks an Init() method
-            var mockUvStreamHandle = new Mock<UvTcpHandle>(mockKestrelTrace).Object;
+            var mockUvStreamHandle = new Mock<UvTcpHandle>(mockLibuvTrace).Object;
             mockUvStreamHandle.Init(mockUvLoopHandle, null);
 
             mockUvStreamHandle.ReadStop();

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/UvStreamHandleTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/UvStreamHandleTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.KestrelTests.TestHelpers;
+using Microsoft.AspNetCore.Testing;
 using Moq;
 using Xunit;
 
@@ -14,13 +15,13 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [Fact]
         public void ReadStopIsIdempotent()
         {
-            var mockLibuvTrace = Mock.Of<ILibuvTrace>();
+            var libuvTrace = new LibuvTrace(new TestApplicationErrorLogger());
 
-            var mockUvLoopHandle = new Mock<UvLoopHandle>(mockLibuvTrace).Object;
+            var mockUvLoopHandle = new Mock<UvLoopHandle>(libuvTrace).Object;
             mockUvLoopHandle.Init(new MockLibuv());
 
             // Need to mock UvTcpHandle instead of UvStreamHandle, since the latter lacks an Init() method
-            var mockUvStreamHandle = new Mock<UvTcpHandle>(mockLibuvTrace).Object;
+            var mockUvStreamHandle = new Mock<UvTcpHandle>(libuvTrace).Object;
             mockUvStreamHandle.Init(mockUvLoopHandle, null);
 
             mockUvStreamHandle.ReadStop();

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/UvTimerHandleTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/UvTimerHandleTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
@@ -12,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [Fact]
         public void TestTimeout()
         {
-            var trace = new TestKestrelTrace();
+            var trace = Mock.Of<ILibuvTrace>();
 
             var loop = new UvLoopHandle(trace);
             loop.Init(new LibuvFunctions());
@@ -38,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [Fact]
         public void TestRepeat()
         {
-            var trace = new TestKestrelTrace();
+            var trace = Mock.Of<ILibuvTrace>();
 
             var loop = new UvLoopHandle(trace);
             loop.Init(new LibuvFunctions());

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/UvTimerHandleTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/UvTimerHandleTests.cs
@@ -4,22 +4,21 @@
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.KestrelTests
 {
     public class UvTimerHandleTests
     {
+        private readonly ILibuvTrace _trace = new LibuvTrace(new TestApplicationErrorLogger());
+
         [Fact]
         public void TestTimeout()
         {
-            var trace = Mock.Of<ILibuvTrace>();
-
-            var loop = new UvLoopHandle(trace);
+            var loop = new UvLoopHandle(_trace);
             loop.Init(new LibuvFunctions());
 
-            var timer = new UvTimerHandle(trace);
+            var timer = new UvTimerHandle(_trace);
             timer.Init(loop, (a, b) => { });
 
             var callbackInvoked = false;
@@ -40,12 +39,10 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
         [Fact]
         public void TestRepeat()
         {
-            var trace = Mock.Of<ILibuvTrace>();
-
-            var loop = new UvLoopHandle(trace);
+            var loop = new UvLoopHandle(_trace);
             loop.Init(new LibuvFunctions());
 
-            var timer = new UvTimerHandle(trace);
+            var timer = new UvTimerHandle(_trace);
             timer.Init(loop, (callback, handle) => { });
 
             var callbackCount = 0;

--- a/test/shared/TestKestrelTrace.cs
+++ b/test/shared/TestKestrelTrace.cs
@@ -17,20 +17,5 @@ namespace Microsoft.AspNetCore.Testing
         }
 
         public TestApplicationErrorLogger Logger { get; private set; }
-
-        public override void ConnectionRead(string connectionId, int count)
-        {
-            //_logger.LogDebug(1, @"Connection id ""{ConnectionId}"" recv {count} bytes.", connectionId, count);
-        }
-
-        public override void ConnectionWrite(string connectionId, int count)
-        {
-            //_logger.LogDebug(1, @"Connection id ""{ConnectionId}"" send {count} bytes.", connectionId, count);
-        }
-
-        public override void ConnectionWriteCallback(string connectionId, int status)
-        {
-            //_logger.LogDebug(1, @"Connection id ""{ConnectionId}"" send finished with status {status}.", connectionId, status);
-        }
     }
 }

--- a/test/shared/TestServiceContext.cs
+++ b/test/shared/TestServiceContext.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Testing
 {
@@ -16,7 +17,9 @@ namespace Microsoft.AspNetCore.Testing
     {
         public TestServiceContext()
         {
-            Log = new TestKestrelTrace();
+            var logger = new TestApplicationErrorLogger();
+
+            Log = new TestKestrelTrace(logger);
             ThreadPool = new LoggingThreadPool(Log);
             DateHeaderValueManager = new DateHeaderValueManager(systemClock: new MockSystemClock());
             DateHeaderValue = DateHeaderValueManager.GetDateHeaderValues().String;
@@ -29,7 +32,7 @@ namespace Microsoft.AspNetCore.Testing
             TransportContext = new LibuvTransportContext
             {
                 AppLifetime = new LifetimeNotImplemented(),
-                Log = Log,
+                Log = new LibuvTrace(logger),
                 Options = new LibuvTransportOptions
                 {
                     ThreadCount = 1,


### PR DESCRIPTION
#1584

Adds `ILibuvTrace` and `LibuvTrace` so the libuv transport can have its own trace and not depend on `IKestrelTrace`.