### PR TITLE
[WIP]: Drain the read buffer before going back to the pipe

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
@@ -1001,7 +1001,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             writableBuffer.WriteFast(_bytesEndHeaders);
         }
 
-        public void ParseRequest(ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
+        public void ParseRequest(ref ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
         {
             consumed = buffer.Start;
             examined = buffer.End;
@@ -1021,7 +1021,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case RequestProcessingStatus.ParsingRequestLine:
                     if (TakeStartLine(buffer, out consumed, out examined))
                     {
-                        buffer = buffer.Slice(consumed, buffer.End);
+                        buffer = buffer.Slice(consumed);
 
                         _requestProcessingStatus = RequestProcessingStatus.ParsingHeaders;
                         goto case RequestProcessingStatus.ParsingHeaders;

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
@@ -1033,6 +1033,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case RequestProcessingStatus.ParsingHeaders:
                     if (TakeMessageHeaders(buffer, out consumed, out examined))
                     {
+                        buffer = buffer.Slice(consumed);
+
                         _requestProcessingStatus = RequestProcessingStatus.AppStarted;
                     }
                     break;

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameOfT.cs
@@ -110,10 +110,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             }
                         }
 
-                        // Incomplete message, we need a new buffer from the pipe
-                        Input.Advance(consumed, examined);
+                        if (!needBuffer)
+                        {
+                            // Incomplete message, we need a new buffer from the pipe
+                            Input.Advance(consumed, examined);
 
-                        needBuffer = true;
+                            needBuffer = true;
+                        }
                     }
 
                     if (!_requestProcessingStopping)

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameOfT.cs
@@ -60,9 +60,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             ParseRequest(ref buffer, out consumed, out examined);
 
-                            if (buffer.Length == 0)
+                            if (buffer.End == examined)
                             {
-                                // We've consumed the entire buffer so we need to advance the pipe
+                                // We've observed or consumed the entire buffer so we need to advance the pipe
                                 needAdvance = true;
                             }
                         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/MessageBody.cs
@@ -28,6 +28,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public bool RequestUpgrade { get; protected set; }
 
+        public bool IsEmpty { get; protected set; }
+
         public Task<int> ReadAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
         {
             var task = PeekAsync(cancellationToken);
@@ -314,6 +316,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 : base(null)
             {
                 RequestKeepAlive = keepAlive;
+                IsEmpty = true;
             }
 
             protected override ValueTask<ArraySegment<byte>> PeekAsync(CancellationToken cancellationToken)

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
             {
                 InsertData(RequestParsingData.PlaintextTechEmpowerPipelinedRequests);
-                var ignore = ParseDataDrainBufferAsync();
+                ParseDataDrainBufferAsync().GetAwaiter().GetResult();
             }
         }
 
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
             {
                 InsertData(RequestParsingData.PlaintextTechEmpowerPipelinedRequests);
-                var ignore = ParseDataAsync();
+                ParseDataAsync().GetAwaiter().GetResult();
             }
         }
 
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
             {
                 InsertData(RequestParsingData.PlaintextTechEmpowerPipelinedRequests);
-                var ignore = ParseDataAsyncHybridDrain();
+                ParseDataAsyncHybridDrain().GetAwaiter().GetResult();
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
@@ -241,7 +241,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             {
                 Frame.Reset();
 
-                var result = await Pipe.Reader.ReadAsync();
+                var awaitable = Pipe.Reader.ReadAsync();
+
+                if (!awaitable.IsCompleted)
+                {
+                    // no data
+                    return;
+                }
+
+                var result = await awaitable;
                 var buffer = result.Buffer;
                 var examined = buffer.End;
                 var consumed = buffer.End;
@@ -271,11 +279,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
                 if (needBuffer)
                 {
-                    var result = await Pipe.Reader.ReadAsync();
+                    var awaitable = Pipe.Reader.ReadAsync();
+
+                    if (!awaitable.IsCompleted)
+                    {
+                        // no data
+                        return;
+                    }
+
+                    var result = await awaitable;
                     buffer = result.Buffer;
                     needBuffer = false;
                 }
-                
+
                 try
                 {
                     ParseRequest(ref buffer, out consumed, out examined);

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
@@ -149,9 +149,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             do
             {
-                ParseRequest(ref buffer, out consumed, out examined);
-
                 Frame.Reset();
+
+                ParseRequest(ref buffer, out consumed, out examined);
             }
             while (buffer.Length > 0);
 
@@ -162,6 +162,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             do
             {
+                Frame.Reset();
+
                 if (!Pipe.Reader.TryRead(out var result))
                 {
                     // No more data
@@ -180,8 +182,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                 {
                     Pipe.Reader.Advance(consumed, examined);
                 }
-
-                Frame.Reset();
             }
             while (true);
         }
@@ -190,14 +190,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             do
             {
-                var awaitable = Pipe.Reader.ReadAsync();
+                Frame.Reset();
+
+                var awaitable = Pipe.Reader.ReadAsync().GetAwaiter();
                 if (!awaitable.IsCompleted)
                 {
                     // No more data
                     return;
                 }
 
-                var result = awaitable.GetAwaiter().GetResult();
+                var result = awaitable.GetResult();
                 var buffer = result.Buffer;
                 var examined = buffer.End;
                 var consumed = buffer.End;
@@ -210,8 +212,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                 {
                     Pipe.Reader.Advance(consumed, examined);
                 }
-
-                Frame.Reset();
             }
             while (true);
         }

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/FrameTests.cs
@@ -326,7 +326,8 @@ namespace Microsoft.AspNetCore.Server.KestrelTests
 
             await _input.Writer.WriteAsync(Encoding.ASCII.GetBytes("G"));
 
-            _frame.ParseRequest((await _input.Reader.ReadAsync()).Buffer, out _consumed, out _examined);
+            var readableBuffer = (await _input.Reader.ReadAsync()).Buffer;
+            _frame.ParseRequest(ref readableBuffer, out _consumed, out _examined);
             _input.Reader.Advance(_consumed, _examined);
 
             var expectedRequestHeadersTimeout = (long)_serviceContext.ServerOptions.Limits.RequestHeadersTimeout.TotalMilliseconds;


### PR DESCRIPTION
- Avoid calling Input.ReadAsync if the existing buffer hasn't
been drained as yet.