### PR TITLE
Switching to the new toolset compiler.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,5 +4,6 @@
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
     <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/" />
   </packageSources>
 </configuration>

--- a/build/common.props
+++ b/build/common.props
@@ -20,4 +20,7 @@
     <PackageReference Include="NETStandard.Library" Version="$(NetStandardImplicitPackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="$(RoslynVersion)" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,6 +4,7 @@
     <CoreFxLabsPipelinesVersion>0.1.0-*</CoreFxLabsPipelinesVersion>
     <CoreFxLabsVersion>0.1.0-*</CoreFxLabsVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
+    <RoslynVersion>2.3.0-rdonly-ref-61607-04</RoslynVersion>
     <InternalAspNetCoreSdkVersion>2.0.0-*</InternalAspNetCoreSdkVersion>
     <LibUvVersion>1.10.0-*</LibUvVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>


### PR DESCRIPTION
The new version is
https://dotnet.myget.org/feed/roslyn/package/nuget/Microsoft.Net.Compilers/2.3.0-rdonly-ref-61607-04

The new version enforces the following rules:
- `Span<T>` and `ReadonlySpan<T>` are stack-only types. (no boxing, invalid use in async, etc...)
- `Span<T>` and `ReadonlySpan<T>` cannot be passed via a writeable parameter.

There were, however, no violations of the rules. (I had to introduce and then remove some violatins, just to se that detection works)

NOTE: we are not yet validating the usage of span-containing structs. There could be more indrect violations of stack safety through that.