### PR TITLE
Switching to the new toolset compiler.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,5 +4,6 @@
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
     <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/common.props
+++ b/build/common.props
@@ -20,4 +20,7 @@
     <PackageReference Include="NETStandard.Library" Version="$(BundledNETStandardPackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(RoslynVersion)" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,6 +5,7 @@
     <CoreFxLabsVersion>0.1.0-*</CoreFxLabsVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
+    <RoslynVersion>2.3.0-rdonly-ref-61625-05</RoslynVersion>
     <LibUvVersion>1.10.0-*</LibUvVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.1</MoqVersion>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker.sh
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# adding dotnet to the path. it is needed to run toolset csc.
+export PATH=$HOME/.dotnet:$PATH
+
 set -e
 
 scriptDir=$(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
The new version is
https://dotnet.myget.org/feed/roslyn/package/nuget/Microsoft.Net.Compilers/2.3.0-rdonly-ref-61625-05

The new version enforces the following rules:
- `Span<T>` and `ReadonlySpan<T>` are stack-only types. (no boxing, invalid use in async, etc...)
- `Span<T>` and `ReadonlySpan<T>` cannot be passed via a writeable parameter.

There were, however, no violations of the rules. (I had to introduce and then remove some violatins, just to see that detection works)

NOTE: we are not yet validating the usage of span-containing structs. There could be more indrect violations of stack safety through that.