### PR TITLE
Add new MessageBody tests and refactor some existing ones

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/TestInput.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/TestInput.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,14 +36,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         public Frame FrameContext { get; set; }
 
-        public void Add(string text, bool fin = false)
+        public void Add(string text)
         {
             var data = Encoding.ASCII.GetBytes(text);
             Pipe.Writer.WriteAsync(data).Wait();
-            if (fin)
-            {
-                Pipe.Writer.Complete();
-            }
         }
 
         public void ProduceContinue()


### PR DESCRIPTION
- No need to test with FIN since we consider that an error
- Consolidate HTTP/1.0 and HTTP/1.1 tests that were the same except for the HTTP version
- Add a few new tests