### PR TITLE
Added a ConnectionAbortedException to Transport.Abstractions

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameRequestStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameRequestStream.cs
@@ -121,11 +121,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 return await _body.ReadAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
             }
-            catch (ConnectionAbortedException)
+            catch (ConnectionAbortedException ex)
             {
-                ExceptionDispatchInfo.Capture(new TaskCanceledException("The request was aborted")).Throw();
-                // We should never get here
-                return 0;
+                throw new TaskCanceledException("The request was aborted", ex);
             }
         }
 
@@ -155,10 +153,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 await _body.CopyToAsync(destination, cancellationToken);
             }
-            catch (ConnectionAbortedException)
+            catch (ConnectionAbortedException ex)
             {
-                ExceptionDispatchInfo.Capture(new TaskCanceledException("The request was aborted")).Throw();
-                // We should never get here
+                throw new TaskCanceledException("The request was aborted", ex);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/FrameConnectionManagerShutdownExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/FrameConnectionManagerShutdownExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
@@ -25,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public static async Task<bool> AbortAllConnectionsAsync(this FrameConnectionManager connectionManager)
         {
             var abortTasks = new List<Task>();
-            var canceledException = new TaskCanceledException(CoreStrings.RequestProcessingAborted);
+            var canceledException = new ConnectionAbortedException();
 
             connectionManager.Walk(connection =>
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Exceptions/ConnectionAbortedException.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Exceptions/ConnectionAbortedException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions
+{
+    public class ConnectionAbortedException : OperationCanceledException
+    {
+        public ConnectionAbortedException() :
+            this("The connection was aborted")
+        {
+
+        }
+
+        public ConnectionAbortedException(string message) : base(message)
+        {
+        }
+
+        public ConnectionAbortedException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                     Input.CancelPendingFlush();
 
                     // Now, complete the input so that no more reads can happen
-                    Input.Complete(new TaskCanceledException("The request was aborted"));
+                    Input.Complete(new ConnectionAbortedException());
 
                     // We're done with the socket now
                     _socket.Dispose();

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/SocketConnection.cs
@@ -115,11 +115,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             }
             catch (SocketException ex) when (ex.SocketErrorCode == SocketError.OperationAborted)
             {
-                error = new TaskCanceledException("The request was aborted");
+                error = new ConnectionAbortedException();
             }
             catch (ObjectDisposedException)
             {
-                error = new TaskCanceledException("The request was aborted");
+                error = new ConnectionAbortedException();
             }
             catch (IOException ex)
             {


### PR DESCRIPTION
- To avoid hard coding TaskCanceledException in each transport
- This PR tries to keep compatibility by converting the ConnectionAbortedException
to a TaskCanceledException on exceptions in FrameRequestStream. The downside is that
this conversion causes an async state machine to be created per call to ReadAsync.
CopyToAsync isn't that bad because it's a single long running task.