### PR TITLE
Update test framework versions and fix issues with tests

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,7 +6,7 @@
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.1</MoqVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameHeadersTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData(" ,,", ConnectionOptions.None)]
         [InlineData(",, ", ConnectionOptions.None)]
         [InlineData(" , ,", ConnectionOptions.None)]
-        [InlineData(" , ,", ConnectionOptions.None)]
         [InlineData(" , , ", ConnectionOptions.None)]
         [InlineData("keep-alive", ConnectionOptions.KeepAlive)]
         [InlineData("keep-alive, upgrade", ConnectionOptions.KeepAlive | ConnectionOptions.Upgrade)]
@@ -31,8 +30,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData("upgrade,,keep-alive", ConnectionOptions.KeepAlive | ConnectionOptions.Upgrade)]
         [InlineData("keep-alive,", ConnectionOptions.KeepAlive)]
         [InlineData("keep-alive,,", ConnectionOptions.KeepAlive)]
-        [InlineData(",keep-alive", ConnectionOptions.KeepAlive)]
-        [InlineData(",,keep-alive", ConnectionOptions.KeepAlive)]
         [InlineData("keep-alive, ", ConnectionOptions.KeepAlive)]
         [InlineData("keep-alive, ,", ConnectionOptions.KeepAlive)]
         [InlineData("keep-alive, , ", ConnectionOptions.KeepAlive)]
@@ -45,8 +42,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData(", , keep-alive", ConnectionOptions.KeepAlive)]
         [InlineData("upgrade,", ConnectionOptions.Upgrade)]
         [InlineData("upgrade,,", ConnectionOptions.Upgrade)]
-        [InlineData(",upgrade", ConnectionOptions.Upgrade)]
-        [InlineData(",,upgrade", ConnectionOptions.Upgrade)]
         [InlineData("upgrade, ", ConnectionOptions.Upgrade)]
         [InlineData("upgrade, ,", ConnectionOptions.Upgrade)]
         [InlineData("upgrade, , ", ConnectionOptions.Upgrade)]
@@ -59,8 +54,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData(", , upgrade", ConnectionOptions.Upgrade)]
         [InlineData("close,", ConnectionOptions.Close)]
         [InlineData("close,,", ConnectionOptions.Close)]
-        [InlineData(",close", ConnectionOptions.Close)]
-        [InlineData(",,close", ConnectionOptions.Close)]
         [InlineData("close, ", ConnectionOptions.Close)]
         [InlineData("close, ,", ConnectionOptions.Close)]
         [InlineData("close, , ", ConnectionOptions.Close)]
@@ -83,17 +76,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData("upgrade,close", ConnectionOptions.Close | ConnectionOptions.Upgrade)]
         [InlineData("close,upgrade", ConnectionOptions.Close | ConnectionOptions.Upgrade)]
         [InlineData("keep-alive2", ConnectionOptions.None)]
-        [InlineData("keep-alive2,", ConnectionOptions.None)]
         [InlineData("keep-alive2 ", ConnectionOptions.None)]
         [InlineData("keep-alive2 ,", ConnectionOptions.None)]
         [InlineData("keep-alive2,", ConnectionOptions.None)]
         [InlineData("upgrade2", ConnectionOptions.None)]
-        [InlineData("upgrade2,", ConnectionOptions.None)]
         [InlineData("upgrade2 ", ConnectionOptions.None)]
         [InlineData("upgrade2 ,", ConnectionOptions.None)]
         [InlineData("upgrade2,", ConnectionOptions.None)]
         [InlineData("close2", ConnectionOptions.None)]
-        [InlineData("close2,", ConnectionOptions.None)]
         [InlineData("close2 ", ConnectionOptions.None)]
         [InlineData("close2 ,", ConnectionOptions.None)]
         [InlineData("close2,", ConnectionOptions.None)]
@@ -171,12 +161,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData(" ,,", TransferCoding.None)]
         [InlineData(",, ", TransferCoding.None)]
         [InlineData(" , ,", TransferCoding.None)]
-        [InlineData(" , ,", TransferCoding.None)]
         [InlineData(" , , ", TransferCoding.None)]
         [InlineData("chunked,", TransferCoding.Chunked)]
         [InlineData("chunked,,", TransferCoding.Chunked)]
-        [InlineData(",chunked", TransferCoding.Chunked)]
-        [InlineData(",,chunked", TransferCoding.Chunked)]
         [InlineData("chunked, ", TransferCoding.Chunked)]
         [InlineData("chunked, ,", TransferCoding.Chunked)]
         [InlineData("chunked, , ", TransferCoding.Chunked)]
@@ -241,7 +228,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             StringValues value;
 
             Assert.False(headers.TryGetValue("Content-Length", out value));
-            Assert.Equal(null, frameHeaders.ContentLength);
+            Assert.Null(frameHeaders.ContentLength);
             Assert.False(frameHeaders.ContentLength.HasValue);
 
             frameHeaders.ContentLength = 1;
@@ -258,7 +245,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             frameHeaders.ContentLength = null;
             Assert.False(headers.TryGetValue("Content-Length", out value));
-            Assert.Equal(null, frameHeaders.ContentLength);
+            Assert.Null(frameHeaders.ContentLength);
             Assert.False(frameHeaders.ContentLength.HasValue);
         }
 
@@ -276,14 +263,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             StringValues value;
 
             Assert.False(headers.TryGetValue("Content-Length", out value));
-            Assert.Equal(null, frameHeaders.ContentLength);
+            Assert.Null(frameHeaders.ContentLength);
             Assert.False(frameHeaders.ContentLength.HasValue);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => frameHeaders.ContentLength = -1);
             Assert.Throws<ArgumentOutOfRangeException>(() => frameHeaders.ContentLength = long.MinValue);
 
             Assert.False(headers.TryGetValue("Content-Length", out value));
-            Assert.Equal(null, frameHeaders.ContentLength);
+            Assert.Null(frameHeaders.ContentLength);
             Assert.False(frameHeaders.ContentLength.HasValue);
         }
     }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameRequestHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameRequestHeadersTests.cs
@@ -30,7 +30,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             headers["custom"] = new[] { "value" };
 
-            Assert.NotNull(headers["custom"]);
             Assert.Equal(1, headers["custom"].Count);
             Assert.Equal("value", headers["custom"][0]);
         }
@@ -43,8 +42,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             headers["host"] = new[] { "value" };
             headers["content-length"] = new[] { "0" };
 
-            Assert.NotNull(headers["host"]);
-            Assert.NotNull(headers["content-length"]);
             Assert.Equal(1, headers["host"].Count);
             Assert.Equal(1, headers["content-length"].Count);
             Assert.Equal("value", headers["host"][0]);
@@ -307,7 +304,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void AppendThrowsWhenHeaderNameContainsNonASCIICharacters()
         {
             var headers = new FrameRequestHeaders();
-            const string key = "\u00141ód\017c";
+            const string key = "\u00141\u00F3d\017c";
 
             var encoding = Encoding.GetEncoding("iso-8859-1");
             var exception = Assert.Throws<BadHttpRequestException>(

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameResponseHeadersTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameResponseHeadersTests.cs
@@ -66,7 +66,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData("Ser™ver", "Data")]
         [InlineData("Server", "Da™ta")]
         [InlineData("Unknown™-Header", "Data")]
-        [InlineData("Ser™ver", "Data")]
         [InlineData("šerver", "Data")]
         [InlineData("Server", "Dašta")]
         [InlineData("Unknownš-Header", "Data")]
@@ -218,7 +217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             dictionary.Remove("Content-Length");
 
-            Assert.Equal(null, headers.ContentLength);
+            Assert.Null(headers.ContentLength);
         }
 
         [Fact]
@@ -230,7 +229,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             dictionary.Clear();
 
-            Assert.Equal(null, headers.ContentLength);
+            Assert.Null(headers.ContentLength);
         }
 
         private static long ParseLong(string value)

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -26,8 +26,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/OutputProducerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/OutputProducerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
@@ -10,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 {
-    public class OutputProducerTests
+    public class OutputProducerTests : IDisposable
     {
         private readonly PipeFactory _pipeFactory;
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
@@ -36,10 +36,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
   <Target Name="DefinePlatformConstants" BeforeTargets="CoreCompile">
     <Sdk_GetOSPlatform>
       <!-- Returns {Linux, macOS, Windows} -->

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -2086,7 +2086,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 lifetime.RequestAborted.Register(() => registrationWh.Set());
 
                 await request.Body.CopyToAsync(Stream.Null);
-                connectionCloseWh.Wait(1000);
+                Assert.True(connectionCloseWh.Wait(10_000));
 
                 try
                 {
@@ -2115,7 +2115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         "",
                         "Hello");
 
-                    requestStartWh.Wait(1000);
+                    Assert.True(requestStartWh.Wait(10_000));
                 }
 
                 connectionCloseWh.Set();

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Tests/Microsoft.AspNetCore.Server.Kestrel.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Tests/Microsoft.AspNetCore.Server.Kestrel.Tests.csproj
@@ -20,8 +20,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.csproj
@@ -27,8 +27,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Update to xunit 2.3.0-beta2 and vstest 15.3

Changes:
 - no more guids thanks to VS 15.3
 - Fix issues in tests as identified by xunit.analyzers
 - Remove duplicate test data
 - Add a missing IDisposable so test cleanup happens properly