### PR TITLE
Add a StressTest target

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -4,16 +4,7 @@
   </Target>
   <Target Name="StressTest" DependsOnTargets="Build">
     <ItemGroup>
-      <Iteration Include="0" />
-      <Iteration Include="1" />
-      <Iteration Include="2" />
-      <Iteration Include="3" />
-      <Iteration Include="4" />
-      <Iteration Include="5" />
-      <Iteration Include="6" />
-      <Iteration Include="7" />
-      <Iteration Include="8" />
-      <Iteration Include="9" />
+      <Iteration Include="0;1;2;3;4;5;6;7;8;9" />
     </ItemGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="TestProjects" Properties="FakeProperty=%(Iteration.Identity)" />
   </Target>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -2,4 +2,19 @@
   <Target Name="CodeGen">
     <Exec Command="dotnet run" WorkingDirectory="$(MSBuildThisFileDirectory)..\tools\CodeGenerator\" />
   </Target>
+  <Target Name="StressTest" DependsOnTargets="Build">
+    <ItemGroup>
+      <Iteration Include="0" />
+      <Iteration Include="1" />
+      <Iteration Include="2" />
+      <Iteration Include="3" />
+      <Iteration Include="4" />
+      <Iteration Include="5" />
+      <Iteration Include="6" />
+      <Iteration Include="7" />
+      <Iteration Include="8" />
+      <Iteration Include="9" />
+    </ItemGroup>
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="TestProjects" Properties="FakeProperty=%(Iteration.Identity)" />
+  </Target>
 </Project>


### PR DESCRIPTION
We decided to run tests multiple times as a very basic approximation of stress testing. I'll add another test configuration to CI in parallel with Win2012-Mvc/EF/... that would run this target.

https://github.com/aspnet/KestrelHttpServer/issues/1685

