### PR TITLE
Fix flaky tests that bind to discovered IP addresses

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -559,7 +558,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 // Non-loopback addresses
                 var ipv4Addresses = GetIPAddresses()
-                    .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork);
+                    .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork)
+                    .Where(ip => CanBindAndConnectToEndpoint(new IPEndPoint(ip, 0)));
+
                 foreach (var ip in ipv4Addresses)
                 {
                     dataset.Add($"http://{ip}:0/", $"http://{ip}");
@@ -602,7 +603,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 // Non-loopback addresses
                 var ipv4Addresses = GetIPAddresses()
-                    .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork);
+                    .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork)
+                    .Where(ip => CanBindAndConnectToEndpoint(new IPEndPoint(ip, 0)));
+
                 foreach (var ip in ipv4Addresses)
                 {
                     dataset.Add(new IPEndPoint(ip, 0), $"http://{ip}");
@@ -611,7 +614,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 var ipv6Addresses = GetIPAddresses()
                     .Where(ip => ip.AddressFamily == AddressFamily.InterNetworkV6)
-                    .Where(ip => ip.ScopeId == 0);
+                    .Where(ip => ip.ScopeId == 0)
+                    .Where(ip => CanBindAndConnectToEndpoint(new IPEndPoint(ip, 0)));
+
                 foreach (var ip in ipv6Addresses)
                 {
                     dataset.Add(new IPEndPoint(ip, 0), $"http://[{ip}]");
@@ -656,7 +661,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 // Non-loopback addresses
                 var ipv6Addresses = GetIPAddresses()
                     .Where(ip => ip.AddressFamily == AddressFamily.InterNetworkV6)
-                    .Where(ip => ip.ScopeId == 0);
+                    .Where(ip => ip.ScopeId == 0)
+                    .Where(ip => CanBindAndConnectToEndpoint(new IPEndPoint(ip, 0)));
+
                 foreach (var ip in ipv6Addresses)
                 {
                     dataset.Add($"http://[{ip}]:0/", new[] { $"http://[{ip}]" });
@@ -692,6 +699,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     .Where(ip => ip.AddressFamily == AddressFamily.InterNetworkV6)
                     .Where(ip => ip.ScopeId != 0)
                     .Where(ip => CanBindAndConnectToEndpoint(new IPEndPoint(ip, 0)));
+
                 foreach (var ip in ipv6Addresses)
                 {
                     dataset.Add($"http://[{ip}]:0/", $"http://[{ip}]");


### PR DESCRIPTION
#1793 

I think the EADDRNOTAVAIL errors happen with "transient" IPAddresses. It's hard to prove though since, IPAddressInformation.IsTransient throws a PlatformNotSupportedException on macOS.

```
Unhandled Exception: System.PlatformNotSupportedException: The information requested in unavailable on the current platform.
   at System.Net.NetworkInformation.UnixUnicastIPAddressInformation.get_IsTransient()
   at ConsoleApp1.Program.<>c.<GetIPAddresses>b__3_3(UnicastIPAddressInformation a)
   at System.Linq.Utilities.<>c__DisplayClass2_0`3.<CombineSelectors>b__0(TSource x)
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at System.Linq.Enumerable.ConcatIterator`1.MoveNext()
   at ConsoleApp1.Program.Main(String[] args)
```