### PR TITLE
Expose Heartbeat and enable adding and removing handlers

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/FrameConnectionManager.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/FrameConnectionManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
@@ -49,7 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                     _trace.ApplicationNeverCompleted(reference.ConnectionId);
                 }
 
-                // If both conditions are false, the connection was removed during the heartbeat.
+                // If both conditions are false, the connection was removed during the walk.
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/FrameHeartbeatManager.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/FrameHeartbeatManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,7 +25,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         private void WalkCallback(FrameConnection connection)
         {
-            connection.Tick(_now);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/Heartbeat.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/Heartbeat.cs
@@ -2,31 +2,61 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
-    public class Heartbeat : IDisposable
+    public class Heartbeat : IHeartbeat, IDisposable
     {
         public static readonly TimeSpan Interval = TimeSpan.FromSeconds(1);
 
-        private readonly IHeartbeatHandler[] _callbacks;
+        private static long _nextId;
+
+        private readonly ConcurrentDictionary<long, HeartbeatHandlerReference> _handlerReferences = new ConcurrentDictionary<long, HeartbeatHandlerReference>();
+
         private readonly ISystemClock _systemClock;
         private readonly IKestrelTrace _trace;
         private Timer _timer;
         private int _executingOnHeartbeat;
 
-        public Heartbeat(IHeartbeatHandler[] callbacks, ISystemClock systemClock, IKestrelTrace trace)
+        public Heartbeat(IEnumerable<IHeartbeatHandler> handlers, ISystemClock systemClock, IKestrelTrace trace)
         {
-            _callbacks = callbacks;
             _systemClock = systemClock;
             _trace = trace;
+
+            foreach (var handler in handlers)
+            {
+                AddHandler(handler);
+            }
         }
 
         public void Start()
         {
             _timer = new Timer(OnHeartbeat, state: this, dueTime: Interval, period: Interval);
+        }
+
+        public long AddHandler(IHeartbeatHandler handler)
+        {
+            var id = Interlocked.Increment(ref _nextId);
+
+            if (!_handlerReferences.TryAdd(id, new HeartbeatHandlerReference(handler)))
+            {
+                throw new InvalidOperationException($"Duplicate heartbeat handler ID: {id}");
+            }
+
+            return id;
+        }
+
+        public void RemoveHandler(long id)
+        {
+            if (!_handlerReferences.TryRemove(id, out _))
+            {
+                throw new ArgumentException(nameof(id));
+            }
         }
 
         private static void OnHeartbeat(object state)
@@ -43,9 +73,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             {
                 try
                 {
-                    foreach (var callback in _callbacks)
+                    foreach (var kvp in _handlerReferences)
                     {
-                        callback.OnHeartbeat(now);
+                        var reference = kvp.Value;
+
+                        if (reference.TryGetHandler(out var handler))
+                        {
+                            handler.OnHeartbeat(now);
+                        }
+                        else
+                        {
+                            // It's safe to modify the ConcurrentDictionary in the foreach.
+                            // The handler reference has become unrooted because the application never completed.
+                            _handlerReferences.TryRemove(kvp.Key, out reference);
+                        }
                     }
                 }
                 catch (Exception ex)

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/HeartbeatHandlerReference.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/HeartbeatHandlerReference.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
+{
+    public class HeartbeatHandlerReference
+    {
+        private readonly WeakReference<IHeartbeatHandler> _weakReference;
+
+        public HeartbeatHandlerReference(IHeartbeatHandler handler)
+        {
+            _weakReference = new WeakReference<IHeartbeatHandler>(handler);
+        }
+
+        public bool TryGetHandler(out IHeartbeatHandler handler)
+        {
+            return _weakReference.TryGetTarget(out handler);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/IHeartbeat.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/IHeartbeat.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
+{
+    public interface IHeartbeat : IDisposable
+    {
+        void Start();
+
+        long AddHandler(IHeartbeatHandler handler);
+
+        void RemoveHandler(long id);
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ServiceContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ServiceContext.cs
@@ -17,6 +17,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         public ISystemClock SystemClock { get; set; }
 
+        public IHeartbeat Heartbeat { get; set; }
+
         public DateHeaderValueManager DateHeaderValueManager { get; set; }
 
         public FrameConnectionManager ConnectionManager { get; set; }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
@@ -186,16 +186,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         private TestServer CreateServer(CancellationToken longRunningCt, CancellationToken upgradeCt)
         {
-            return new TestServer(httpContext => App(httpContext, longRunningCt, upgradeCt), new TestServiceContext
-            {
-                // Use real SystemClock so timeouts trigger.
-                SystemClock = new SystemClock(),
-                ServerOptions =
-                {
-                    AddServerHeader = false,
-                    Limits = { KeepAliveTimeout = KeepAliveTimeout }
-                }
-            });
+            var serviceContext = new TestServiceContext();
+
+            // Use real SystemClock so timeouts trigger.
+            serviceContext.SystemClock = new SystemClock();
+            serviceContext.Heartbeat = new Heartbeat(new IHeartbeatHandler[] { }, serviceContext.SystemClock, serviceContext.Log);
+            serviceContext.ServerOptions.AddServerHeader = false;
+            serviceContext.ServerOptions.Limits.KeepAliveTimeout = KeepAliveTimeout;
+
+            return new TestServer(httpContext => App(httpContext, longRunningCt, upgradeCt), serviceContext);
         }
 
         private async Task App(HttpContext httpContext, CancellationToken longRunningCt, CancellationToken upgradeCt)

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/TestServer.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/TestServer.cs
@@ -55,33 +55,33 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             Context = context;
 
             _host = new WebHostBuilder()
-                     .UseKestrel(o =>
-                     {
-                         o.ListenOptions.Add(_listenOptions);
-                     })
-                     .ConfigureServices(services =>
-                     {
-                         if (httpContextFactory != null)
-                         {
-                             services.AddSingleton(httpContextFactory);
-                         }
+                .UseKestrel(o =>
+                {
+                    o.ListenOptions.Add(_listenOptions);
+                })
+                .ConfigureServices(services =>
+                {
+                    if (httpContextFactory != null)
+                    {
+                        services.AddSingleton(httpContextFactory);
+                    }
 
-                         services.AddSingleton<IStartup>(this);
-                         services.AddSingleton<ILoggerFactory>(new KestrelTestLoggerFactory(context.ErrorLogger));
-                         services.AddSingleton<IServer>(sp =>
-                         {
-                             // Manually configure options on the TestServiceContext.
-                             // We're doing this so we can use the same instance that was passed in
-                             var configureOptions = sp.GetServices<IConfigureOptions<KestrelServerOptions>>();
-                             foreach (var c in configureOptions)
-                             {
-                                 c.Configure(context.ServerOptions);
-                             }
-                             return new KestrelServer(sp.GetRequiredService<ITransportFactory>(), context);
-                         });
-                     })
-                     .UseSetting(WebHostDefaults.ApplicationKey, typeof(TestServer).GetTypeInfo().Assembly.FullName)
-                     .Build();
+                    services.AddSingleton<IStartup>(this);
+                    services.AddSingleton<ILoggerFactory>(new KestrelTestLoggerFactory(context.ErrorLogger));
+                    services.AddSingleton<IServer>(sp =>
+                    {
+                        // Manually configure options on the TestServiceContext.
+                        // We're doing this so we can use the same instance that was passed in
+                        var configureOptions = sp.GetServices<IConfigureOptions<KestrelServerOptions>>();
+                        foreach (var c in configureOptions)
+                        {
+                            c.Configure(context.ServerOptions);
+                        }
+                        return new KestrelServer(sp.GetRequiredService<ITransportFactory>(), context);
+                    });
+                })
+                .UseSetting(WebHostDefaults.ApplicationKey, typeof(TestServer).GetTypeInfo().Assembly.FullName)
+                .Build();
 
             _host.Start();
         }

--- a/test/shared/TestServiceContext.cs
+++ b/test/shared/TestServiceContext.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.Testing
             Log = new TestKestrelTrace(ErrorLogger);
             ThreadPool = new LoggingThreadPool(Log);
             SystemClock = new MockSystemClock();
+            Heartbeat = new Heartbeat(new IHeartbeatHandler[] { DateHeaderValueManager }, SystemClock, Log);
             DateHeaderValueManager = new DateHeaderValueManager(SystemClock);
             ConnectionManager = new FrameConnectionManager(Log);
             DateHeaderValue = DateHeaderValueManager.GetDateHeaderValues().String;


### PR DESCRIPTION
This would allow hooking `MessageBody` directly to `Heartbeat` after #1840, to implement the request body timeout. Allows for a cleaner timeout implementation than passing `ITimeoutControl` to `MessageBody` and doing tricks like `SetTimeout(0)` to force a timeout when using a variable timeout based on the request rate.