### PR TITLE
Less awaits for Response Write(Async)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
@@ -498,22 +498,94 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        protected async Task FireOnStarting()
+        protected Task FireOnStarting()
         {
-            Stack<KeyValuePair<Func<object, Task>, object>> onStarting = null;
+            Stack<KeyValuePair<Func<object, Task>, object>> onStarting;
             lock (_onStartingSync)
             {
                 onStarting = _onStarting;
                 _onStarting = null;
             }
-            if (onStarting != null)
+
+            if (onStarting == null)
+            {
+                return TaskCache.CompletedTask;
+            }
+            else
+            {
+                return FireOnStartingMayAwait(onStarting);
+            }
+
+        }
+
+        private Task FireOnStartingMayAwait(Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
+        {
+            try
+            {
+                var count = onStarting.Count;
+                for(var i = 0; i < count; i++)
+                {
+                    var entry = onStarting.Pop();
+                    var task = entry.Key.Invoke(entry.Value);
+                    if (!ReferenceEquals(task, TaskCache.CompletedTask))
+                    {
+                        return FireOnStartingAwaited(task, onStarting);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                ReportApplicationError(ex);
+            }
+
+            return TaskCache.CompletedTask;
+        }
+
+        private async Task FireOnStartingAwaited(Task currentTask, Stack<KeyValuePair<Func<object, Task>, object>> onStarting)
+        {
+            try
+            {
+                await currentTask;
+
+                var count = onStarting.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    var entry = onStarting.Pop();
+                    await entry.Key.Invoke(entry.Value);
+                }
+            }
+            catch (Exception ex)
+            {
+                ReportApplicationError(ex);
+            }
+        }
+
+        protected Task FireOnCompleted()
+        {
+            Stack<KeyValuePair<Func<object, Task>, object>> onCompleted;
+            lock (_onCompletedSync)
+            {
+                onCompleted = _onCompleted;
+                _onCompleted = null;
+            }
+
+            if (onCompleted == null)
+            {
+                return TaskCache.CompletedTask;
+            }
+            else
+            {
+                return FireOnCompletedAwaited(onCompleted);
+            }
+        }
+
+        private async Task FireOnCompletedAwaited(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
+        {
+            foreach (var entry in onCompleted)
             {
                 try
                 {
-                    foreach (var entry in onStarting)
-                    {
-                        await entry.Key.Invoke(entry.Value);
-                    }
+                    await entry.Key.Invoke(entry.Value);
                 }
                 catch (Exception ex)
                 {
@@ -522,39 +594,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        protected async Task FireOnCompleted()
-        {
-            Stack<KeyValuePair<Func<object, Task>, object>> onCompleted = null;
-            lock (_onCompletedSync)
-            {
-                onCompleted = _onCompleted;
-                _onCompleted = null;
-            }
-            if (onCompleted != null)
-            {
-                foreach (var entry in onCompleted)
-                {
-                    try
-                    {
-                        await entry.Key.Invoke(entry.Value);
-                    }
-                    catch (Exception ex)
-                    {
-                        ReportApplicationError(ex);
-                    }
-                }
-            }
-        }
-
         public void Flush()
         {
-            InitializeResponse(0).GetAwaiter().GetResult();
+            if (!HasResponseStarted)
+            {
+                InitializeResponseAsync(0).GetAwaiter().GetResult();
+            }
             Output.Flush();
         }
 
-        public async Task FlushAsync(CancellationToken cancellationToken)
+        public Task FlushAsync(CancellationToken cancellationToken)
         {
-            await InitializeResponse(0);
+            if (!HasResponseStarted)
+            {
+                var initializeTask = InitializeResponseAsync(0);
+                // If return is TaskCache.CompletedTask no awaiting is required
+                if (!ReferenceEquals(initializeTask, TaskCache.CompletedTask))
+                {
+                    return FlushAsyncAwaited(initializeTask, cancellationToken);
+                }
+            }
+
+            return Output.FlushAsync(cancellationToken);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private async Task FlushAsyncAwaited(Task initializeTask, CancellationToken cancellationToken)
+        {
+            await initializeTask;
             await Output.FlushAsync(cancellationToken);
         }
 
@@ -565,7 +632,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             if (firstWrite)
             {
-                InitializeResponse(data.Count).GetAwaiter().GetResult();
+                InitializeResponseAsync(data.Count).GetAwaiter().GetResult();
             }
             else
             {
@@ -605,12 +672,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public Task WriteAsync(ArraySegment<byte> data, CancellationToken cancellationToken)
         {
-            if (!HasResponseStarted)
-            {
-                return WriteAsyncAwaited(data, cancellationToken);
-            }
+            // For the first write, ensure headers are flushed if Write(Chunked)Async isn't called.
+            var firstWrite = !HasResponseStarted;
 
-            VerifyAndUpdateWrite(data.Count);
+            if (firstWrite)
+            {
+                var initializeTask = InitializeResponseAsync(data.Count);
+                // If return is TaskCache.CompletedTask no awaiting is required
+                if (!ReferenceEquals(initializeTask, TaskCache.CompletedTask))
+                {
+                    return WriteAsyncAwaited(initializeTask, data, cancellationToken);
+                }
+            }
+            else
+            {
+                VerifyAndUpdateWrite(data.Count);
+            }
 
             if (_canHaveBody)
             {
@@ -618,7 +695,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (data.Count == 0)
                     {
-                        return TaskCache.CompletedTask;
+                        return !firstWrite ? TaskCache.CompletedTask : FlushAsync(cancellationToken);
                     }
                     return WriteChunkedAsync(data, cancellationToken);
                 }
@@ -631,13 +708,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else
             {
                 HandleNonBodyResponseWrite();
-                return TaskCache.CompletedTask;
+                return !firstWrite ? TaskCache.CompletedTask : FlushAsync(cancellationToken);
             }
         }
 
-        public async Task WriteAsyncAwaited(ArraySegment<byte> data, CancellationToken cancellationToken)
+        public async Task WriteAsyncAwaited(Task initializeTask, ArraySegment<byte> data, CancellationToken cancellationToken)
         {
-            await InitializeResponseAwaited(data.Count);
+            await initializeTask;
 
             // WriteAsyncAwaited is only called for the first write to the body.
             // Ensure headers are flushed if Write(Chunked)Async isn't called.
@@ -759,16 +836,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        public Task InitializeResponse(int firstWriteByteCount)
+        public Task InitializeResponseAsync(int firstWriteByteCount)
         {
-            if (HasResponseStarted)
+            var startingTask = FireOnStarting();
+            // If return is TaskCache.CompletedTask no awaiting is required
+            if (!ReferenceEquals(startingTask, TaskCache.CompletedTask))
             {
-                return TaskCache.CompletedTask;
-            }
-
-            if (_onStarting != null)
-            {
-                return InitializeResponseAwaited(firstWriteByteCount);
+                return InitializeResponseAwaited(startingTask, firstWriteByteCount);
             }
 
             if (_applicationException != null)
@@ -782,9 +856,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return TaskCache.CompletedTask;
         }
 
-        private async Task InitializeResponseAwaited(int firstWriteByteCount)
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public async Task InitializeResponseAwaited(Task startingTask, int firstWriteByteCount)
         {
-            await FireOnStarting();
+            await startingTask;
 
             if (_applicationException != null)
             {
@@ -854,6 +929,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return WriteSuffix();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private async Task ProduceEndAwaited()
         {
             ProduceStart(appCompleted: true);

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/OutputProducer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/OutputProducer.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
@@ -82,6 +84,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return FlushAsync(writableBuffer);
         }
 
+        // Single caller, at end of method - so inline
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private Task FlushAsync(WritableBuffer writableBuffer)
         {
             var awaitable = writableBuffer.FlushAsync();
@@ -124,18 +128,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         Task ISocketOutput.WriteAsync(ArraySegment<byte> buffer, bool chunk, CancellationToken cancellationToken)
         {
+            if (!(cancellationToken.IsCancellationRequested || _cancelled))
+            {
+                return WriteAsync(buffer, cancellationToken, chunk);
+            }
+
             if (cancellationToken.IsCancellationRequested)
             {
                 _frame.Abort();
                 _cancelled = true;
                 return Task.FromCanceled(cancellationToken);
             }
-            else if (_cancelled)
+            else
             {
+                Debug.Assert(_cancelled);
                 return TaskCache.CompletedTask;
             }
-
-            return WriteAsync(buffer, cancellationToken, chunk);
         }
 
         void ISocketOutput.Flush()

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameTests.cs
@@ -589,13 +589,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             // Need to compare WaitHandle ref since CancellationToken is struct
             var original = _frame.RequestAborted.WaitHandle;
 
-            foreach (var ch in "hello, worl")
+            // Only first write can be WriteAsyncAwaited
+            var startingTask = _frame.InitializeResponseAwaited(Task.CompletedTask, 1);
+            await _frame.WriteAsyncAwaited(startingTask, new ArraySegment<byte>(new[] { (byte)'h' }), default(CancellationToken));
+            Assert.Same(original, _frame.RequestAborted.WaitHandle);
+
+            foreach (var ch in "ello, worl")
             {
-                await _frame.WriteAsyncAwaited(new ArraySegment<byte>(new[] { (byte)ch }), default(CancellationToken));
+                await _frame.WriteAsync(new ArraySegment<byte>(new[] { (byte)ch }), default(CancellationToken));
                 Assert.Same(original, _frame.RequestAborted.WaitHandle);
             }
 
-            await _frame.WriteAsyncAwaited(new ArraySegment<byte>(new[] { (byte)'d' }), default(CancellationToken));
+            await _frame.WriteAsync(new ArraySegment<byte>(new[] { (byte)'d' }), default(CancellationToken));
             Assert.NotSame(original, _frame.RequestAborted.WaitHandle);
         }
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
@@ -64,13 +64,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         [Benchmark]
         public async Task WriteAsyncAwaited()
         {
-            await _frame.WriteAsyncAwaited(new ArraySegment<byte>(_writeData), default(CancellationToken));
+            await _frame.WriteAsyncAwaited(Task.CompletedTask, new ArraySegment<byte>(_writeData), default(CancellationToken));
         }
 
         [Benchmark]
         public async Task WriteAsyncAwaitedChunked()
         {
-            await _frameChunked.WriteAsyncAwaited(new ArraySegment<byte>(_writeData), default(CancellationToken));
+            await _frameChunked.WriteAsyncAwaited(Task.CompletedTask, new ArraySegment<byte>(_writeData), default(CancellationToken));
         }
 
         [Benchmark]


### PR DESCRIPTION
If there aren't any `_onStarting` events; generally the whole startup can bypass the `async`.

Using `ReferenceEquals` on `TaskCache.CompletedTask` rather than doing the bit manipulations that Task does to work out if it has completed sync, as is simpler. 

Better bits from https://github.com/aspnet/KestrelHttpServer/pull/1477