### PR TITLE
Specialized struct generics rather than interface

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/StreamSocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/StreamSocketOutput.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
             return WriteAsync(default(ArraySegment<byte>), chunk: false, cancellationToken: cancellationToken);
         }
 
-        public void Write<T>(Action<WritableBuffer, T> callback, T state)
+        public void Write<T>(Action<WritableBuffer, T> callback, T state) where T : struct
         {
             lock (_sync)
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameAdapter.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameAdapter.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
+{
+    public struct FrameAdapter : IHttpRequestLineHandler, IHttpHeadersHandler
+    {
+        public Frame Frame;
+
+        public FrameAdapter(Frame frame)
+        {
+            Frame = frame;
+        }
+
+        public void OnHeader(Span<byte> name, Span<byte> value)
+            => Frame.OnHeader(name, value);
+
+        public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
+            => Frame.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    public class HttpParser : IHttpParser
+    public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TRequestHandler : struct, IHttpHeadersHandler, IHttpRequestLineHandler
     {
         public HttpParser(IKestrelTrace log)
         {
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private const byte ByteQuestionMark = (byte)'?';
         private const byte BytePercentage = (byte)'%';
 
-        public unsafe bool ParseRequestLine(IHttpRequestLineHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
+        public unsafe bool ParseRequestLine(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
         {
             consumed = buffer.Start;
             examined = buffer.End;
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return true;
         }
 
-        private unsafe void ParseRequestLine(IHttpRequestLineHandler handler, byte* data, int length)
+        private unsafe void ParseRequestLine(TRequestHandler handler, byte* data, int length)
         {
             int offset;
             Span<byte> customMethod = default(Span<byte>);
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             handler.OnStartLine(method, httpVersion, targetBuffer, pathBuffer, query, customMethod, pathEncoded);
         }
 
-        public unsafe bool ParseHeaders(IHttpHeadersHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes)
+        public unsafe bool ParseHeaders(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes)
         {
             consumed = buffer.Start;
             examined = buffer.End;
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe void TakeSingleHeader(byte* headerLine, int length, IHttpHeadersHandler handler)
+        private unsafe void TakeSingleHeader(byte* headerLine, int length, TRequestHandler handler)
         {
             // Skip CR, LF from end position
             var valueEnd = length - 3;

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TRequestHandler : struct, IHttpHeadersHandler, IHttpRequestLineHandler
+    public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TRequestHandler : IHttpHeadersHandler, IHttpRequestLineHandler
     {
         public HttpParser(IKestrelTrace log)
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/IHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/IHttpParser.cs
@@ -5,11 +5,11 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    public interface IHttpParser
+    public interface IHttpParser<TRequestHandler> where TRequestHandler : struct, IHttpHeadersHandler, IHttpRequestLineHandler
     {
-        bool ParseRequestLine(IHttpRequestLineHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined);
+        bool ParseRequestLine(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined);
 
-        bool ParseHeaders(IHttpHeadersHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes);
+        bool ParseHeaders(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes);
 
         void Reset();
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/IHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/IHttpParser.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    public interface IHttpParser<TRequestHandler> where TRequestHandler : struct, IHttpHeadersHandler, IHttpRequestLineHandler
+    public interface IHttpParser<TRequestHandler> where TRequestHandler : IHttpHeadersHandler, IHttpRequestLineHandler
     {
         bool ParseRequestLine(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined);
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/ISocketOutput.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/ISocketOutput.cs
@@ -17,6 +17,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         Task WriteAsync(ArraySegment<byte> buffer, bool chunk = false, CancellationToken cancellationToken = default(CancellationToken));
         void Flush();
         Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken));
-        void Write<T>(Action<WritableBuffer, T> write, T state);
+        void Write<T>(Action<WritableBuffer, T> write, T state) where T : struct;
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ServiceContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ServiceContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         public IThreadPool ThreadPool { get; set; }
 
-        public Func<Frame, IHttpParser> HttpParserFactory { get; set; }
+        public Func<FrameAdapter, IHttpParser<FrameAdapter>> HttpParserFactory { get; set; }
 
         public DateHeaderValueManager DateHeaderValueManager { get; set; }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                 var serviceContext = new ServiceContext
                 {
                     Log = trace,
-                    HttpParserFactory = frame => new HttpParser(frame.ServiceContext.Log),
+                    HttpParserFactory = frameParser => new HttpParser<FrameAdapter>(frameParser.Frame.ServiceContext.Log),
                     ThreadPool = threadPool,
                     DateHeaderValueManager = _dateHeaderValueManager,
                     ServerOptions = Options

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameResponseHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameResponseHeadersTests.cs
@@ -257,9 +257,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             "42.000",
         };
 
-        private class NoopHttpParser : IHttpParser
+        private class NoopHttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TRequestHandler : struct, IHttpHeadersHandler, IHttpRequestLineHandler
         {
-            public bool ParseHeaders(IHttpHeadersHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes)
+            public bool ParseHeaders(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes)
             {
                 consumed = buffer.Start;
                 examined = buffer.End;
@@ -267,7 +267,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 return false;
             }
 
-            public bool ParseRequestLine(IHttpRequestLineHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
+            public bool ParseRequestLine(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
             {
                 consumed = buffer.Start;
                 examined = buffer.End;

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameResponseHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameResponseHeadersTests.cs
@@ -256,28 +256,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             "42,000",
             "42.000",
         };
-
-        private class NoopHttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TRequestHandler : struct, IHttpHeadersHandler, IHttpRequestLineHandler
-        {
-            public bool ParseHeaders(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes)
-            {
-                consumed = buffer.Start;
-                examined = buffer.End;
-                consumedBytes = 0;
-                return false;
-            }
-
-            public bool ParseRequestLine(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
-            {
-                consumed = buffer.Start;
-                examined = buffer.End;
-                return false;
-            }
-
-            public void Reset()
-            {
-
-            }
-        }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/HttpParserTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/HttpParserTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.System;
@@ -35,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var buffer = ReadableBuffer.Create(Encoding.ASCII.GetBytes(requestLine));
             var requestHandler = new RequestHandler();
 
-            Assert.True(parser.ParseRequestLine(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined));
+            Assert.True(parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal(requestHandler.Method, expectedMethod);
             Assert.Equal(requestHandler.Version, expectedVersion);
@@ -54,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var buffer = ReadableBuffer.Create(Encoding.ASCII.GetBytes(requestLine));
             var requestHandler = new RequestHandler();
 
-            Assert.False(parser.ParseRequestLine(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined));
+            Assert.False(parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
         }
 
         [Theory]
@@ -65,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var buffer = ReadableBuffer.Create(Encoding.ASCII.GetBytes(requestLine));
             var requestHandler = new RequestHandler();
 
-            Assert.False(parser.ParseRequestLine(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined));
+            Assert.False(parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal(buffer.Start, consumed);
             Assert.Equal(buffer.End, examined);
@@ -85,7 +84,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var requestHandler = new RequestHandler();
 
             var exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseRequestLine(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined));
+                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal($"Invalid request line: '{requestLine.EscapeNonPrintable()}'", exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, (exception as BadHttpRequestException).StatusCode);
@@ -107,7 +106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var requestHandler = new RequestHandler();
 
             var exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseRequestLine(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined));
+                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal($"Invalid request line: '{method.EscapeNonPrintable()} / HTTP/1.1\\x0D\\x0A'", exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, (exception as BadHttpRequestException).StatusCode);
@@ -129,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var requestHandler = new RequestHandler();
 
             var exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseRequestLine(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined));
+                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal($"Unrecognized HTTP version: '{httpVersion}'", exception.Message);
             Assert.Equal(StatusCodes.Status505HttpVersionNotsupported, (exception as BadHttpRequestException).StatusCode);
@@ -178,7 +177,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             var buffer = ReadableBuffer.Create(Encoding.ASCII.GetBytes(rawHeaders));
             var requestHandler = new RequestHandler();
-            Assert.False(parser.ParseHeaders(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined, out var consumedBytes));
+            Assert.False(parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out var consumedBytes));
         }
 
         [Theory]
@@ -203,7 +202,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             var buffer = ReadableBuffer.Create(Encoding.ASCII.GetBytes(rawHeaders));
             var requestHandler = new RequestHandler();
-            parser.ParseHeaders(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined, out var consumedBytes);
+            parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out var consumedBytes);
 
             Assert.Equal(buffer.Start, consumed);
             Assert.Equal(buffer.End, examined);
@@ -293,14 +292,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             const string headerLine = "Header: value\r\n\r";
             var buffer1 = ReadableBuffer.Create(Encoding.ASCII.GetBytes(headerLine));
             var requestHandler = new RequestHandler();
-            Assert.False(parser.ParseHeaders(new RequestAdapter(requestHandler), buffer1, out var consumed, out var examined, out var consumedBytes));
+            Assert.False(parser.ParseHeaders(requestHandler, buffer1, out var consumed, out var examined, out var consumedBytes));
 
             Assert.Equal(buffer1.Move(buffer1.Start, headerLine.Length - 1), consumed);
             Assert.Equal(buffer1.End, examined);
             Assert.Equal(headerLine.Length - 1, consumedBytes);
 
             var buffer2 = ReadableBuffer.Create(Encoding.ASCII.GetBytes("\r\n"));
-            Assert.True(parser.ParseHeaders(new RequestAdapter(requestHandler), buffer2, out consumed, out examined, out consumedBytes));
+            Assert.True(parser.ParseHeaders(requestHandler, buffer2, out consumed, out examined, out consumedBytes));
 
             Assert.Equal(buffer2.End, consumed);
             Assert.Equal(buffer2.End, examined);
@@ -321,7 +320,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var requestHandler = new RequestHandler();
 
             var exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseHeaders(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined, out var consumedBytes));
+                parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out var consumedBytes));
 
             Assert.Equal(expectedExceptionMessage, exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
@@ -342,7 +341,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var requestHandler = new RequestHandler();
 
             var exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseRequestLine(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined));
+                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal("Invalid request line: ''", exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, (exception as BadHttpRequestException).StatusCode);
@@ -351,7 +350,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             buffer = ReadableBuffer.Create(Encoding.ASCII.GetBytes("GET / HTTP/1.2\r\n"));
 
             exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseRequestLine(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined));
+                parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined));
 
             Assert.Equal("Unrecognized HTTP version: ''", exception.Message);
             Assert.Equal(StatusCodes.Status505HttpVersionNotsupported, (exception as BadHttpRequestException).StatusCode);
@@ -360,7 +359,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             buffer = ReadableBuffer.Create(Encoding.ASCII.GetBytes("Header: value\n\r\n"));
 
             exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseHeaders(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined, out var consumedBytes));
+                parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out var consumedBytes));
 
             Assert.Equal("Invalid request header: ''", exception.Message);
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
@@ -373,7 +372,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var buffer = BufferUtilities.CreateBuffer("GET ", "/");
 
             var requestHandler = new RequestHandler();
-            var result = parser.ParseRequestLine(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined);
+            var result = parser.ParseRequestLine(requestHandler, buffer, out var consumed, out var examined);
 
             Assert.False(result);
             Assert.Equal(buffer.Start, consumed);
@@ -389,7 +388,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var buffer = ReadableBuffer.Create(Encoding.ASCII.GetBytes($"{headerName}:{rawHeaderValue}\r\n"));
 
             var requestHandler = new RequestHandler();
-            parser.ParseHeaders(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined, out var consumedBytes);
+            parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out var consumedBytes);
 
             var pairs = requestHandler.Headers.ToArray();
             Assert.Equal(1, pairs.Length);
@@ -407,7 +406,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var buffer = ReadableBuffer.Create(Encoding.ASCII.GetBytes(rawHeaders));
 
             var requestHandler = new RequestHandler();
-            parser.ParseHeaders(new RequestAdapter(requestHandler), buffer, out var consumed, out var examined, out var consumedBytes);
+            parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out var consumedBytes);
 
             var parsedHeaders = requestHandler.Headers.ToArray();
 
@@ -418,7 +417,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(buffer.End, examined);
         }
 
-        private IHttpParser<RequestAdapter> CreateParser(IKestrelTrace log) => new HttpParser<RequestAdapter>(log);
+        private IHttpParser<RequestHandler> CreateParser(IKestrelTrace log) => new HttpParser<RequestHandler>(log);
 
         public static IEnumerable<string[]> RequestLineValidData => HttpParsingData.RequestLineValidData;
 
@@ -462,22 +461,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Query = query.GetAsciiStringNonNullCharacters();
                 PathEncoded = pathEncoded;
             }
-        }
-
-        private struct RequestAdapter : IHttpRequestLineHandler, IHttpHeadersHandler
-        {
-            public RequestHandler Handler;
-
-            public RequestAdapter(RequestHandler handler)
-            {
-                Handler = handler;
-            }
-
-            public void OnHeader(Span<byte> name, Span<byte> value)
-                => Handler.OnHeader(name, value);
-
-            public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
-                => Handler.OnStartLine(method, version, target, path, query, customMethod, pathEncoded);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/OutputProducerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/OutputProducerTests.cs
@@ -38,11 +38,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 var called = false;
 
-                ((ISocketOutput)socketOutput).Write<object>((buffer, state) =>
+                ((ISocketOutput)socketOutput).Write((buffer, state) =>
                 {
                     called = true;
                 },
-                null);
+                0);
 
                 Assert.False(called);
             }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameFeatureCollection.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameFeatureCollection.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             var serviceContext = new ServiceContext
             {
-                HttpParserFactory = _ => NullParser.Instance,
+                HttpParserFactory = _ => NullParser<FrameAdapter>.Instance,
                 ServerOptions = new KestrelServerOptions()
             };
             var frameContext = new FrameContext

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverheadBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverheadBenchmark.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             var serviceContext = new ServiceContext
             {
-                HttpParserFactory = _ => NullParser.Instance,
+                HttpParserFactory = _ => NullParser<FrameAdapter>.Instance,
                 ServerOptions = new KestrelServerOptions()
             };
             var frameContext = new FrameContext

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                 DateHeaderValueManager = new DateHeaderValueManager(),
                 ServerOptions = new KestrelServerOptions(),
                 Log = new MockTrace(),
-                HttpParserFactory = f => new HttpParser(log: null)
+                HttpParserFactory = f => new HttpParser<FrameAdapter>(log: null)
             };
             var frameContext = new FrameContext
             {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Mocks/NullParser.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Mocks/NullParser.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 {
-    public class NullParser : IHttpParser
+    public class NullParser<TRequestHandler> : IHttpParser<TRequestHandler> where TRequestHandler : struct, IHttpHeadersHandler, IHttpRequestLineHandler
     {
         private readonly byte[] _startLine = Encoding.ASCII.GetBytes("GET /plaintext HTTP/1.1\r\n");
         private readonly byte[] _target = Encoding.ASCII.GetBytes("/plaintext");
@@ -19,9 +19,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         private readonly byte[] _connectionHeaderName = Encoding.ASCII.GetBytes("Connection");
         private readonly byte[] _connectionHeaderValue = Encoding.ASCII.GetBytes("keep-alive");
 
-        public static readonly NullParser Instance = new NullParser();
+        public static readonly NullParser<FrameAdapter> Instance = new NullParser<FrameAdapter>();
 
-        public bool ParseHeaders(IHttpHeadersHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes)
+        public bool ParseHeaders(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes)
         {
             handler.OnHeader(new Span<byte>(_hostHeaderName), new Span<byte>(_hostHeaderValue));
             handler.OnHeader(new Span<byte>(_acceptHeaderName), new Span<byte>(_acceptHeaderValue));
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             return true;
         }
 
-        public bool ParseRequestLine(IHttpRequestLineHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
+        public bool ParseRequestLine(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
         {
             handler.OnStartLine(HttpMethod.Get,
                 HttpVersion.Http11,

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/RequestParsingBenchmark.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             var serviceContext = new ServiceContext
             {
-                HttpParserFactory = f => new HttpParser(f.ServiceContext.Log),
+                HttpParserFactory = f => new HttpParser<FrameAdapter>(f.Frame.ServiceContext.Log),
                 ServerOptions = new KestrelServerOptions()
             };
             var frameContext = new FrameContext

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeaderCollectionBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeaderCollectionBenchmark.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         {
             var serviceContext = new ServiceContext
             {
-                HttpParserFactory = f => new HttpParser(f.ServiceContext.Log),
+                HttpParserFactory = f => new HttpParser<FrameAdapter>(f.Frame.ServiceContext.Log),
                 ServerOptions = new KestrelServerOptions()
             };
             var frameContext = new FrameContext

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                 DateHeaderValueManager = new DateHeaderValueManager(),
                 ServerOptions = new KestrelServerOptions(),
                 Log = new MockTrace(),
-                HttpParserFactory = f => new HttpParser(log: null)
+                HttpParserFactory = f => new HttpParser<FrameAdapter>(log: null)
             };
 
             var frameContext = new FrameContext

--- a/test/shared/MockSocketOutput.cs
+++ b/test/shared/MockSocketOutput.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Testing
             return TaskCache.CompletedTask;
         }
 
-        public void Write<T>(Action<WritableBuffer, T> write, T state)
+        public void Write<T>(Action<WritableBuffer, T> write, T state) where T : struct
         {
 
         }

--- a/test/shared/TestServiceContext.cs
+++ b/test/shared/TestServiceContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Testing
             ThreadPool = new LoggingThreadPool(Log);
             DateHeaderValueManager = new DateHeaderValueManager(systemClock: new MockSystemClock());
             DateHeaderValue = DateHeaderValueManager.GetDateHeaderValues().String;
-            HttpParserFactory = frame => new HttpParser(frame.ServiceContext.Log);
+            HttpParserFactory = frameAdapter => new HttpParser<FrameAdapter>(frameAdapter.Frame.ServiceContext.Log);
             ServerOptions = new KestrelServerOptions
             {
                 AddServerHeader = false


### PR DESCRIPTION
Use struct wrappers to specialize generic dispatch

`Generic<object> Dispatch` < `Interface Dispatch` < `Virtual Dispatch` < `Generic<struct> Dispatch`

Follow up to https://github.com/aspnet/KestrelHttpServer/pull/1624#issuecomment-292521621