### PR TITLE
Dispatch only if not already on TP

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/LoggingThreadPool.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/LoggingThreadPool.cs
@@ -16,6 +16,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private WaitCallback _cancelTcs;
         private WaitCallback _completeTcs;
 
+#if net46
+        private bool AlreadyOnThreadPool => Thread.CurrentThread.IsThreadPoolThread;
+#else
+        // IsThreadPoolThread isn't available until .NET Standard 2.0, 
+        // however the non threadpool threads we use are named so this
+        // acts an approximation to it.
+        private bool AlreadyOnThreadPool => Thread.CurrentThread.Name == null;
+#endif
+
         public LoggingThreadPool(IKestrelTrace log)
         {
             _log = log;
@@ -79,7 +88,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         public void Run(Action action)
         {
-            ThreadPool.QueueUserWorkItem(_runAction, action);
+            if (AlreadyOnThreadPool)
+            {
+                _runAction(action);
+            }
+            else
+            {
+                ThreadPool.QueueUserWorkItem(_runAction, action);
+            }
         }
 
         public void UnsafeRun(WaitCallback action, object state)


### PR DESCRIPTION
Don't double dispatch. 

Input pipe can dispatch (flush); then output pipe can also dispatch for write (flush)

Detect if already on TP (as either behaviour could change) and don't dispatch a second time if so.

/cc @davidfowl 