### PR TITLE
Tweak libuv shutdown sequence

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvThread.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -103,15 +102,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             {
                 var stepTimeout = TimeSpan.FromTicks(timeout.Ticks / 3);
 
-                Post(t => t.AllowStop());
+                await PostAsync(t => t.AllowStop(), this).ConfigureAwait(false);
                 if (!await WaitAsync(_threadTcs.Task, stepTimeout).ConfigureAwait(false))
                 {
                     try
                     {
-                        Post(t => t.OnStopRude());
+                        await PostAsync(t => t.OnStopRude(), this).ConfigureAwait(false);
                         if (!await WaitAsync(_threadTcs.Task, stepTimeout).ConfigureAwait(false))
                         {
-                            Post(t => t.OnStopImmediate());
+                            await PostAsync(t => t.OnStopImmediate(), this).ConfigureAwait(false);
                             if (!await WaitAsync(_threadTcs.Task, stepTimeout).ConfigureAwait(false))
                             {
                                 _log.LogCritical($"{nameof(LibuvThread)}.{nameof(StopAsync)} failed to terminate libuv thread.");

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvThread.cs
@@ -102,15 +102,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             {
                 var stepTimeout = TimeSpan.FromTicks(timeout.Ticks / 3);
 
-                await PostAsync(t => t.AllowStop(), this).ConfigureAwait(false);
+                Post(t => t.AllowStop());
                 if (!await WaitAsync(_threadTcs.Task, stepTimeout).ConfigureAwait(false))
                 {
                     try
                     {
-                        await PostAsync(t => t.OnStopRude(), this).ConfigureAwait(false);
+                        Post(t => t.OnStopRude());
                         if (!await WaitAsync(_threadTcs.Task, stepTimeout).ConfigureAwait(false))
                         {
-                            await PostAsync(t => t.OnStopImmediate(), this).ConfigureAwait(false);
+                            Post(t => t.OnStopImmediate());
                             if (!await WaitAsync(_threadTcs.Task, stepTimeout).ConfigureAwait(false))
                             {
                                 _log.LogCritical($"{nameof(LibuvThread)}.{nameof(StopAsync)} failed to terminate libuv thread.");
@@ -164,9 +164,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                     handle?.Dispose();
                 }
             });
-
-            // uv_unref is idempotent so it's OK to call this here and in AllowStop.
-            _post.Unreference();
         }
 
         private void OnStopImmediate()

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/LibuvTransport.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/LibuvTransport.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv
         {
             try
             {
-                await Task.WhenAll(Threads.Select(thread => thread.StopAsync(TimeSpan.FromSeconds(2.5))).ToArray())
+                await Task.WhenAll(Threads.Select(thread => thread.StopAsync(TimeSpan.FromSeconds(5))).ToArray())
                     .ConfigureAwait(false);
             }
             catch (AggregateException aggEx)
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv
         {
             var disposeTasks = _listeners.Select(listener => listener.DisposeAsync()).ToArray();
 
-            if (!await WaitAsync(Task.WhenAll(disposeTasks), TimeSpan.FromSeconds(2.5)).ConfigureAwait(false))
+            if (!await WaitAsync(Task.WhenAll(disposeTasks), TimeSpan.FromSeconds(5)).ConfigureAwait(false))
             {
                 Log.LogError(0, null, "Disposing listeners failed");
             }


### PR DESCRIPTION
- Increase timeouts for thread and listener shutdowns
- Use PostAsync to observe ObjectDisposedExceptions in the shutdown sequence