### PR TITLE
Attempt to make UnrootedConnectionsGetRemovedFromHeartbeat reliable

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/FrameConnectionManager.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/FrameConnectionManager.cs
@@ -16,6 +16,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             _trace = trace;
         }
 
+        // For testing
+        internal ConcurrentDictionary<long, FrameConnectionReference> Connections => _connectionReferences;
+
         public void AddConnection(long id, FrameConnection connection)
         {
             if (!_connectionReferences.TryAdd(id, new FrameConnectionReference(connection)))


### PR DESCRIPTION
- Attempt to make this test more reliable by using TryStartNoGCRegion and `MethodImplOptions.NoOptimization`