### PR TITLE
[1.1.2] Check if request is aborted before verifying response bytes written (#1376)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/FrameOfT.cs
@@ -107,7 +107,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Internal.Http
                             try
                             {
                                 await _application.ProcessRequestAsync(context).ConfigureAwait(false);
-                                VerifyResponseContentLength();
+
+                                if (Volatile.Read(ref _requestAborted) == 0)
+                                {
+                                    VerifyResponseContentLength();
+                                }
                             }
                             catch (Exception ex)
                             {

--- a/test/shared/TestConnection.cs
+++ b/test/shared/TestConnection.cs
@@ -27,6 +27,8 @@ namespace Microsoft.AspNetCore.Testing
             Create(port);
         }
 
+        public Socket Socket => _socket;
+
         public void Create(int port)
         {
             _socket = CreateConnectedLoopbackSocket(port);


### PR DESCRIPTION
#1376