### PR TITLE
Signal the reader after aborting the connection

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
@@ -217,8 +217,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
             if (!normalRead)
             {
-                Input.Complete(error);
                 var ignore = AbortAsync(error);
+
+                // Complete after aborting the connection
+                Input.Complete(error);
             }
         }
 


### PR DESCRIPTION
- This will give it a chance to unwind gracefully before failing
with an invalid request.

Fixes #1632