### PR TITLE
Remove Reset from IHttpParser

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
@@ -407,9 +407,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _requestHeadersParsed = 0;
 
             _responseBytesWritten = 0;
-
-            // When testing parser can be null
-            _parser.Reset();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/HttpParser.cs
@@ -491,9 +491,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 Log.IsEnabled(LogLevel.Information)
                     ? new Span<byte>(detail, length).GetAsciiStringEscaped(Constants.MaxExceptionDetailSize)
                     : string.Empty);
-
-        public void Reset()
-        {
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/IHttpParser.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/IHttpParser.cs
@@ -10,7 +10,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         bool ParseRequestLine(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined);
 
         bool ParseHeaders(TRequestHandler handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes);
-
-        void Reset();
     }
 }


### PR DESCRIPTION
- The parser isn't stateful and doesn't need it