### PR TITLE
[1.0.4] Call ProduceEnd() before consuming request body if response has already started

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ branches:
   only:
     - master
     - release
+    - /^rel\//
     - dev
     - /^(.*\/)?ci-.*$/
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - master
     - release
+    - /^rel\/.*/
     - dev
     - /^(.*\/)?ci-.*$/
 build_script:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,9 @@
 {
-    "projects": ["src"],
-    "sdk": {
-      "version": "1.0.0-preview2-003154"
-    }
+  "projects": [
+    "src",
+    "test"
+  ],
+  "sdk": {
+    "version": "1.0.0-preview2-003154"
+  }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
@@ -121,13 +121,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                         {
                             ResumeStreams();
 
+                            if (HasResponseStarted)
+                            {
+                                // If the response has already started, call ProduceEnd() before
+                                // consuming the rest of the request body to prevent
+                                // delaying clients waiting for the chunk terminator:
+                                //
+                                // https://github.com/dotnet/corefx/issues/17330#issuecomment-288248663
+                                //
+                                // ProduceEnd() must be called before _application.DisposeContext(), to ensure
+                                // HttpContext.Response.StatusCode is correctly set when
+                                // IHttpContextFactory.Dispose(HttpContext) is called.
+                                await ProduceEnd();
+                            }
+
                             if (_keepAlive)
                             {
                                 // Finish reading the request body in case the app did not.
                                 await messageBody.Consume();
                             }
 
-                            await ProduceEnd();
+                            if (!HasResponseStarted)
+                            {
+                                await ProduceEnd();
+                            }
                         }
 
                         StopStreams();

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json
@@ -4,6 +4,7 @@
     "dotnet-test-xunit": "1.0.0-rc3-000000-01",
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.2",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.3",
+    "Microsoft.AspNetCore.Server.KestrelTests": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel.Https": "1.0.3",
     "Microsoft.AspNetCore.Testing": "1.0.1",
     "Microsoft.Extensions.Logging.Console": "1.0.2",


### PR DESCRIPTION
This fix was authored by @cesarbs in #1537. I've verified #1530 repros in 1.0.3 and that this change fixed it.

Close https://github.com/aspnet/KestrelHttpServer/issues/1544