### PR TITLE
Added ApplicationSchedulingMode to KestrelServerOptions

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace SampleApp
@@ -45,7 +45,7 @@ namespace SampleApp
                 .UseKestrel(options =>
                 {
                     // Run callbacks on the transport thread
-                    options.UseTransportThread = true;
+                    options.ApplicationSchedulingMode = SchedulingMode.Inline;
 
                     options.Listen(IPAddress.Loopback, 5000, listenOptions =>
                     {

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerOptions.cs
@@ -37,8 +37,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// <summary>
         /// Gets or sets a value that determines how Kestrel should schedule user callbacks.
         /// </summary>
-        /// <remarks>The default mode is <see cref="SchedulingMode.ThreadPool"/></remarks>
-        public SchedulingMode ApplicationSchedulingMode { get; set; } = SchedulingMode.ThreadPool;
+        /// <remarks>The default mode is <see cref="SchedulingMode.Default"/></remarks>
+        public SchedulingMode ApplicationSchedulingMode { get; set; } = SchedulingMode.Default;
 
         /// <summary>
         /// Enables the Listen options callback to resolve and use services registered by the application during startup.

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core
 {
@@ -32,6 +33,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// Gets or sets a value that determines if Kestrel should use the transport thread thread when executing user code.
         /// </summary>
         public bool UseTransportThread { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that determines how Kestrel should schedule user callbacks.
+        /// </summary>
+        /// <remarks>The default mode is <see cref="SchedulingMode.ThreadPool"/></remarks>
+        public SchedulingMode ApplicationSchedulingMode { get; set; } = SchedulingMode.ThreadPool;
 
         /// <summary>
         /// Enables the Listen options callback to resolve and use services registered by the application during startup.

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/SchedulingMode.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/SchedulingMode.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions
 {
     public enum SchedulingMode
     {

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/SchedulingMode.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/SchedulingMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions
+{
+    public enum SchedulingMode
+    {
+        Default,
+        ThreadPool,
+        Inline
+    }
+}


### PR DESCRIPTION
Will remove `UseTransportThread` in another PR after I update http://github.com/aspnet/benchmarks.

Fixes #1750 