### PR TITLE
More FrameConnection refactoring

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/AdaptedPipeline.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/AdaptedPipeline.cs
@@ -71,11 +71,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
 
                         if (buffer.IsEmpty)
                         {
-                            if (result.IsCompleted)
-                            {
-                                break;
-                            }
-
                             await stream.FlushAsync();
                         }
                         else if (buffer.IsSingleSpan)
@@ -90,6 +85,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
                                 var array = memory.GetArray();
                                 await stream.WriteAsync(array.Array, array.Offset, array.Count);
                             }
+                        }
+
+                        if (result.IsCompleted)
+                        {
+                            break;
                         }
                     }
                     finally

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/AdaptedPipeline.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/AdaptedPipeline.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
-using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
 {
@@ -16,17 +15,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
         private const int MinAllocBufferSize = 2048;
 
         private readonly IKestrelTrace _trace;
-        private readonly IPipeWriter _transportOutputPipeWriter;
+        private readonly IPipe _transportOutputPipe;
         private readonly IPipeReader _transportInputPipeReader;
 
         public AdaptedPipeline(IPipeReader transportInputPipeReader,
-                               IPipeWriter transportOutputPipeWriter,
+                               IPipe transportOutputPipe,
                                IPipe inputPipe,
                                IPipe outputPipe,
                                IKestrelTrace trace)
         {
             _transportInputPipeReader = transportInputPipeReader;
-            _transportOutputPipeWriter = transportOutputPipeWriter;
+            _transportOutputPipe = transportOutputPipe;
             Input = inputPipe;
             Output = outputPipe;
             _trace = trace;
@@ -58,18 +57,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
 
                 while (true)
                 {
-                    var readResult = await Output.Reader.ReadAsync();
-                    var buffer = readResult.Buffer;
+                    var result = await Output.Reader.ReadAsync();
+                    var buffer = result.Buffer;
 
                     try
                     {
-                        if (buffer.IsEmpty && readResult.IsCompleted)
+                        if (result.IsCancelled)
                         {
+                            // Forward the cancellation to the transport pipe
+                            _transportOutputPipe.Reader.CancelPendingRead();
                             break;
                         }
 
                         if (buffer.IsEmpty)
                         {
+                            if (result.IsCompleted)
+                            {
+                                break;
+                            }
+
                             await stream.FlushAsync();
                         }
                         else if (buffer.IsSingleSpan)
@@ -99,7 +105,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
             finally
             {
                 Output.Reader.Complete();
-                _transportOutputPipeWriter.Complete(error);
+                _transportOutputPipe.Writer.Complete(error);
             }
         }
 
@@ -111,8 +117,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
             {
                 if (stream == null)
                 {
-                    // If the stream is null then we're going to abort the connection
-                    throw new ConnectionAbortedException();
+                    // REVIEW: Do we need an exception here?
+                    return;
                 }
 
                 while (true)

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/AdaptedPipeline.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/AdaptedPipeline.cs
@@ -71,6 +71,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
 
                         if (buffer.IsEmpty)
                         {
+                            if (result.IsCompleted)
+                            {
+                                break;
+                            }
                             await stream.FlushAsync();
                         }
                         else if (buffer.IsSingleSpan)
@@ -85,11 +89,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
                                 var array = memory.GetArray();
                                 await stream.WriteAsync(array.Array, array.Offset, array.Count);
                             }
-                        }
-
-                        if (result.IsCompleted)
-                        {
-                            break;
                         }
                     }
                     finally

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ConnectionHandler.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ConnectionHandler.cs
@@ -47,15 +47,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 ConnectionId = connectionId,
                 FrameConnectionId = frameConnectionId,
                 ServiceContext = _serviceContext,
-                PipeFactory = connectionInfo.PipeFactory,
+                ConnectionInformation = connectionInfo,
                 ConnectionAdapters = _listenOptions.ConnectionAdapters,
                 Frame = frame,
                 Input = inputPipe,
                 Output = outputPipe,
             });
-
-            _serviceContext.Log.ConnectionStart(connectionId);
-            KestrelEventSource.Log.ConnectionStart(connection, connectionInfo);
 
             // Since data cannot be added to the inputPipe by the transport until OnConnection returns,
             // Frame.ProcessRequestsAsync is guaranteed to unblock the transport thread before calling

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnectionContext.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
@@ -13,8 +14,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         public string ConnectionId { get; set; }
         public long FrameConnectionId { get; set; }
         public ServiceContext ServiceContext { get; set; }
-        public PipeFactory PipeFactory { get; set; }
         public List<IConnectionAdapter> ConnectionAdapters { get; set; }
+        public IConnectionInformation ConnectionInformation { get; set; }
         public Frame Frame { get; set; }
 
         public IPipe Input { get; set; }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 TimeoutControl = Mock.Of<ITimeoutControl>()
             };
 
-            _frame.Output = new OutputProducer(output.Writer, "", Mock.Of<IKestrelTrace>());
+            _frame.Output = new OutputProducer(output, "", Mock.Of<IKestrelTrace>());
 
             _frame.Reset();
         }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/OutputProducerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/OutputProducerTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var pipe = _pipeFactory.Create(pipeOptions);
             var serviceContext = new TestServiceContext();
             var frame = new Frame<object>(null, new FrameContext { ServiceContext = serviceContext });
-            var socketOutput = new OutputProducer(pipe.Writer, "0", serviceContext.Log);
+            var socketOutput = new OutputProducer(pipe, "0", serviceContext.Log);
 
             return socketOutput;
         }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                 Input = input.Reader,
             };
 
-            frame.Output = new OutputProducer(output.Writer, "", null);
+            frame.Output = new OutputProducer(output, "", null);
 
             frame.Reset();
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             {
                 Input = input.Reader,
             };
-            frame.Output = new OutputProducer(output.Writer, "", null);
+            frame.Output = new OutputProducer(output, "", null);
 
             frame.Reset();
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
@@ -393,6 +393,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
 
                     Assert.True(abortedSource.IsCancellationRequested);
 
+                    await _mockLibuv.OnPostTask;
+
                     // Complete the 4th write
                     while (completeQueue.TryDequeue(out var triggerNextCompleted))
                     {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
@@ -392,6 +392,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                     Assert.True(task3Canceled.IsCanceled);
 
                     Assert.True(abortedSource.IsCancellationRequested);
+
+                    // Complete the 4th write
+                    while (completeQueue.TryDequeue(out var triggerNextCompleted))
+                    {
+                        await _libuvThread.PostAsync(cb => cb(0), triggerNextCompleted);
+                    }
                 }
             });
         }
@@ -467,6 +473,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                     Assert.True(task3Canceled.IsCanceled);
 
                     Assert.True(abortedSource.IsCancellationRequested);
+
+                    await _mockLibuv.OnPostTask;
+
+                    // Complete the 4th write
+                    while (completeQueue.TryDequeue(out var triggerNextCompleted))
+                    {
+                        await _libuvThread.PostAsync(cb => cb(0), triggerNextCompleted);
+                    }
                 }
             });
         }
@@ -544,6 +558,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                     // Third task is now canceled
                     await Assert.ThrowsAsync<OperationCanceledException>(() => task3Canceled);
                     Assert.True(task3Canceled.IsCanceled);
+
+                    await _mockLibuv.OnPostTask;
+
+                    // Complete the 4th write
+                    while (completeQueue.TryDequeue(out var triggerNextCompleted))
+                    {
+                        await _libuvThread.PostAsync(cb => cb(0), triggerNextCompleted);
+                    }
                 }
             });
         }
@@ -585,6 +607,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                 // Act
                 var writeTask2 = socketOutput.WriteAsync(buffer);
                 var writeTask3 = socketOutput.WriteAsync(buffer);
+
+                await _mockLibuv.OnPostTask;
 
                 // Drain the write queue
                 while (completeQueue.TryDequeue(out var triggerNextCompleted))
@@ -670,7 +694,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             var frame = new Frame<object>(null, new FrameContext { ServiceContext = serviceContext });
 
             var socket = new MockSocket(_mockLibuv, _libuvThread.Loop.ThreadId, transportContext.Log);
-            var outputProducer = new OutputProducer(pipe.Writer, "0", serviceContext.Log);
+            var outputProducer = new OutputProducer(pipe, "0", serviceContext.Log);
             var consumer = new LibuvOutputConsumer(pipe.Reader, _libuvThread, socket, "0", transportContext.Log);
             frame.Output = outputProducer;
 


### PR DESCRIPTION
- This change reverts the change to complete the writer with an
exception on abort because of the number of first chance exceptions
that get thrown.
- This change also moves connection logging into FrameConnection instead
of being split between the ConnectionHandler and FrameConnection.
- Fixed issues with LibuvOutputConsumerTests that leak WriteReq since
cancelled writes no longer end the connection.