### PR TITLE
Honor PreferHostingUrls

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServer.cs
@@ -119,14 +119,36 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                 var hasListenOptions = listenOptions.Any();
                 var hasServerAddresses = _serverAddresses.Addresses.Any();
 
-                if (hasListenOptions && hasServerAddresses)
+                if (_serverAddresses.PreferHostingUrls && hasServerAddresses)
                 {
-                    var joined = string.Join(", ", _serverAddresses.Addresses);
-                    _logger.LogWarning($"Overriding address(es) '{joined}'. Binding to endpoints defined in UseKestrel() instead.");
+                    if (hasListenOptions)
+                    {
+                        var joined = string.Join(", ", _serverAddresses.Addresses);
+                        _logger.LogInformation($"Overriding endpoints defined in UseKestrel() since {nameof(IServerAddressesFeature.PreferHostingUrls)} is set to true. Binding to address(es) '{joined}' instead.");
 
-                    _serverAddresses.Addresses.Clear();
+                        listenOptions.Clear();
+                    }
+
+                    await BindToServerAddresses(listenOptions, serviceContext, application, cancellationToken).ConfigureAwait(false);
                 }
-                else if (!hasListenOptions && !hasServerAddresses)
+                else if (hasListenOptions)
+                {
+                    if (hasServerAddresses)
+                    {
+                        var joined = string.Join(", ", _serverAddresses.Addresses);
+                        _logger.LogWarning($"Overriding address(es) '{joined}'. Binding to endpoints defined in UseKestrel() instead.");
+
+                        _serverAddresses.Addresses.Clear();
+                    }
+
+                    await BindToEndpoints(listenOptions, serviceContext, application).ConfigureAwait(false);
+                }
+                else if (hasServerAddresses)
+                {
+                    // If no endpoints are configured directly using KestrelServerOptions, use those configured via the IServerAddressesFeature.
+                    await BindToServerAddresses(listenOptions, serviceContext, application, cancellationToken).ConfigureAwait(false);
+                }
+                else
                 {
                     _logger.LogDebug($"No listening endpoints were configured. Binding to {Constants.DefaultServerAddress} by default.");
 
@@ -136,78 +158,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                     // If StartLocalhost doesn't throw, there is at least one listener.
                     // The port cannot change for "localhost".
                     _serverAddresses.Addresses.Add(Constants.DefaultServerAddress);
-
-                    return;
-                }
-                else if (!hasListenOptions)
-                {
-                    // If no endpoints are configured directly using KestrelServerOptions, use those configured via the IServerAddressesFeature.
-                    var copiedAddresses = _serverAddresses.Addresses.ToArray();
-                    _serverAddresses.Addresses.Clear();
-
-                    foreach (var address in copiedAddresses)
-                    {
-                        var parsedAddress = ServerAddress.FromUrl(address);
-
-                        if (parsedAddress.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
-                        {
-                            throw new InvalidOperationException($"HTTPS endpoints can only be configured using {nameof(KestrelServerOptions)}.{nameof(KestrelServerOptions.Listen)}().");
-                        }
-                        else if (!parsedAddress.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
-                        {
-                            throw new InvalidOperationException($"Unrecognized scheme in server address '{address}'. Only 'http://' is supported.");
-                        }
-
-                        if (!string.IsNullOrEmpty(parsedAddress.PathBase))
-                        {
-                            throw new InvalidOperationException($"A path base can only be configured using {nameof(IApplicationBuilder)}.UsePathBase().");
-                        }
-
-                        if (!string.IsNullOrEmpty(parsedAddress.PathBase))
-                        {
-                            _logger.LogWarning($"Path base in address {address} is not supported and will be ignored. To specify a path base, use {nameof(IApplicationBuilder)}.UsePathBase().");
-                        }
-
-                        if (parsedAddress.IsUnixPipe)
-                        {
-                            listenOptions.Add(new ListenOptions(parsedAddress.UnixPipePath));
-                        }
-                        else
-                        {
-                            if (string.Equals(parsedAddress.Host, "localhost", StringComparison.OrdinalIgnoreCase))
-                            {
-                                // "localhost" for both IPv4 and IPv6 can't be represented as an IPEndPoint.
-                                await StartLocalhostAsync(parsedAddress, serviceContext, application, cancellationToken).ConfigureAwait(false);
-
-                                // If StartLocalhost doesn't throw, there is at least one listener.
-                                // The port cannot change for "localhost".
-                                _serverAddresses.Addresses.Add(parsedAddress.ToString());
-                            }
-                            else
-                            {
-                                // These endPoints will be added later to _serverAddresses.Addresses
-                                listenOptions.Add(new ListenOptions(CreateIPEndPoint(parsedAddress)));
-                            }
-                        }
-                    }
-                }
-
-                foreach (var endPoint in listenOptions)
-                {
-                    var connectionHandler = new ConnectionHandler<TContext>(endPoint, serviceContext, application);
-                    var transport = _transportFactory.Create(endPoint, connectionHandler);
-                    _transports.Add(transport);
-
-                    try
-                    {
-                        await transport.BindAsync().ConfigureAwait(false);
-                    }
-                    catch (AddressInUseException ex)
-                    {
-                        throw new IOException($"Failed to bind to address {endPoint}: address already in use.", ex);
-                    }
-
-                    _serverAddresses.Addresses.Add(endPoint.GetDisplayName());
                 }
             }
             catch (Exception ex)
@@ -215,6 +165,72 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                 _logger.LogCritical(0, ex, "Unable to start Kestrel.");
                 Dispose();
                 throw;
+            }
+        }
+
+        private async Task BindToServerAddresses<TContext>(List<ListenOptions> listenOptions, ServiceContext serviceContext, IHttpApplication<TContext> application, CancellationToken cancellationToken)
+        {
+            var copiedAddresses = _serverAddresses.Addresses.ToArray();
+            _serverAddresses.Addresses.Clear();
+            foreach (var address in copiedAddresses)
+            {
+                var parsedAddress = ServerAddress.FromUrl(address);
+
+                if (parsedAddress.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"HTTPS endpoints can only be configured using {nameof(KestrelServerOptions)}.{nameof(KestrelServerOptions.Listen)}().");
+                }
+                else if (!parsedAddress.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"Unrecognized scheme in server address '{address}'. Only 'http://' is supported.");
+                }
+
+                if (!string.IsNullOrEmpty(parsedAddress.PathBase))
+                {
+                    throw new InvalidOperationException($"A path base can only be configured using {nameof(IApplicationBuilder)}.UsePathBase().");
+                }
+
+                if (parsedAddress.IsUnixPipe)
+                {
+                    listenOptions.Add(new ListenOptions(parsedAddress.UnixPipePath));
+                }
+                else if (string.Equals(parsedAddress.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+                {
+                    // "localhost" for both IPv4 and IPv6 can't be represented as an IPEndPoint.
+                    await StartLocalhostAsync(parsedAddress, serviceContext, application, cancellationToken).ConfigureAwait(false);
+                    // If StartLocalhost doesn't throw, there is at least one listener.
+                    // The port cannot change for "localhost".
+                    _serverAddresses.Addresses.Add(parsedAddress.ToString());
+                }
+                else
+                {
+                    // These endPoints will be added later to _serverAddresses.Addresses
+                    listenOptions.Add(new ListenOptions(CreateIPEndPoint(parsedAddress)));
+                }
+            }
+
+            await BindToEndpoints(listenOptions, serviceContext, application).ConfigureAwait(false);
+        }
+
+        private async Task BindToEndpoints<TContext>(List<ListenOptions> listenOptions, ServiceContext serviceContext, IHttpApplication<TContext> application)
+        {
+            foreach (var endPoint in listenOptions)
+            {
+                var connectionHandler = new ConnectionHandler<TContext>(endPoint, serviceContext, application);
+                var transport = _transportFactory.Create(endPoint, connectionHandler);
+                _transports.Add(transport);
+
+                try
+                {
+                    await transport.BindAsync().ConfigureAwait(false);
+                }
+                catch (AddressInUseException ex)
+                {
+                    throw new IOException($"Failed to bind to address {endPoint}: address already in use.", ex);
+                }
+
+                // If requested port was "0", replace with assigned dynamic port.
+                _serverAddresses.Addresses.Add(endPoint.GetDisplayName());
             }
         }
 


### PR DESCRIPTION
Addresses #1575. Alternative to https://github.com/aspnet/KestrelHttpServer/pull/1639

We want to override the endpoints configured in the listen options when PreferHostingUrls is set to true with the addresses in the IServerAddressesFeature if it's not empty.

Will squash with a meaningful commit message once ready to merge.