### PR TITLE
Use Span.IndexOf rather than Contains

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
@@ -404,7 +404,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 valueBuffer = new Span<byte>(headerLine + valueStart, valueEnd - valueStart + 1);
             }
 
-            handler.OnHeader(new Span<byte>(headerLine, nameEnd), valueBuffer);
+            var nameBuffer = new Span<byte>(headerLine, nameEnd);
+
+            handler.OnHeader(nameBuffer, valueBuffer);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
@@ -378,8 +378,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             // Check for CR in value
-            var valueLength = valueEnd - valueStart + 1;
-            var valueBuffer = new Span<byte>(headerLine + valueStart, valueLength);
+            var valueBuffer = new Span<byte>(headerLine + valueStart, valueEnd - valueStart + 1);
             if (valueBuffer.IndexOf(ByteCR) >= 0)
             {
                 RejectRequestHeader(headerLine, length);


### PR DESCRIPTION
It will only search for the byte if its found; so shouldn't be slower in fast path

/cc @davidfowl 