### PR TITLE
Schedule connection adapter reads on configured thread pool

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         // Internal for testing
         internal PipeOptions AdaptedInputPipeOptions => new PipeOptions
         {
-            ReaderScheduler = InlineScheduler.Default,
+            ReaderScheduler = _context.ServiceContext.ThreadPool,
             WriterScheduler = InlineScheduler.Default,
             MaximumSizeHigh = _context.ServiceContext.ServerOptions.Limits.MaxRequestBufferSize ?? 0,
             MaximumSizeLow = _context.ServiceContext.ServerOptions.Limits.MaxRequestBufferSize ?? 0

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/PipeOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/PipeOptionsTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             Assert.Equal(expectedMaximumSizeLow, connectionLifetime.AdaptedInputPipeOptions.MaximumSizeLow);
             Assert.Equal(expectedMaximumSizeHigh, connectionLifetime.AdaptedInputPipeOptions.MaximumSizeHigh);
-            Assert.Same(InlineScheduler.Default, connectionLifetime.AdaptedInputPipeOptions.ReaderScheduler);
+            Assert.Same(serviceContext.ThreadPool, connectionLifetime.AdaptedInputPipeOptions.ReaderScheduler);
             Assert.Same(InlineScheduler.Default, connectionLifetime.AdaptedInputPipeOptions.WriterScheduler);
         }
 


### PR DESCRIPTION
- This should speed up connection adapters as we don't block
new reads. It *might* also help some of the test flakiness. This is more
similar to what we did before with `SocketInput` (https://github.com/aspnet/KestrelHttpServer/blob/rel/1.1.1/src/Microsoft.AspNetCore.Server.Kestrel/Filter/Internal/FilteredStreamAdapter.cs#L58) (Socket Input always used the thread pool)