### PR TITLE
Don't reassign _adaptedPipelineTask in FrameConnection

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
@@ -59,8 +59,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             if (_connectionAdapters.Count == 0)
             {
                 _frame.Start();
-                _frameStartedTcs.TrySetResult(null);
-                _adaptedPipelineTcs.TrySetResult(null);
+                _frameStartedTcs.SetResult(null);
+                _adaptedPipelineTcs.SetResult(null);
             }
             else
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
@@ -135,6 +135,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             {
                 Log.LogError(0, ex, $"Uncaught exception from the {nameof(IConnectionAdapter.OnConnectionAsync)} method of an {nameof(IConnectionAdapter)}.");
                 _frameStartedTcs.SetResult(null);
+                _adaptedPipelineTcs.SetResult(null);
                 CloseRawPipes();
             }
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
@@ -59,8 +59,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             if (_connectionAdapters.Count == 0)
             {
                 _frame.Start();
-                _frameStartedTcs.SetResult(null);
-                _adaptedPipelineTcs.SetResult(null);
+                _frameStartedTcs.TrySetResult(null);
+                _adaptedPipelineTcs.TrySetResult(null);
             }
             else
             {
@@ -129,13 +129,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
                 _frame.AdaptedConnections = adaptedConnections;
                 _frame.Start();
-                _frameStartedTcs.SetResult(null);
+                _frameStartedTcs.TrySetResult(null);
             }
             catch (Exception ex)
             {
                 Log.LogError(0, ex, $"Uncaught exception from the {nameof(IConnectionAdapter.OnConnectionAsync)} method of an {nameof(IConnectionAdapter)}.");
-                _frameStartedTcs.SetResult(null);
-                _adaptedPipelineTcs.SetResult(null);
+                _frameStartedTcs.TrySetResult(null);
+                _adaptedPipelineTcs.TrySetResult(null);
                 CloseRawPipes();
             }
         }


### PR DESCRIPTION
Prevents a race where the server is disposed while an adapted connection is still being setup. If `StopAsync` is called before the task is re-assigned, everything is disposed and then `ReadInputAsync` throws a `Debug.Assert` because it tries to alloc from a disposed memory pool.