### PR TITLE
Remove rogue ConfigureAwait

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameOfT.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameOfT.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             {
                                 KestrelEventSource.Log.RequestStart(this);
 
-                                await _application.ProcessRequestAsync(context).ConfigureAwait(false);
+                                await _application.ProcessRequestAsync(context);
 
                                 if (Volatile.Read(ref _requestAborted) == 0)
                                 {


### PR DESCRIPTION
- We don't do it anywhere else, I assume this is left over
from older legacy