### PR TITLE
FrameFeatureCollection benchmark

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.Generated.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.Generated.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _currentIHttpSendFileFeature = null;
         }
 
-        private object FastFeatureGet(Type key)
+        internal object FastFeatureGet(Type key)
         {
             if (key == IHttpRequestFeatureType)
             {
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return ExtraFeatureGet(key);
         }
 
-        private void FastFeatureSet(Type key, object feature)
+        internal void FastFeatureSet(Type key, object feature)
         {
             _featureRevision++;
             

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameFeatureCollection.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameFeatureCollection.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    [Config(typeof(CoreConfig))]
+    public class FrameFeatureCollection
+    {
+        private readonly Frame<object> _frame;
+        private IFeatureCollection _collection;
+
+        [Benchmark(Baseline = true)]
+        public IHttpRequestFeature GetFirstViaFastFeature()
+        {
+            return (IHttpRequestFeature)GetFastFeature(typeof(IHttpRequestFeature));
+        }
+
+        [Benchmark]
+        public IHttpRequestFeature GetFirstViaType()
+        {
+            return (IHttpRequestFeature)Get(typeof(IHttpRequestFeature));
+        }
+
+        [Benchmark]
+        public IHttpRequestFeature GetFirstViaExtension()
+        {
+            return _collection.GetType<IHttpRequestFeature>();
+        }
+
+        [Benchmark]
+        public IHttpRequestFeature GetFirstViaGeneric()
+        {
+            return _collection.Get<IHttpRequestFeature>();
+        }
+
+        [Benchmark]
+        public IHttpSendFileFeature GetLastViaFastFeature()
+        {
+            return (IHttpSendFileFeature)GetFastFeature(typeof(IHttpSendFileFeature));
+        }
+
+        [Benchmark]
+        public IHttpSendFileFeature GetLastViaType()
+        {
+            return (IHttpSendFileFeature)Get(typeof(IHttpSendFileFeature));
+        }
+
+        [Benchmark]
+        public IHttpSendFileFeature GetLastViaExtension()
+        {
+            return _collection.GetType<IHttpSendFileFeature>();
+        }
+
+        [Benchmark]
+        public IHttpSendFileFeature GetLastViaGeneric()
+        {
+            return _collection.Get<IHttpSendFileFeature> ();
+        }
+
+        private object Get(Type type)
+        {
+            return _collection[type];
+        }
+
+        private object GetFastFeature(Type type)
+        {
+            return _frame.FastFeatureGet(type);
+        }
+
+        public FrameFeatureCollection()
+        {
+            var serviceContext = new ServiceContext
+            {
+                HttpParserFactory = _ => NullParser.Instance,
+                ServerOptions = new KestrelServerOptions()
+            };
+            var frameContext = new FrameContext
+            {
+                ServiceContext = serviceContext,
+                ConnectionInformation = new MockConnectionInformation()
+            };
+
+            _frame = new Frame<object>(application: null, frameContext: frameContext);
+        }
+
+        [Setup]
+        public void Setup()
+        {
+            _collection = _frame;
+        }
+
+    }
+    public static class IFeatureCollectionExtensions
+    {
+        public static T GetType<T>(this IFeatureCollection collection)
+        {
+            return (T)collection[typeof(T)];
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverheadBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameParsingOverheadBenchmark.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Text;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Internal.System;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Performance
@@ -98,53 +96,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             if (!_frame.TakeMessageHeaders(_buffer, out var consumed, out var examined))
             {
                 ErrorUtilities.ThrowInvalidRequestHeaders();
-            }
-        }
-
-        private class NullParser : IHttpParser
-        {
-            private readonly byte[] _startLine = Encoding.ASCII.GetBytes("GET /plaintext HTTP/1.1\r\n");
-            private readonly byte[] _target = Encoding.ASCII.GetBytes("/plaintext");
-            private readonly byte[] _hostHeaderName = Encoding.ASCII.GetBytes("Host");
-            private readonly byte[] _hostHeaderValue = Encoding.ASCII.GetBytes("www.example.com");
-            private readonly byte[] _acceptHeaderName = Encoding.ASCII.GetBytes("Accept");
-            private readonly byte[] _acceptHeaderValue = Encoding.ASCII.GetBytes("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7\r\n\r\n");
-            private readonly byte[] _connectionHeaderName = Encoding.ASCII.GetBytes("Connection");
-            private readonly byte[] _connectionHeaderValue = Encoding.ASCII.GetBytes("keep-alive");
-
-            public static readonly NullParser Instance = new NullParser();
-
-            public bool ParseHeaders(IHttpHeadersHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes)
-            {
-                handler.OnHeader(new Span<byte>(_hostHeaderName), new Span<byte>(_hostHeaderValue));
-                handler.OnHeader(new Span<byte>(_acceptHeaderName), new Span<byte>(_acceptHeaderValue));
-                handler.OnHeader(new Span<byte>(_connectionHeaderName), new Span<byte>(_connectionHeaderValue));
-
-                consumedBytes = 0;
-                consumed = buffer.Start;
-                examined = buffer.End;
-
-                return true;
-            }
-
-            public bool ParseRequestLine(IHttpRequestLineHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
-            {
-                handler.OnStartLine(HttpMethod.Get,
-                    HttpVersion.Http11,
-                    new Span<byte>(_target),
-                    new Span<byte>(_target),
-                    Span<byte>.Empty,
-                    Span<byte>.Empty,
-                    false);
-
-                consumed = buffer.Start;
-                examined = buffer.End;
-
-                return true;
-            }
-
-            public void Reset()
-            {
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Mocks/NullParser.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/Mocks/NullParser.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    public class NullParser : IHttpParser
+    {
+        private readonly byte[] _startLine = Encoding.ASCII.GetBytes("GET /plaintext HTTP/1.1\r\n");
+        private readonly byte[] _target = Encoding.ASCII.GetBytes("/plaintext");
+        private readonly byte[] _hostHeaderName = Encoding.ASCII.GetBytes("Host");
+        private readonly byte[] _hostHeaderValue = Encoding.ASCII.GetBytes("www.example.com");
+        private readonly byte[] _acceptHeaderName = Encoding.ASCII.GetBytes("Accept");
+        private readonly byte[] _acceptHeaderValue = Encoding.ASCII.GetBytes("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7\r\n\r\n");
+        private readonly byte[] _connectionHeaderName = Encoding.ASCII.GetBytes("Connection");
+        private readonly byte[] _connectionHeaderValue = Encoding.ASCII.GetBytes("keep-alive");
+
+        public static readonly NullParser Instance = new NullParser();
+
+        public bool ParseHeaders(IHttpHeadersHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes)
+        {
+            handler.OnHeader(new Span<byte>(_hostHeaderName), new Span<byte>(_hostHeaderValue));
+            handler.OnHeader(new Span<byte>(_acceptHeaderName), new Span<byte>(_acceptHeaderValue));
+            handler.OnHeader(new Span<byte>(_connectionHeaderName), new Span<byte>(_connectionHeaderValue));
+
+            consumedBytes = 0;
+            consumed = buffer.Start;
+            examined = buffer.End;
+
+            return true;
+        }
+
+        public bool ParseRequestLine(IHttpRequestLineHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined)
+        {
+            handler.OnStartLine(HttpMethod.Get,
+                HttpVersion.Http11,
+                new Span<byte>(_target),
+                new Span<byte>(_target),
+                Span<byte>.Empty,
+                Span<byte>.Empty,
+                false);
+
+            consumed = buffer.Start;
+            examined = buffer.End;
+
+            return true;
+        }
+
+        public void Reset()
+        {
+        }
+    }
+}

--- a/tools/CodeGenerator/FrameFeatureCollection.cs
+++ b/tools/CodeGenerator/FrameFeatureCollection.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _current{feature.Name} = null;")}
         }}
 
-        private object FastFeatureGet(Type key)
+        internal object FastFeatureGet(Type key)
         {{{Each(allFeatures, feature => $@"
             if (key == {feature.Name}Type)
             {{
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return ExtraFeatureGet(key);
         }}
 
-        private void FastFeatureSet(Type key, object feature)
+        internal void FastFeatureSet(Type key, object feature)
         {{
             _featureRevision++;
             {Each(allFeatures, feature => $@"


### PR DESCRIPTION
Output
```
                 Method |       Mean |    StdDev |         Op/s | Scaled | Allocated |
----------------------- |----------- |---------- |------------- |------- |---------- |
 GetFirstViaFastFeature |  5.7434 ns | 0.0642 ns | 174113914.78 |   1.00 |       0 B |
        GetFirstViaType |  7.2421 ns | 0.0549 ns | 138081472.44 |   1.26 |       0 B |
   GetFirstViaExtension |  8.8473 ns | 0.2046 ns | 113028985.80 |   1.54 |       0 B |
     GetFirstViaGeneric | 12.7234 ns | 0.1493 ns |  78595386.17 |   2.22 |       0 B |
  GetLastViaFastFeature | 12.7502 ns | 0.1002 ns |  78430044.58 |   2.22 |       0 B |
         GetLastViaType | 14.3296 ns | 0.4810 ns |  69785859.00 |   2.50 |       0 B |
    GetLastViaExtension | 15.5168 ns | 0.1387 ns |  64446150.84 |   2.70 |       0 B |
      GetLastViaGeneric | 18.9250 ns | 0.2723 ns |  52840253.99 |   3.30 |       0 B |
```

/cc @davidfowl 