### PR TITLE
Skip potentially flaky tests in address registration tests

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -226,7 +226,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 // Dynamic port and non-loopback addresses
                 dataset.Add("http://127.0.0.1:0/;https://127.0.0.1:0/", GetTestUrls);
-                dataset.Add($"http://{Dns.GetHostName()}:0/;https://{Dns.GetHostName()}:0/", GetTestUrls);
 
                 var ipv4Addresses = GetIPAddresses()
                     .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork);


### PR DESCRIPTION
Skip a potentially flaky test in the patch build. The test is still in dev branch. If it continues to be a problem in dev, then we'll look for a better solution.

Close https://github.com/aspnet/KestrelHttpServer/issues/1729