### PR TITLE
Workaround for "Explicit RID still required for .NET Framework test projects"

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
@@ -8,6 +8,12 @@
     <PlatformTarget Condition="'$(TargetFramework)' == 'net46'">x64</PlatformTarget>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+
+    <!--
+      Workaround for "Explicit RID still required for .NET Framework test projects" (https://github.com/dotnet/sdk/issues/909).
+      Remove when fixed.
+    -->
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Server.KestrelTests/Microsoft.AspNetCore.Server.KestrelTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.KestrelTests/Microsoft.AspNetCore.Server.KestrelTests.csproj
@@ -7,6 +7,12 @@
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <PlatformTarget Condition="'$(TargetFramework)' == 'net46'">x64</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!--
+      Workaround for "Explicit RID still required for .NET Framework test projects" (https://github.com/dotnet/sdk/issues/909).
+      Remove when fixed.
+    -->
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Addresses https://github.com/aspnet/KestrelHttpServer/issues/1617