### PR TITLE
Fix flaky ResponseTests.FailedWritesResultInAbortedRequest.

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -2063,7 +2063,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionAdapterData))]
-        public async Task FailedWritesResultInAbortedRequest(ListenOptions listenOptions)
+        public async Task ThrowsOnWriteAfterRequestIsAborted(ListenOptions listenOptions)
         {
             // This should match _maxBytesPreCompleted in SocketOutput
             var maxBytesPreCompleted = 65536;
@@ -2072,7 +2072,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             var writeTcs = new TaskCompletionSource<object>();
             var requestAbortedWh = new ManualResetEventSlim();
-            var connectionCloseWh = new ManualResetEventSlim();
             var requestStartWh = new ManualResetEventSlim();
 
             using (var server = new TestServer(async httpContext =>
@@ -2113,8 +2112,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                     Assert.True(requestStartWh.Wait(TimeSpan.FromSeconds(10)));
                 }
-
-                connectionCloseWh.Set();
 
                 // Write failed - can throw TaskCanceledException or OperationCanceledException,
                 // dependending on how far the canceled write goes.

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -2085,8 +2085,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 lifetime.RequestAborted.Register(() => requestAbortedWh.Set());
 
-                requestAbortedWh.Wait(TimeSpan.FromSeconds(10));
-
                 try
                 {
                     // Ensure write is long enough to disable write-behind buffering
@@ -2118,8 +2116,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 connectionCloseWh.Set();
 
-                // Write failed
-                await Assert.ThrowsAsync<TaskCanceledException>(async () => await writeTcs.Task).TimeoutAfter(TimeSpan.FromSeconds(15));
+                // Write failed - can throw TaskCanceledException or OperationCanceledException,
+                // dependending on how far the canceled write goes.
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await writeTcs.Task).TimeoutAfter(TimeSpan.FromSeconds(15));
 
                 // RequestAborted tripped
                 Assert.True(requestAbortedWh.Wait(TimeSpan.FromSeconds(1)));

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -2083,6 +2083,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 var lifetime = httpContext.Features.Get<IHttpRequestLifetimeFeature>();
 
                 lifetime.RequestAborted.Register(() => requestAbortedWh.Set());
+                Assert.True(requestAbortedWh.Wait(TimeSpan.FromSeconds(10)));
 
                 try
                 {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -2063,10 +2063,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionAdapterData))]
-        public async Task ThrowsOnWriteAfterRequestIsAborted(ListenOptions listenOptions)
+        public async Task ThrowsOnWriteWithRequestAbortedTokenAfterRequestIsAborted(ListenOptions listenOptions)
         {
             // This should match _maxBytesPreCompleted in SocketOutput
             var maxBytesPreCompleted = 65536;
+
             // Ensure string is long enough to disable write-behind buffering
             var largeString = new string('a', maxBytesPreCompleted + 1);
 
@@ -2087,11 +2088,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 try
                 {
-                    // Ensure write is long enough to disable write-behind buffering
-                    for (var i = 0; i < 100; i++)
-                    {
-                        await response.WriteAsync(largeString, lifetime.RequestAborted);
-                    }
+                    await response.WriteAsync(largeString, lifetime.RequestAborted);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Sometimes it throws `TaskCancelledException`, sometimes `OperationCancelledException`. Depends on how far the write that's cancelled goes.

This makes the test more deterministic so it always throws `TaskCancelledException`.