### PR TITLE
Add wait in ListenerPrimaryTests to avoid race condition with List.Add

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerPrimary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerPrimary.cs
@@ -33,6 +33,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
         {
         }
 
+        /// <summary>
+        /// For testing purposes.
+        /// </summary>
+        public int UvPipeCount => _dispatchPipes.Count;
+
         private UvPipeHandle ListenPipe { get; set; }
 
         public async Task StartAsync(


### PR DESCRIPTION
I couldn't actually reproduce the race condition in ListenerPrimaryTests even in a tight loop of 100,000 iterations. However, from discussion with @pakrym, we think this should fix the issue in the test.

Resolves #1681. We can re-open and try something else if the test still fails.