### PR TITLE
Throw from UpgradeAsync when request is not upgradable

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/CoreStrings.resx
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/CoreStrings.resx
@@ -306,4 +306,7 @@
   <data name="RequestProcessingEndError" xml:space="preserve">
     <value>Connection processing ended abnormally.</value>
   </data>
+  <data name="CannotUpgradeNonUpgradableRequest" xml:space="preserve">
+    <value>Cannot upgrade a non-upgradable request. Check IHttpUpgradeFeature.IsUpgradableRequest to determine if a request can be upgraded.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.FeatureCollection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/Frame.FeatureCollection.cs
@@ -230,6 +230,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         async Task<Stream> IHttpUpgradeFeature.UpgradeAsync()
         {
+            if (!((IHttpUpgradeFeature)this).IsUpgradableRequest)
+            {
+                throw new InvalidOperationException(CoreStrings.CannotUpgradeNonUpgradableRequest);
+            }
+
             StatusCode = StatusCodes.Status101SwitchingProtocols;
             ReasonPhrase = "Switching Protocols";
             ResponseHeaders["Connection"] = "Upgrade";

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -892,6 +892,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal static string FormatRequestProcessingEndError()
             => GetString("RequestProcessingEndError");
 
+        /// <summary>
+        /// Cannot upgrade a non-upgradable request. Check IHttpUpgradeFeature.IsUpgradableRequest to determine if a request can be upgraded.
+        /// </summary>
+        internal static string CannotUpgradeNonUpgradableRequest
+        {
+            get => GetString("CannotUpgradeNonUpgradableRequest");
+        }
+
+        /// <summary>
+        /// Cannot upgrade a non-upgradable request. Check IHttpUpgradeFeature.IsUpgradableRequest to determine if a request can be upgraded.
+        /// </summary>
+        internal static string FormatCannotUpgradeNonUpgradableRequest()
+            => GetString("CannotUpgradeNonUpgradableRequest");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
@@ -162,6 +162,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 await connection.Send(
                     "GET /upgrade HTTP/1.1",
                     "Host:",
+                    "Connection: Upgrade",
                     "",
                     "");
                 await connection.Receive(

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/ResponseTests.cs
@@ -1775,6 +1775,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     await connection.Send(
                         "GET / HTTP/1.1",
                         "Host:",
+                        "Connection: Upgrade",
                         "",
                         "");
                     await connection.ReceiveForcedEnd(
@@ -1789,7 +1790,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 {
                     await connection.Send(
                         "GET / HTTP/1.0",
-                        "Connection: keep-alive",
+                        "Connection: keep-alive, Upgrade",
                         "",
                         "");
                     await connection.ReceiveForcedEnd(


### PR DESCRIPTION
Add a check to IHttpUpgradeFeature.UpgradeAsync to ensure IHttpUpgradeFeature.IsUpgradableRequest is true before upgrading the request and sending HTTP 101.

