### PR TITLE
Fix duplicate ID test warning.

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -660,6 +660,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 // Non-loopback addresses
                 var ipv6Addresses = GetIPAddresses()
+                    .Where(ip => !ip.Equals(IPAddress.IPv6Loopback))
                     .Where(ip => ip.AddressFamily == AddressFamily.InterNetworkV6)
                     .Where(ip => ip.ScopeId == 0)
                     .Where(ip => CanBindAndConnectToEndpoint(new IPEndPoint(ip, 0)));


### PR DESCRIPTION
Fixes this:

```
[xUnit.net 00:00:06.2487125] Microsoft.AspNetCore.Server.Kestrel.FunctionalTests: Skipping test case with duplicate ID '77171261389001f7a47d657516c8b4e280ac4079' ('RegisterAddresses_IPv6_Success(addressInput: "http://[::1]:0/", testUrls: ["http://[::1]"])' and 'RegisterAddresses_IPv6_Success(addressInput: "http://[::1]:0/", testUrls: ["http://[::1]"])')
```