### PR TITLE
Remove synchronous Write APIs on IFrameControl

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameResponseStream.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/FrameResponseStream.cs
@@ -33,9 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public override void Flush()
         {
-            ValidateState(default(CancellationToken));
-
-            _frameControl.Flush();
+            FlushAsync(default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken)
@@ -60,9 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            ValidateState(default(CancellationToken));
-
-            _frameControl.Write(new ArraySegment<byte>(buffer, offset, count));
+            WriteAsync(buffer, offset, count, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/IFrameControl.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/IFrameControl.cs
@@ -10,9 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     public interface IFrameControl
     {
         void ProduceContinue();
-        void Write(ArraySegment<byte> data);
         Task WriteAsync(ArraySegment<byte> data, CancellationToken cancellationToken);
-        void Flush();
         Task FlushAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/OutputProducer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/OutputProducer.cs
@@ -39,11 +39,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _flushCompleted = OnFlushCompleted;
         }
 
-        public void Write(ArraySegment<byte> buffer, bool chunk = false)
-        {
-            WriteAsync(buffer, default(CancellationToken), chunk).GetAwaiter().GetResult();
-        }
-
         public Task WriteAsync(ArraySegment<byte> buffer, bool chunk = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (cancellationToken.IsCancellationRequested)
@@ -52,11 +47,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             return WriteAsync(buffer, cancellationToken, chunk);
-        }
-
-        public void Flush()
-        {
-            WriteAsync(_emptyData, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameTests.cs
@@ -211,10 +211,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public void ThrowsWhenStatusCodeIsSetAfterResponseStarted()
+        public async Task ThrowsWhenStatusCodeIsSetAfterResponseStarted()
         {
             // Act
-            _frame.Write(new ArraySegment<byte>(new byte[1]));
+            await _frame.WriteAsync(new ArraySegment<byte>(new byte[1]));
 
             // Assert
             Assert.True(_frame.HasResponseStarted);
@@ -222,10 +222,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public void ThrowsWhenReasonPhraseIsSetAfterResponseStarted()
+        public async Task ThrowsWhenReasonPhraseIsSetAfterResponseStarted()
         {
             // Act
-            _frame.Write(new ArraySegment<byte>(new byte[1]));
+            await _frame.WriteAsync(new ArraySegment<byte>(new byte[1]));
 
             // Assert
             Assert.True(_frame.HasResponseStarted);
@@ -233,9 +233,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public void ThrowsWhenOnStartingIsSetAfterResponseStarted()
+        public async Task ThrowsWhenOnStartingIsSetAfterResponseStarted()
         {
-            _frame.Write(new ArraySegment<byte>(new byte[1]));
+            await _frame.WriteAsync(new ArraySegment<byte>(new byte[1]));
 
             // Act/Assert
             Assert.True(_frame.HasResponseStarted);
@@ -472,13 +472,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public void WriteThrowsForNonBodyResponse()
+        public async Task WriteThrowsForNonBodyResponse()
         {
             // Arrange
             ((IHttpResponseFeature)_frame).StatusCode = StatusCodes.Status304NotModified;
 
             // Act/Assert
-            Assert.Throws<InvalidOperationException>(() => _frame.Write(new ArraySegment<byte>(new byte[1])));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _frame.WriteAsync(new ArraySegment<byte>(new byte[1])));
         }
 
         [Fact]
@@ -493,14 +493,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public void WriteDoesNotThrowForHeadResponse()
+        public async Task WriteDoesNotThrowForHeadResponse()
         {
             // Arrange
             _frame.HttpVersion = "HTTP/1.1";
             ((IHttpRequestFeature)_frame).Method = "HEAD";
 
             // Act/Assert
-            _frame.Write(new ArraySegment<byte>(new byte[1]));
+            await _frame.WriteAsync(new ArraySegment<byte>(new byte[1]));
         }
 
         [Fact]
@@ -515,7 +515,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public void ManuallySettingTransferEncodingThrowsForHeadResponse()
+        public async Task ManuallySettingTransferEncodingThrowsForHeadResponse()
         {
             // Arrange
             _frame.HttpVersion = "HTTP/1.1";
@@ -525,11 +525,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _frame.ResponseHeaders.Add("Transfer-Encoding", "chunked");
 
             // Assert
-            Assert.Throws<InvalidOperationException>(() => _frame.Flush());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _frame.FlushAsync());
         }
 
         [Fact]
-        public void ManuallySettingTransferEncodingThrowsForNoBodyResponse()
+        public async Task ManuallySettingTransferEncodingThrowsForNoBodyResponse()
         {
             // Arrange
             _frame.HttpVersion = "HTTP/1.1";
@@ -539,7 +539,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _frame.ResponseHeaders.Add("Transfer-Encoding", "chunked");
 
             // Assert
-            Assert.Throws<InvalidOperationException>(() => _frame.Flush());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _frame.FlushAsync());
         }
 
         [Fact]
@@ -558,7 +558,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public void RequestAbortedTokenIsResetBeforeLastWriteWithContentLength()
+        public async Task RequestAbortedTokenIsResetBeforeLastWriteWithContentLength()
         {
             _frame.ResponseHeaders["Content-Length"] = "12";
 
@@ -567,11 +567,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             foreach (var ch in "hello, worl")
             {
-                _frame.Write(new ArraySegment<byte>(new[] { (byte)ch }));
+                await _frame.WriteAsync(new ArraySegment<byte>(new[] { (byte)ch }));
                 Assert.Same(original, _frame.RequestAborted.WaitHandle);
             }
 
-            _frame.Write(new ArraySegment<byte>(new[] { (byte)'d' }));
+            await _frame.WriteAsync(new ArraySegment<byte>(new[] { (byte)'d' }));
             Assert.NotSame(original, _frame.RequestAborted.WaitHandle);
         }
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/TestHelpers/MockFrameControl.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/TestHelpers/MockFrameControl.cs
@@ -11,20 +11,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests.TestHelpers
 {
     public class MockFrameControl : IFrameControl
     {
-        public void Flush()
-        {
-        }
-
         public Task FlushAsync(CancellationToken cancellationToken)
         {
             return TaskCache.CompletedTask;
         }
 
         public void ProduceContinue()
-        {
-        }
-
-        public void Write(ArraySegment<byte> data)
         {
         }
 

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/TestInput.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/TestInput.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             FrameContext.FrameControl = this;
         }
 
-        public IPipe Pipe { get;  }
+        public IPipe Pipe { get; }
 
         public Frame FrameContext { get; set; }
 
@@ -70,21 +70,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
         }
 
-        void IFrameControl.ProduceContinue()
-        {
-        }
-
-        void IFrameControl.Write(ArraySegment<byte> data)
-        {
-        }
-
         Task IFrameControl.WriteAsync(ArraySegment<byte> data, CancellationToken cancellationToken)
         {
             return TaskCache.CompletedTask;
-        }
-
-        void IFrameControl.Flush()
-        {
         }
 
         Task IFrameControl.FlushAsync(CancellationToken cancellationToken)

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/FrameWritingBenchmark.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
-using Microsoft.AspNetCore.Server.Kestrel.Performance.Mocks;
 using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Performance
@@ -36,18 +35,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             _frameChunked.Reset();
             _frameChunked.RequestHeaders.Add("Transfer-Encoding", "chunked");
-        }
-
-        [Benchmark]
-        public void Write()
-        {
-            _frame.Write(new ArraySegment<byte>(_writeData));
-        }
-
-        [Benchmark]
-        public void WriteChunked()
-        {
-            _frameChunked.Write(new ArraySegment<byte>(_writeData));
         }
 
         [Benchmark]


### PR DESCRIPTION
Remove sync write APIs. There were already doing sync over async so there's no real behavior change here. I was lazy and didn't make ProduceContinue async because it would conflict with @cesarbs's body changes.