### PR TITLE
[WIP][ALT] Remove Kestrel.Core dependency from Transport.Libuv (#1584)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
@@ -1,37 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
-using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 {
-    public interface IKestrelTrace : ILogger
+    public interface IKestrelTrace : ITransportTrace
     {
         void ConnectionStart(string connectionId);
 
         void ConnectionStop(string connectionId);
 
-        void ConnectionRead(string connectionId, int count);
-
         void ConnectionPause(string connectionId);
 
         void ConnectionResume(string connectionId);
-
-        void ConnectionReadFin(string connectionId);
-
-        void ConnectionWriteFin(string connectionId);
-
-        void ConnectionWroteFin(string connectionId, int status);
 
         void ConnectionKeepAlive(string connectionId);
 
         void ConnectionDisconnect(string connectionId);
 
         void ConnectionWrite(string connectionId, int count);
-
-        void ConnectionWriteCallback(string connectionId, int status);
-
-        void ConnectionError(string connectionId, Exception ex);
-
-        void ConnectionReset(string connectionId);
 
         void RequestProcessingError(string connectionId, Exception ex);
 
@@ -40,10 +29,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
         void ConnectionHeadResponseBodyWrite(string connectionId, long count);
 
         void ConnectionBadRequest(string connectionId, BadHttpRequestException ex);
-
-        void NotAllConnectionsClosedGracefully();
-
-        void NotAllConnectionsAborted();
 
         void ApplicationError(string connectionId, string traceIdentifier, Exception ex);
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal
@@ -10,7 +11,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
     /// <summary>
     /// Summary description for KestrelTrace
     /// </summary>
-    public class KestrelTrace : IKestrelTrace
+    public class KestrelTrace : IKestrelTrace, ITransportTrace
     {
         private static readonly Action<ILogger, string, Exception> _connectionStart =
             LoggerMessage.Define<string>(LogLevel.Debug, 1, @"Connection id ""{ConnectionId}"" started.");

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     _logger.LogDebug($"No listening endpoints were configured. Binding to {Constants.DefaultServerAddress} by default.");
 
                     // "localhost" for both IPv4 and IPv6 can't be represented as an IPEndPoint.
-                    StartLocalhost(connectionHandler, ServerAddress.FromUrl(Constants.DefaultServerAddress));
+                    StartLocalhost(connectionHandler, ServerAddress.FromUrl(Constants.DefaultServerAddress), trace);
 
                     // If StartLocalhost doesn't throw, there is at least one listener.
                     // The port cannot change for "localhost".
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                             if (string.Equals(parsedAddress.Host, "localhost", StringComparison.OrdinalIgnoreCase))
                             {
                                 // "localhost" for both IPv4 and IPv6 can't be represented as an IPEndPoint.
-                                StartLocalhost(connectionHandler, parsedAddress);
+                                StartLocalhost(connectionHandler, parsedAddress, trace);
 
                                 // If StartLocalhost doesn't throw, there is at least one listener.
                                 // The port cannot change for "localhost".
@@ -192,7 +192,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
 
                 foreach (var endPoint in listenOptions)
                 {
-                    var transport = _transportFactory.Create(endPoint, connectionHandler);
+                    var transport = _transportFactory.Create(endPoint, connectionHandler, trace);
                     _transports.Add(transport);
 
                     try
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
             }
         }
 
-        private void StartLocalhost<TContext>(ConnectionHandler<TContext> connectionHandler, ServerAddress parsedAddress)
+        private void StartLocalhost<TContext>(ConnectionHandler<TContext> connectionHandler, ServerAddress parsedAddress, ITransportTrace trace)
         {
             if (parsedAddress.Port == 0)
             {
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     Scheme = parsedAddress.Scheme,
                 };
 
-                var transport = _transportFactory.Create(ipv4ListenOptions, connectionHandler);
+                var transport = _transportFactory.Create(ipv4ListenOptions, connectionHandler, trace);
                 _transports.Add(transport);
                 transport.BindAsync().Wait();
             }
@@ -292,7 +292,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     Scheme = parsedAddress.Scheme,
                 };
 
-                var transport = _transportFactory.Create(ipv6ListenOptions, connectionHandler);
+                var transport = _transportFactory.Create(ipv6ListenOptions, connectionHandler, trace);
                 _transports.Add(transport);
                 transport.BindAsync().Wait();
             }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/ITransportFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/ITransportFactory.cs
@@ -5,6 +5,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions
 {
     public interface ITransportFactory
     {
-        ITransport Create(IEndPointInformation endPointInformation, IConnectionHandler handler);
+        ITransport Create(IEndPointInformation endPointInformation, IConnectionHandler handler, ITransportTrace trace);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/ITransportTrace.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/ITransportTrace.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions
+{
+    public interface ITransportTrace : ILogger
+    {
+        void ConnectionRead(string connectionId, int count);
+
+        void ConnectionReadFin(string connectionId);
+
+        void ConnectionWriteFin(string connectionId);
+
+        void ConnectionWroteFin(string connectionId, int status);
+
+        void ConnectionWriteCallback(string connectionId, int status);
+
+        void ConnectionError(string connectionId, Exception ex);
+
+        void ConnectionReset(string connectionId);
+
+        void NotAllConnectionsClosedGracefully();
+
+        void NotAllConnectionsAborted();
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.IO.Pipelines" Version="$(CoreFxLabsPipelinesVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Connection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Connection.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         public IPipeWriter Input { get; set; }
         public SocketOutputConsumer Output { get; set; }
 
-        private IKestrelTrace Log => ListenerContext.TransportContext.Log;
+        private ITransportTrace Log => ListenerContext.TransportContext.Log;
         private IConnectionHandler ConnectionHandler => ListenerContext.TransportContext.ConnectionHandler;
         private KestrelThread Thread => ListenerContext.Thread;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Listener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/Listener.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         protected UvStreamHandle ListenSocket { get; private set; }
 
-        public IKestrelTrace Log => TransportContext.Log;
+        public ITransportTrace Log => TransportContext.Log;
 
         public Task StartAsync(
             IEndPointInformation endPointInformation,

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/ListenerSecondary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/ListenerSecondary.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 
         UvPipeHandle DispatchPipe { get; set; }
 
-        public IKestrelTrace Log => TransportContext.Log;
+        public ITransportTrace Log => TransportContext.Log;
 
         public Task StartAsync(
             string pipeName,

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/SocketOutputConsumer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Http/SocketOutputConsumer.cs
@@ -6,6 +6,7 @@ using System.IO.Pipelines;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
 {
@@ -15,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
         private readonly UvStreamHandle _socket;
         private readonly Connection _connection;
         private readonly string _connectionId;
-        private readonly IKestrelTrace _log;
+        private readonly ITransportTrace _log;
 
         private readonly WriteReqPool _writeReqPool;
         private readonly IPipeReader _pipe;
@@ -26,7 +27,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
             UvStreamHandle socket,
             Connection connection,
             string connectionId,
-            IKestrelTrace log)
+            ITransportTrace log)
         {
             _pipe = pipe;
             // We need to have empty pipe at this moment so callback

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/KestrelThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/KestrelThread.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal
@@ -52,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         private bool _stopImmediate = false;
         private bool _initCompleted = false;
         private ExceptionDispatchInfo _closeError;
-        private readonly IKestrelTrace _log;
+        private readonly ITransportTrace _log;
         private readonly TimeSpan _shutdownTimeout;
         private IntPtr _thisPtr;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/WriteReqPool.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Infrastructure/WriteReqPool.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Networking;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 {
@@ -10,10 +11,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure
 
         private readonly KestrelThread _thread;
         private readonly Queue<UvWriteReq> _pool = new Queue<UvWriteReq>(_maxPooledWriteReqs);
-        private readonly IKestrelTrace _log;
+        private readonly ITransportTrace _log;
         private bool _disposed;
 
-        public WriteReqPool(KestrelThread thread, IKestrelTrace log)
+        public WriteReqPool(KestrelThread thread, ITransportTrace log)
         {
             _thread = thread;
             _log = log;

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvTransportContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvTransportContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
@@ -13,7 +12,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
         public IApplicationLifetime AppLifetime { get; set; }
 
-        public IKestrelTrace Log { get; set; }
+        public ITransportTrace Log { get; set; }
 
         public IConnectionHandler ConnectionHandler { get; set; }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvAsyncHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvAsyncHandle.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private Action _callback;
         private Action<Action<IntPtr>, IntPtr> _queueCloseHandle;
 
-        public UvAsyncHandle(IKestrelTrace logger) : base(logger)
+        public UvAsyncHandle(ITransportTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvConnectRequest.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvConnectRequest.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private Action<UvConnectRequest, int, Exception, object> _callback;
         private object _state;
 
-        public UvConnectRequest(IKestrelTrace logger) : base (logger)
+        public UvConnectRequest(ITransportTrace logger) : base (logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvHandle.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private static readonly LibuvFunctions.uv_close_cb _destroyMemory = (handle) => DestroyMemory(handle);
         private Action<Action<IntPtr>, IntPtr> _queueCloseHandle;
 
-        protected UvHandle(IKestrelTrace logger) : base (logger)
+        protected UvHandle(ITransportTrace logger) : base (logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvLoopHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvLoopHandle.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Threading;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
     public class UvLoopHandle : UvMemory
     {
-        public UvLoopHandle(IKestrelTrace logger) : base(logger)
+        public UvLoopHandle(ITransportTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvMemory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvMemory.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -16,9 +16,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
     {
         protected LibuvFunctions _uv;
         protected int _threadId;
-        protected readonly IKestrelTrace _log;
+        protected readonly ITransportTrace _log;
 
-        protected UvMemory(IKestrelTrace logger) : base(IntPtr.Zero, true)
+        protected UvMemory(ITransportTrace logger) : base(IntPtr.Zero, true)
         {
             _log = logger;
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvPipeHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvPipeHandle.cs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
     public class UvPipeHandle : UvStreamHandle
     {
-        public UvPipeHandle(IKestrelTrace logger) : base(logger)
+        public UvPipeHandle(ITransportTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvRequest.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvRequest.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
     {
         private GCHandle _pin;
 
-        protected UvRequest(IKestrelTrace logger) : base (logger)
+        protected UvRequest(ITransportTrace logger) : base (logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvShutdownReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvShutdownReq.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private Action<UvShutdownReq, int, object> _callback;
         private object _state;
 
-        public UvShutdownReq(IKestrelTrace logger) : base (logger)
+        public UvShutdownReq(ITransportTrace logger) : base (logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvStreamHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvStreamHandle.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private object _readState;
         private GCHandle _readVitality;
 
-        protected UvStreamHandle(IKestrelTrace logger) : base(logger)
+        protected UvStreamHandle(ITransportTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvTcpHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvTcpHandle.cs
@@ -4,13 +4,13 @@
 using System;
 using System.Net;
 using System.Runtime.InteropServices;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 {
     public class UvTcpHandle : UvStreamHandle
     {
-        public UvTcpHandle(IKestrelTrace logger) : base(logger)
+        public UvTcpHandle(ITransportTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvTimerHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvTimerHandle.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
 
         private Action<UvTimerHandle> _callback;
 
-        public UvTimerHandle(IKestrelTrace logger) : base(logger)
+        public UvTimerHandle(ITransportTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvWriteReq.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvWriteReq.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
@@ -28,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Networking
         private List<GCHandle> _pins = new List<GCHandle>(BUFFER_COUNT + 1);
         private List<BufferHandle> _handles = new List<BufferHandle>(BUFFER_COUNT + 1);
 
-        public UvWriteReq(IKestrelTrace logger) : base(logger)
+        public UvWriteReq(ITransportTrace logger) : base(logger)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/KestrelEngine.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/KestrelEngine.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal
         public List<KestrelThread> Threads { get; } = new List<KestrelThread>();
 
         public IApplicationLifetime AppLifetime => TransportContext.AppLifetime;
-        public IKestrelTrace Log => TransportContext.Log;
+        public ITransportTrace Log => TransportContext.Log;
         public LibuvTransportOptions TransportOptions => TransportContext.Options;
 
         public async Task StopAsync()

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/LibuvTransportFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/LibuvTransportFactory.cs
@@ -34,11 +34,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            // REVIEW: Should we change the logger namespace for transport logs?
-            var logger  = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel");
-            // TODO: Add LibuvTrace
-            var trace = new KestrelTrace(logger);
-
             var threadCount = options.Value.ThreadCount;
 
             if (threadCount <= 0)
@@ -48,31 +43,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv
                     "ThreadCount must be positive.");
             }
 
+            var log = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv");
+
             if (!Constants.ECONNRESET.HasValue)
             {
-                trace.LogWarning("Unable to determine ECONNRESET value on this platform.");
+                log.LogWarning("Unable to determine ECONNRESET value on this platform.");
             }
 
             if (!Constants.EADDRINUSE.HasValue)
             {
-                trace.LogWarning("Unable to determine EADDRINUSE value on this platform.");
+                log.LogWarning("Unable to determine EADDRINUSE value on this platform.");
             }
 
             _baseTransportContext = new LibuvTransportContext
             {
                 Options = options.Value,
                 AppLifetime = applicationLifetime,
-                Log = trace,
             };
         }
 
-        public ITransport Create(IEndPointInformation endPointInformation, IConnectionHandler handler)
+        public ITransport Create(IEndPointInformation endPointInformation, IConnectionHandler handler, ITransportTrace trace)
         {
             var transportContext = new LibuvTransportContext
             {
                 Options = _baseTransportContext.Options,
                 AppLifetime = _baseTransportContext.AppLifetime,
-                Log = _baseTransportContext.Log,
+                Log = trace,
                 ConnectionHandler = handler
             };
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.csproj
@@ -14,11 +14,18 @@
 
   <ItemGroup>
     <PackageReference Include="Libuv" Version="$(LibUvVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.AspNetCore.Server.Kestrel.Core\Microsoft.AspNetCore.Server.Kestrel.Core.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions\Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.ThreadPool" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/KestrelServerTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
         private class MockTransportFactory : ITransportFactory
         {
-            public ITransport Create(IEndPointInformation endPointInformation, IConnectionHandler handler)
+            public ITransport Create(IEndPointInformation endPointInformation, IConnectionHandler handler, ITransportTrace trace)
             {
                 return Mock.Of<ITransport>();
             }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/LibuvTransportFactoryTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/LibuvTransportFactoryTests.cs
@@ -25,13 +25,5 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             Assert.Equal("threadCount", exception.ParamName);
         }
-
-        [Fact]
-        public void LoggerCategoryNameIsKestrelServerNamespace()
-        {
-            var mockLoggerFactory = new Mock<ILoggerFactory>();
-            new LibuvTransportFactory(Options.Create<LibuvTransportOptions>(new LibuvTransportOptions()), new LifetimeNotImplemented(), mockLoggerFactory.Object);
-            mockLoggerFactory.Verify(factory => factory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel"));
-        }
     }
 }


### PR DESCRIPTION
Alternative to #1595.

Implements `ITransportTrace` in `KestrelTrace` and passes it to the transport via `ITransportFactory.Create()`.

Requires creating a short-lived logged in `LibuvTransportFactory` to log warnings about `ECONNRESET` and   `EADDRINUSE`.