### PR TITLE
Workaround for "Explicit RID still required for .NET Framework test projects"

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.csproj
@@ -7,6 +7,12 @@
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <PlatformTarget Condition="'$(TargetFramework)' == 'net46'">x64</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!--
+      Workaround for "Explicit RID still required for .NET Framework test projects" (https://github.com/dotnet/sdk/issues/909).
+      Remove when fixed.
+    -->
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Addresses #1617