### PR TITLE
[1.1.2] Don't log stack traces for localhost bind failures

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/KestrelServer.cs
@@ -150,14 +150,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                         }
                         catch (AggregateException ex) when (ex.InnerException is UvException)
                         {
-                            if ((ex.InnerException as UvException).StatusCode == Constants.EADDRINUSE)
+                            var uvEx = (UvException)ex.InnerException;
+                            if (uvEx.StatusCode == Constants.EADDRINUSE)
                             {
                                 throw new IOException($"Failed to bind to address {parsedAddress.ToString()} on the IPv4 loopback interface: port already in use.", ex);
                             }
                             else
                             {
-                                _logger.LogWarning(0, ex, $"Unable to bind to {parsedAddress.ToString()} on the IPv4 loopback interface.");
-                                exceptions.Add(ex.InnerException);
+                                _logger.LogWarning(0, $"Unable to bind to {parsedAddress.ToString()} on the IPv4 loopback interface: ({uvEx.Message})");
+                                exceptions.Add(uvEx);
                             }
                         }
 
@@ -169,14 +170,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                         }
                         catch (AggregateException ex) when (ex.InnerException is UvException)
                         {
-                            if ((ex.InnerException as UvException).StatusCode == Constants.EADDRINUSE)
+                            var uvEx = (UvException)ex.InnerException;
+                            if (uvEx.StatusCode == Constants.EADDRINUSE)
                             {
                                 throw new IOException($"Failed to bind to address {parsedAddress.ToString()} on the IPv6 loopback interface: port already in use.", ex);
                             }
                             else
                             {
-                                _logger.LogWarning(0, ex, $"Unable to bind to {parsedAddress.ToString()} on the IPv6 loopback interface.");
-                                exceptions.Add(ex.InnerException);
+                                _logger.LogWarning(0, $"Unable to bind to {parsedAddress.ToString()} on the IPv6 loopback interface: ({uvEx.Message})");
+                                exceptions.Add(uvEx);
                             }
                         }
 


### PR DESCRIPTION
#1238, backported to 1.1.x.

Resolves #1629 