### PR TITLE
Fix flaky 400 response tests

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/UpgradeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/UpgradeTests.cs
@@ -123,7 +123,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     "",
                     "1");
 
-                await connection.Receive("HTTP/1.1 400 Bad Request");
+                await connection.ReceiveForcedEnd(
+                    "HTTP/1.1 400 Bad Request",
+                    "Connection: close",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "Content-Length: 0",
+                    "",
+                    "");
             }
         }
 
@@ -167,7 +173,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     "Connection: Upgrade",
                     "",
                     "");
-                await connection.Receive("HTTP/1.1 400 Bad Request");
+                await connection.ReceiveForcedEnd(
+                    "HTTP/1.1 400 Bad Request",
+                    "Connection: close",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "Content-Length: 0",
+                    "",
+                    "");
             }
         }
     }


### PR DESCRIPTION
#1753 

From [ReceiveForcedEnd](https://github.com/aspnet/KestrelHttpServer/blob/f26c31c1169adbcc8a7185a7527a4b9c86659ca1/test/shared/TestConnection.cs#L123-L125):

                // The server is forcefully closing the connection so an IOException:
                // "Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host."
                // isn't guaranteed but not unexpected.