### PR TITLE
Fix EBUSY errors on uv_loop_close 

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvThread.cs
@@ -264,6 +264,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 _post.Reference();
                 _post.Dispose();
 
+                // We need this walk because we call ReadStop on 2 places:
+                // 1. On the dispatch pipe UvPipeHandle after reading the correct message
+                // 2. On on accepted connections when there's back pressure
+                // Calling ReadStop makes the handle as in-active which means the loop can
+                // end while there's still valid handles around. This makes loop.Dispose throw
+                // with an EBUSY. To avoid that, we walk all of the handles and dispose them.
+                Walk(ptr =>
+                {
+                    var handle = UvMemory.FromIntPtr<UvHandle>(ptr);
+                    // handle can be null because UvMemory.FromIntPtr looks up a weak reference
+                    handle?.Dispose();
+                });
+
                 // Ensure the Dispose operations complete in the event loop.
                 _loop.Run();
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvThread.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvThread.cs
@@ -264,9 +264,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 _post.Reference();
                 _post.Dispose();
 
-                // We need this walk because we call ReadStop on 2 places:
-                // 1. On the dispatch pipe UvPipeHandle after reading the correct message
-                // 2. On on accepted connections when there's back pressure
+                // We need this walk because we call ReadStop on on accepted connections when there's back pressure
                 // Calling ReadStop makes the handle as in-active which means the loop can
                 // end while there's still valid handles around. This makes loop.Dispose throw
                 // with an EBUSY. To avoid that, we walk all of the handles and dispose them.

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerPrimary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerPrimary.cs
@@ -245,6 +245,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                         {
                             _listener._dispatchPipes.Add((UvPipeHandle)dispatchPipe);
                             dispatchPipe.ReadStop();
+                            // Calling uv_read_stop removes this from the list of active handles which makes it possible
+                            // to end the loop pre-maturely. Call uv_ref on the handle to make sure that doesn't happen.
+                            dispatchPipe.Reference();
                             _bufHandle.Free();
                         }
                         else

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerPrimary.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerPrimary.cs
@@ -245,9 +245,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                         {
                             _listener._dispatchPipes.Add((UvPipeHandle)dispatchPipe);
                             dispatchPipe.ReadStop();
-                            // Calling uv_read_stop removes this from the list of active handles which makes it possible
-                            // to end the loop pre-maturely. Call uv_ref on the handle to make sure that doesn't happen.
-                            dispatchPipe.Reference();
                             _bufHandle.Free();
                         }
                         else


### PR DESCRIPTION
We need this walk because we call ReadStop on 2 places:
 1. On the dispatch pipe UvPipeHandle after reading the correct message
 2. On on accepted connections when there's back pressure

Calling ReadStop makes the handle as in-active which means the loop can
end while there's still valid handles around. This makes loop.Dispose throw
with an EBUSY. To avoid that, we walk all of the handles and dispose them.

#1761