### PR TITLE
Add request body read timeout

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
@@ -42,6 +42,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         private PipeFactory PipeFactory => _context.ConnectionInformation.PipeFactory;
 
+        public bool TimedOut { get; private set; }
+
         // Internal for testing
         internal PipeOptions AdaptedInputPipeOptions => new PipeOptions
         {
@@ -238,6 +240,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             // TODO: Use PlatformApis.VolatileRead equivalent again
             if (timestamp > Interlocked.Read(ref _timeoutTimestamp))
             {
+                TimedOut = true;
                 CancelTimeout();
 
                 if (_timeoutAction == TimeoutAction.SendTimeoutResponse)
@@ -270,6 +273,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         private void AssignTimeout(long ticks, TimeoutAction timeoutAction)
         {
+            TimedOut = false;
             _timeoutAction = timeoutAction;
 
             // Add Heartbeat.Interval since this can be called right before the next heartbeat.

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/MessageBody.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/MessageBody.cs
@@ -48,7 +48,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         TryProduceContinue();
                     }
 
+                    _context.TimeoutControl.SetTimeout(_context.ServiceContext.ServerOptions.Limits.RequestBodyReadTimeout.Ticks, Infrastructure.TimeoutAction.SendTimeoutResponse);
                     var result = await awaitable;
+                    _context.TimeoutControl.CancelTimeout();
+
+                    if (_context.TimeoutControl.TimedOut)
+                    {
+                        _context.RejectRequest(RequestRejectionReason.RequestTimeout);
+                    }
+
                     var readableBuffer = result.Buffer;
                     var consumed = readableBuffer.Start;
                     var examined = readableBuffer.End;

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/ITimeoutControl.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/ITimeoutControl.cs
@@ -5,6 +5,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
     public interface ITimeoutControl
     {
+        bool TimedOut { get; }
         void SetTimeout(long ticks, TimeoutAction timeoutAction);
         void ResetTimeout(long ticks, TimeoutAction timeoutAction);
         void CancelTimeout();

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerLimits.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerLimits.cs
@@ -32,6 +32,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         private long? _maxConcurrentConnections = null;
         private long? _maxConcurrentUpgradedConnections = null;
 
+        private TimeSpan _requestBodyReadTimeout = TimeSpan.FromSeconds(60);
+
         /// <summary>
         /// Gets or sets the maximum size of the response buffer before write
         /// calls begin to block or return tasks that don't complete until the
@@ -205,6 +207,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                     throw new ArgumentOutOfRangeException(nameof(value), CoreStrings.NonNegativeNumberOrNullRequired);
                 }
                 _maxConcurrentUpgradedConnections = value;
+            }
+        }
+
+        public TimeSpan RequestBodyReadTimeout
+        {
+            get => _requestBodyReadTimeout;
+            set
+            {
+                _requestBodyReadTimeout = value;
             }
         }
     }


### PR DESCRIPTION
This is a per read timeout similar to nginx's [`client_body_timeout`](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout). Most other servers offer this feature. It's a simpler alternative to #1874.

TODO:

- [ ] Don't enforce on upgrade requests
- [ ] Make it configurable per request
- [ ] Tests