### PR TITLE
Complete IPipeWriter in OutputProducer.Abort()

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/OutputProducer.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Http/OutputProducer.cs
@@ -95,6 +95,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 _log.ConnectionDisconnect(_connectionId);
                 _completed = true;
                 _pipe.Reader.CancelPendingRead();
+                _pipe.Writer.Complete();
             }
         }
 


### PR DESCRIPTION
- This prevents MemoryPoolBlocks from leaking when writes fail

The leak can be observed by running LibuvOutputConsumerTests.FailedWriteCompletesOrCancelsAllPendingTasks with BLOCK_LEASE_TRACKING defined in Transport.Abstractions. Once https://github.com/dotnet/corefxlab/pull/1601 is merged, defining BLOCK_LEASE_TRACKING won't be necessary to see the leak occurred.