### PR TITLE
Do not enforce timeouts when the debugger is attached

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnectionContext.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/DebuggerWrapper.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/DebuggerWrapper.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
+{
+    internal sealed class DebuggerWrapper : IDebugger
+    {
+        private DebuggerWrapper()
+        { }
+
+        public static IDebugger Singleton { get; } = new DebuggerWrapper();
+
+        public bool IsAttached => Debugger.IsAttached;
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/IDebugger.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/Infrastructure/IDebugger.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
+{
+    public interface IDebugger
+    {
+        bool IsAttached { get; }
+    }
+}

--- a/test/shared/DummyApplication.cs
+++ b/test/shared/DummyApplication.cs
@@ -14,6 +14,11 @@ namespace Microsoft.AspNetCore.Testing
         private readonly RequestDelegate _requestDelegate;
         private readonly IHttpContextFactory _httpContextFactory;
 
+        public DummyApplication()
+            : this(_ => Task.CompletedTask)
+        {
+        }
+
         public DummyApplication(RequestDelegate requestDelegate)
             : this(requestDelegate, null)
         {


### PR DESCRIPTION
Resolves https://github.com/aspnet/KestrelHttpServer/issues/1884