### PR TITLE
Measure Writing in FrameWritingBenchmark

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
@@ -346,6 +346,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _frameStreams.ResponseBody.StopAcceptingWrites();
         }
 
+        // For testing
+        internal void ResetState()
+        {
+            _requestProcessingStatus = RequestProcessingStatus.RequestPending;
+        }
+
         public void Reset()
         {
             FrameRequestHeaders?.Reset();

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/MessageBody.cs
@@ -16,6 +16,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private static readonly MessageBody _zeroContentLengthClose = new ForZeroContentLength(keepAlive: false);
         private static readonly MessageBody _zeroContentLengthKeepAlive = new ForZeroContentLength(keepAlive: true);
 
+        // For testing
+        internal static MessageBody ZeroContentLengthKeepAlive => _zeroContentLengthKeepAlive;
+
         private readonly Frame _context;
         private bool _send100Continue = true;
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -16,78 +17,88 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
     [Config(typeof(CoreConfig))]
     public class FrameWritingBenchmark
     {
+        // Standard completed task
+        private static readonly Task CompletedStandardTask = Task.CompletedTask;
+        private static readonly Func<object, Task> _syncTask = (obj) => CompletedStandardTask;
+        // Non-standard completed task
+        private static readonly Task CompletedDifferentTask = Task.FromResult(27);
+        private static readonly Func<object, Task> _asyncTask = (obj) => CompletedDifferentTask;
+
         private readonly TestFrame<object> _frame;
-        private readonly TestFrame<object> _frameChunked;
+        private readonly IPipe _outputPipe;
+
         private readonly byte[] _writeData;
 
         public FrameWritingBenchmark()
         {
-            _frame = MakeFrame();
-            _frameChunked = MakeFrame();
-            _writeData = new byte[1];
+            var factory = new PipeFactory();
+
+            _frame = MakeFrame(factory);
+            _outputPipe = factory.Create();
+            _frame.Output = new OutputProducer(_outputPipe.Writer, null, null, null);
+
+            _writeData = Encoding.ASCII.GetBytes("Hello, World!");
         }
+
+        [Params(true, false)]
+        public bool WithHeaders { get; set; }
+
+        [Params(true, false)]
+        public bool Chunked { get; set; }
+
+        [Params(Startup.None, Startup.Sync, Startup.Async)]
+        public Startup OnStarting { get; set; }
 
         [Setup]
         public void Setup()
         {
             _frame.Reset();
-            _frame.RequestHeaders.Add("Content-Length", "1073741824");
+            if (Chunked)
+            {
+                _frame.RequestHeaders.Add("Transfer-Encoding", "chunked");
+            }
+            else
+            {
+                _frame.RequestHeaders.ContentLength = _writeData.Length;
+            }
 
-            _frameChunked.Reset();
-            _frameChunked.RequestHeaders.Add("Transfer-Encoding", "chunked");
+            if (!WithHeaders)
+            {
+                _frame.Flush();
+            }
+
+            ResetState();
+        }
+
+        private void ResetState()
+        {
+            if (WithHeaders)
+            {
+                _frame.ResetState();
+
+                switch (OnStarting)
+                {
+                    case Startup.Sync:
+                        _frame.OnStarting(_syncTask, null);
+                        break;
+                    case Startup.Async:
+                        _frame.OnStarting(_asyncTask, null);
+                        break;
+                }
+            }
         }
 
         [Benchmark]
-        public void Write()
+        public Task WriteAsync()
         {
-            _frame.Write(new ArraySegment<byte>(_writeData));
+            ResetState();
+
+            return _frame.ResponseBody.WriteAsync(_writeData, 0, _writeData.Length, default(CancellationToken));
         }
 
-        [Benchmark]
-        public void WriteChunked()
+        private TestFrame<object> MakeFrame(PipeFactory factory)
         {
-            _frameChunked.Write(new ArraySegment<byte>(_writeData));
-        }
-
-        [Benchmark]
-        public async Task WriteAsync()
-        {
-            await _frame.WriteAsync(new ArraySegment<byte>(_writeData), default(CancellationToken));
-        }
-
-        [Benchmark]
-        public async Task WriteAsyncChunked()
-        {
-            await _frameChunked.WriteAsync(new ArraySegment<byte>(_writeData), default(CancellationToken));
-        }
-
-        [Benchmark]
-        public async Task WriteAsyncAwaited()
-        {
-            await _frame.WriteAsyncAwaited(new ArraySegment<byte>(_writeData), default(CancellationToken));
-        }
-
-        [Benchmark]
-        public async Task WriteAsyncAwaitedChunked()
-        {
-            await _frameChunked.WriteAsyncAwaited(new ArraySegment<byte>(_writeData), default(CancellationToken));
-        }
-
-        [Benchmark]
-        public async Task ProduceEnd()
-        {
-            await _frame.ProduceEndAsync();
-        }
-
-        [Benchmark]
-        public async Task ProduceEndChunked()
-        {
-            await _frameChunked.ProduceEndAsync();
-        }
-
-        private TestFrame<object> MakeFrame()
-        {
-            var socketInput = new PipeFactory().Create();
+            var socketInput = factory.Create();
 
             var serviceContext = new ServiceContext
             {
@@ -104,14 +115,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             var frame = new TestFrame<object>(application: null, context: frameContext)
             {
-                Input = socketInput.Reader,
-                Output = new MockSocketOutput()
+                Input = socketInput.Reader
             };
 
             frame.Reset();
             frame.InitializeHeaders();
+            frame.InitializeStreams(MessageBody.ZeroContentLengthKeepAlive);
 
             return frame;
+        }
+
+        [Cleanup]
+        public void Cleanup()
+        {
+            EmptyPipe(_outputPipe.Reader);
+        }
+
+        private void EmptyPipe(IPipeReader reader)
+        {
+            if (reader.TryRead(out var readResult))
+            {
+                reader.Advance(readResult.Buffer.End);
+            }
+        }
+
+        public enum Startup
+        {
+            None,
+            Sync,
+            Async
         }
     }
 }


### PR DESCRIPTION
Wasn't really measuring the actual writing path before
Also was incorrectly measuring sync vs async by adding an additional await in the async path

/cc @davidfowl 