### PR TITLE
Close the input if the output ends but not vice versa

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketConnection.cs
@@ -109,7 +109,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                     if (result.IsCompleted)
                     {
                         // Pipe consumer is shut down, do we stop writing
-                        _socket.Shutdown(SocketShutdown.Receive);
                         break;
                     }
                 }
@@ -134,7 +133,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                     }
                 }
 
-                if (ex is IOException ioe)
+                if (ex is ObjectDisposedException)
+                {
+                    error = new TaskCanceledException("The request was aborted");
+                }
+                else if (ex is IOException ioe)
                 {
                     error = ioe;
                 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketConnection.cs
@@ -56,8 +56,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 // will trigger the output closing once the input is complete.
                 if (await Task.WhenAny(receiveTask, sendTask) == sendTask)
                 {
-                    // Shutdown the receive task
-                    _socket.Shutdown(SocketShutdown.Receive);
+                    // Shutdown the both sides
+                    _socket.Shutdown(SocketShutdown.Both);
                 }
 
                 // Now wait for both to complete

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networking;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
@@ -462,9 +463,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     {
                         await context.Request.Body.ReadAsync(new byte[1], 0, 1);
                     }
-                    catch (IOException ex)
+                    catch (ConnectionResetException)
                     {
-                        expectedExceptionThrown = ex.InnerException is UvException && ex.InnerException.Message.Contains("ECONNRESET");
+                        expectedExceptionThrown = true;
                     }
 
                     appDone.Release();


### PR DESCRIPTION
- This gives kestrel control over when the output closes

Fixes #1774

EDIT: I'll merge when all of the tests pass locally on my dev box. Right now I'm seeing a couple of failures:

```
ConnectionResetMidRequestIsLoggedAsDebug
ConnectionResetBetweenRequestsIsLoggedAsDebug
ConnectionResetPriorToRequestIsLoggedAsDebug
```

These all work via the specific logger name (the libuv logger) so they don't work right no with the socket transport. It shouldn't block this commit though. I'll add these to the issue here #1686