### PR TITLE
Don't return data from RawStream after pipe is completed

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/RawStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/RawStream.cs
@@ -115,16 +115,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
                 var readableBuffer = result.Buffer;
                 try
                 {
+                    if (result.IsCompleted)
+                    {
+                        return 0;
+                    }
+
                     if (!readableBuffer.IsEmpty)
                     {
                         var count = Math.Min(readableBuffer.Length, buffer.Count);
                         readableBuffer = readableBuffer.Slice(0, count);
                         readableBuffer.CopyTo(buffer);
                         return count;
-                    }
-                    else if (result.IsCompleted)
-                    {
-                        return 0;
                     }
                 }
                 finally


### PR DESCRIPTION
Makes adapters fail faster after the connection closes, preventing ungraceful shutdowns that lead to #1616.