### PR TITLE
Add option to disable dispatching writes to thread pool

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketConnection.cs
@@ -36,6 +36,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
             _localEndPoint = (IPEndPoint)_socket.LocalEndPoint;
             _remoteEndPoint = (IPEndPoint)_socket.RemoteEndPoint;
+
+            OutputReaderScheduler = _transport.TransportFactory.Options.DispatchWritesToThreadPool ?
+                                    (IScheduler)TaskRunScheduler.Default : InlineScheduler.Default;
         }
 
         public async void Start(IConnectionHandler connectionHandler)
@@ -215,8 +218,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
         public PipeFactory PipeFactory => _transport.TransportFactory.PipeFactory;
 
-        public IScheduler InputWriterScheduler => InlineScheduler.Default;
+        public IScheduler InputWriterScheduler { get; } = InlineScheduler.Default;
 
-        public IScheduler OutputReaderScheduler => TaskRunScheduler.Default;
+        public IScheduler OutputReaderScheduler { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketTransportFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketTransportFactory.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
         public SocketTransportFactory(IOptions<SocketTransportOptions> options)
         {
+            Options = options.Value;
         }
 
         public ITransport Create(IEndPointInformation endPointInformation, IConnectionHandler handler)
@@ -37,5 +38,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         }
 
         internal PipeFactory PipeFactory => _pipeFactory;
+
+        internal SocketTransportOptions Options { get; private set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketTransportOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketTransportOptions.cs
@@ -7,9 +7,14 @@ using System.Text;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
-    // TODO: Come up with some options
+    /// <summary>
+    /// Provides programmatic configuration of Socket transport features.
+    /// </summary>
     public class SocketTransportOptions
     {
-
+        /// <summary>
+        /// Gets or sets a value that determines if Kestrel should dispatch writes to the thread pool
+        /// </summary>
+        public bool DispatchWritesToThreadPool { get; set; } = true;
     }
 }


### PR DESCRIPTION
- The socket transport gets free output buffering when writes are dispatched to the thread pool.
We want to allow experimentation where callbacks all run on the same thread.