### PR TITLE
Honor PreferHostingUrls

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
@@ -111,7 +111,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                 var hasListenOptions = listenOptions.Any();
                 var hasServerAddresses = _serverAddresses.Addresses.Any();
 
-                if (!hasListenOptions && !hasServerAddresses)
+                if (hasListenOptions && hasServerAddresses && !_serverAddresses.PreferHostingUrls)
+                {
+                    var joined = string.Join(", ", _serverAddresses.Addresses);
+                    _logger.LogWarning($"Overriding address(es) '{joined}'. Binding to endpoints defined in UseKestrel() instead.");
+
+                    _serverAddresses.Addresses.Clear();
+                }
+                else if (!hasListenOptions && !hasServerAddresses)
                 {
                     _logger.LogDebug($"No listening endpoints were configured. Binding to {Constants.DefaultServerAddress} by default.");
 
@@ -123,13 +130,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                     _serverAddresses.Addresses.Add(Constants.DefaultServerAddress);
 
                     return;
-                }
-                else if (hasListenOptions && hasServerAddresses && !_serverAddresses.PreferHostingUrls)
-                {
-                    var joined = string.Join(", ", _serverAddresses.Addresses);
-                    _logger.LogWarning($"Overriding address(es) '{joined}'. Binding to endpoints defined in UseKestrel() instead.");
-
-                    _serverAddresses.Addresses.Clear();
                 }
                 else if (!hasListenOptions || (_serverAddresses.PreferHostingUrls && hasServerAddresses))
                 {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 Assert.Equal(5002, host.GetPort());
                 Assert.Single(testLogger.Messages, log => log.LogLevel == LogLevel.Warning &&
-                    string.Equals($"Overriding endpoints defined in UseKestrel() since {nameof(IServerAddressesFeature.PreferHostingUrls)} ist set to true. Binding to address(es) '{overrideAddress}' instead.",
+                    string.Equals($"Overriding endpoints defined in UseKestrel() since {nameof(IServerAddressesFeature.PreferHostingUrls)} is set to true. Binding to address(es) '{overrideAddress}' instead.",
                     log.Message, StringComparison.Ordinal));
 
                 Assert.Equal(new Uri(overrideAddress).ToString(), await HttpClientSlim.GetStringAsync(overrideAddress));

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -216,18 +216,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [ConditionalFact]
-        [PortSupportedCondition(5001)]
         [PortSupportedCondition(5002)]
         public async Task OverrideDirectConfigurationWithIServerAddressesFeature_Succeeds()
         {
             var overrideAddress = "http://localhost:5002";
             var testLogger = new TestApplicationErrorLogger();
-
             var hostBuilder = new WebHostBuilder()
-               .UseKestrel(options =>
-               {
-                   options.Listen(IPAddress.Loopback, 5001);
-               })
+               .UseKestrel(options => options.Listen(IPAddress.Loopback, 5001))
                .UseUrls(overrideAddress)
                .PreferHostingUrls(true)
                .UseLoggerFactory(_ => new KestrelTestLoggerFactory(testLogger))
@@ -248,20 +243,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [ConditionalFact]
         [PortSupportedCondition(5001)]
-        [PortSupportedCondition(5002)]
         public async Task DoesNotOverrideDirectConfigurationWithIServerAddressesFeature_IfPreferHostingUrlsFalse()
         {
             var endPointAddress = "http://localhost:5001";
-            var testLogger = new TestApplicationErrorLogger();
-
             var hostBuilder = new WebHostBuilder()
-               .UseKestrel(options =>
-               {
-                   options.Listen(IPAddress.Loopback, 5001);
-               })
+               .UseKestrel(options => options.Listen(IPAddress.Loopback, 5001))
                .UseUrls("http://localhost:5002")
                .PreferHostingUrls(false)
-               .UseLoggerFactory(_ => new KestrelTestLoggerFactory(testLogger))
                .Configure(ConfigureEchoAddress);
 
             using (var host = hostBuilder.Build())
@@ -278,15 +266,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task DoesNotOverrideDirectConfigurationWithIServerAddressesFeature_IfAddressesEmpty()
         {
             var endPointAddress = "http://localhost:5001";
-            var testLogger = new TestApplicationErrorLogger();
-
             var hostBuilder = new WebHostBuilder()
-               .UseKestrel(options =>
-               {
-                   options.Listen(IPAddress.Loopback, 5001);
-               })
+               .UseKestrel(options => options.Listen(IPAddress.Loopback, 5001))
                .PreferHostingUrls(true)
-               .UseLoggerFactory(_ => new KestrelTestLoggerFactory(testLogger))
                .Configure(ConfigureEchoAddress);
 
             using (var host = hostBuilder.Build())
@@ -632,7 +614,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+        [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
         private class PortSupportedConditionAttribute : Attribute, ITestCondition
         {
             private readonly int _port;


### PR DESCRIPTION
Addresses #1575.

We want to override the endpoints configured in the listen options when PreferHostingUrls is set to true with the addresses in the IServerAddressesFeature if it's not empty.

Will squash with a meaningful commit message once ready to merge.