### PR TITLE
Invert the dependency between connection adapters and Frame

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/ConnectionAdapterContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/ConnectionAdapterContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
 {
@@ -9,10 +10,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
     // we want to add more connection metadata later.
     public class ConnectionAdapterContext
     {
-        internal ConnectionAdapterContext(Stream connectionStream)
+        internal ConnectionAdapterContext(IFeatureCollection features, Stream connectionStream)
         {
+            Features = features;
             ConnectionStream = connectionStream;
         }
+
+        public IFeatureCollection Features { get; }
 
         public Stream ConnectionStream { get; }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/IAdaptedConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/IAdaptedConnection.cs
@@ -3,14 +3,11 @@
 
 using System;
 using System.IO;
-using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
 {
     public interface IAdaptedConnection : IDisposable
     {
         Stream ConnectionStream { get; }
-
-        void PrepareRequest(IFeatureCollection requestFeatures);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/LoggingConnectionAdapter.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Adapter/Internal/LoggingConnectionAdapter.cs
@@ -40,10 +40,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
 
             public Stream ConnectionStream { get; }
 
-            public void PrepareRequest(IFeatureCollection requestFeatures)
-            {
-            }
-
             public void Dispose()
             {
             }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ConnectionAdapterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ConnectionAdapterTests.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal;
 using Microsoft.AspNetCore.Testing;
@@ -217,10 +216,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
 
             public Stream ConnectionStream { get; }
-
-            public void PrepareRequest(IFeatureCollection requestFeatures)
-            {
-            }
 
             public void Dispose()
             {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpsConnectionAdapterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpsConnectionAdapterTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 {
                     var tlsFeature = context.Features.Get<ITlsConnectionFeature>();
                     Assert.NotNull(tlsFeature);
-                    Assert.Equal(tlsFeature.ClientCertificate, null);
+                    Assert.Null(tlsFeature.ClientCertificate);
                     return context.Response.WriteAsync("hello world");
                 },
                 serviceContext, listenOptions))

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpsConnectionAdapterTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/HttpsConnectionAdapterTests.cs
@@ -94,7 +94,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             using (var server = new TestServer(context =>
                 {
-                    Assert.Equal(context.Features.Get<ITlsConnectionFeature>(), null);
+                    var tlsFeature = context.Features.Get<ITlsConnectionFeature>();
+                    Assert.NotNull(tlsFeature);
+                    Assert.Equal(tlsFeature.ClientCertificate, null);
                     return context.Response.WriteAsync("hello world");
                 },
                 serviceContext, listenOptions))

--- a/test/shared/PassThroughConnectionAdapter.cs
+++ b/test/shared/PassThroughConnectionAdapter.cs
@@ -27,10 +27,6 @@ namespace Microsoft.AspNetCore.Testing
 
             public Stream ConnectionStream { get; }
 
-            public void PrepareRequest(IFeatureCollection requestFeatures)
-            {
-            }
-
             public void Dispose()
             {
             }


### PR DESCRIPTION
- Removed PrepareRequest from IAdaptedConnection and instead added
a feature collection to the ConnectionAdapterContext. This allows features to be set
once by the adapter instead of per request. It's the Frame's job to copy features
from the connection level feature collection into the per request feature collection.
- Set the scheme to "https" based on the presence of ITlsConnectionFeature.
- Always set ITlsConnection feature if the HttpsAdaptedConnection doesn't throw during
the handshake