### PR TITLE
Implement new request trace identifier format

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.cs
@@ -73,6 +73,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private string _requestId;
         private int _remainingRequestHeadersBytesAllowed;
         private int _requestHeadersParsed;
+        private uint _requestCount;
 
         protected readonly long _keepAliveTicks;
         private readonly long _requestHeadersTimeoutTicks;
@@ -128,7 +129,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 // don't generate an ID until it is requested
                 if (_requestId == null)
                 {
-                    _requestId = CorrelationIdGenerator.GetNextId();
+                    _requestId = StringUtilities.ConcatAsHexSuffix(ConnectionId, ':', _requestCount);
                 }
                 return _requestId;
             }
@@ -388,6 +389,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _requestHeadersParsed = 0;
 
             _responseBytesWritten = 0;
+            _requestCount++;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameRequestHeaders.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameRequestHeaders.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             string key = new string('\0', keyLength);
             fixed (char* keyBuffer = key)
             {
-                if (!AsciiUtilities.TryGetAsciiString(pKeyBytes, keyBuffer, keyLength))
+                if (!StringUtilities.TryGetAsciiString(pKeyBytes, keyBuffer, keyLength))
                 {
                     throw BadHttpRequestException.GetException(RequestRejectionReason.InvalidCharactersInHeaderName);
                 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             {
                 // This version if AsciiUtilities returns null if there are any null (0 byte) characters
                 // in the string
-                if (!AsciiUtilities.TryGetAsciiString(buffer, output, span.Length))
+                if (!StringUtilities.TryGetAsciiString(buffer, output, span.Length))
                 {
                     throw new InvalidOperationException();
                 }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/StringUtilitiesTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/StringUtilitiesTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
+{
+    public class StringUtilitiesTests
+    {
+        [Theory]
+        [InlineData(uint.MinValue)]
+        [InlineData(0xF)]
+        [InlineData(0xA)]
+        [InlineData(0xFF)]
+        [InlineData(0xFFC59)]
+        [InlineData(uint.MaxValue)]
+        public void ConvertsToHex(uint value)
+        {
+            var str = CorrelationIdGenerator.GetNextId();
+            Assert.Equal($"{str}:{value:X8}", StringUtilities.ConcatAsHexSuffix(str, ':', value));
+        }
+
+        [Fact]
+        public void HandlesNull()
+        {
+            uint value = 0x23BC0234;
+            Assert.Equal(":23BC0234", StringUtilities.ConcatAsHexSuffix(null, ':', value));
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -611,13 +611,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task TraceIdentifierIsUnique()
         {
-            const int IdentifierLength = 13;
+            const int identifierLength = 22;
             const int iterations = 10;
 
             using (var server = new TestServer(async context =>
             {
-                Assert.Equal(IdentifierLength, Encoding.ASCII.GetByteCount(context.TraceIdentifier));
-                context.Response.ContentLength = IdentifierLength;
+                Assert.Equal(identifierLength, Encoding.ASCII.GetByteCount(context.TraceIdentifier));
+                context.Response.ContentLength = identifierLength;
                 await context.Response.WriteAsync(context.TraceIdentifier);
             }))
             {
@@ -635,7 +635,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 // requests on same connection
                 using (var connection = server.CreateConnection())
                 {
-                    var buffer = new char[IdentifierLength];
+                    var buffer = new char[identifierLength];
                     for (var i = 0; i < iterations; i++)
                     {
                         await connection.Send("GET / HTTP/1.1",
@@ -645,12 +645,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                         await connection.Receive($"HTTP/1.1 200 OK",
                            $"Date: {server.Context.DateHeaderValue}",
-                           $"Content-Length: {IdentifierLength}",
+                           $"Content-Length: {identifierLength}",
                            "",
                            "").TimeoutAfter(TimeSpan.FromSeconds(10));
 
-                        var read = await connection.Reader.ReadAsync(buffer, 0, IdentifierLength);
-                        Assert.Equal(IdentifierLength, read);
+                        var read = await connection.Reader.ReadAsync(buffer, 0, identifierLength);
+                        Assert.Equal(identifierLength, read);
                         var id = new string(buffer, 0, read);
                         Assert.DoesNotContain(id, usedIds.ToArray());
                         usedIds.Add(id);

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/StringUtilitiesBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/StringUtilitiesBenchmark.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    [Config(typeof(CoreConfig))]
+    public class StringUtilitiesBenchmark
+    {
+        private const int Iterations = 500_000;
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Iterations)]
+        public void UintToString()
+        {
+            var connectionId = CorrelationIdGenerator.GetNextId();
+            for (uint i = 0; i < Iterations; i++)
+            {
+                var id = connectionId + ':' + i.ToString("X8");
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void ConcatAsHexSuffix()
+        {
+            var connectionId = CorrelationIdGenerator.GetNextId();
+            for (uint i = 0; i < Iterations; i++)
+            {
+                var id = StringUtilities.ConcatAsHexSuffix(connectionId, ':', i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #1591.

The format:
The trace identifier begins with connection ID and ends with a number that increments with each request per connection.

Example:
Connection ID = xyz
Request 1 = "xyz:00000001"
Request 2 = "xyz:00000002"
...
Request 15 = "xyz:0000000F"
Request 16 = "xyz:00000010"

**Benchmark**

I implemented the unsafe 'ConcatAsHexSuffix' method because it allocates one fewer string and is almost 3x faster in a tight loop of 0.5 million iterations.

```
            Method |       Mean |    StdDev |  Op/s | Scaled | Scaled-StdDev | Allocated |
------------------ |----------- |---------- |------ |------- |-------------- |---------- |
      UintToString | 50.0737 ms | 1.4121 ms | 19.97 |   1.00 |          0.00 |     60 MB |
 ConcatAsHexSuffix | 18.3235 ms | 0.9086 ms | 54.57 |   0.37 |          0.02 |     36 MB |
```