### PR TITLE
Domain socket handles

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/ListenOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/ListenOptions.cs
@@ -62,9 +62,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             set
             {
                 if (value == _handleType)
+                {
                     return;
+                }
                 if (Type != ListenType.FileHandle || _handleType != FileHandleType.Auto)
+                {
                     throw new InvalidOperationException();
+                }
+
                 switch (value)
                 {
                     case FileHandleType.Tcp:

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/ListenOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/ListenOptions.cs
@@ -16,6 +16,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
     /// </summary>
     public class ListenOptions : IEndPointInformation
     {
+        private FileHandleType _handleType;
+
         internal ListenOptions(IPEndPoint endPoint)
         {
             Type = ListenType.IPEndPoint;
@@ -53,8 +55,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// The type of interface being described: either an <see cref="IPEndPoint"/>, Unix domain socket path, or a file descriptor.
         /// </summary>
         public ListenType Type { get; }
-
-        private FileHandleType _handleType;
 
         public FileHandleType HandleType
         {

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/ListenOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/ListenOptions.cs
@@ -29,15 +29,53 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         }
 
         internal ListenOptions(ulong fileHandle)
+            : this(fileHandle, FileHandleType.Auto)
+        {
+        }
+
+        internal ListenOptions(ulong fileHandle, FileHandleType handleType)
         {
             Type = ListenType.FileHandle;
             FileHandle = fileHandle;
+            switch (handleType)
+            {
+                case FileHandleType.Auto:
+                case FileHandleType.Tcp:
+                case FileHandleType.Pipe:
+                    _handleType = handleType;
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
         }
 
         /// <summary>
         /// The type of interface being described: either an <see cref="IPEndPoint"/>, Unix domain socket path, or a file descriptor.
         /// </summary>
         public ListenType Type { get; }
+
+        private FileHandleType _handleType;
+
+        public FileHandleType HandleType
+        {
+            get => _handleType;
+            set
+            {
+                if (value == _handleType)
+                    return;
+                if (Type != ListenType.FileHandle || _handleType != FileHandleType.Auto)
+                    throw new InvalidOperationException();
+                switch (value)
+                {
+                    case FileHandleType.Tcp:
+                    case FileHandleType.Pipe:
+                        _handleType = value;
+                        break;
+                    default:
+                        throw new ArgumentException(nameof(HandleType));
+                }
+            }
+        }
 
         // IPEndPoint is mutable so port 0 can be updated to the bound port.
         /// <summary>

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Internal/FileHandleType.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Internal/FileHandleType.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
+{
+    /// <summary>
+    /// Enumerates the <see cref="IEndPointInformation.FileHandle"/> types.
+    /// </summary>
+    public enum FileHandleType
+    {
+        Auto,
+        Tcp,
+        Pipe
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Internal/IEndPointInformation.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Internal/IEndPointInformation.cs
@@ -31,6 +31,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         /// </summary>
         ulong FileHandle { get; }
 
+        //  HandleType is mutable so it can be re-specified later.
+        /// <summary>
+        /// The type of file descriptor being used.
+        /// Only set if <see cref="Type"/> is <see cref="ListenType.FileHandle"/>.
+        /// </summary>
+        FileHandleType HandleType { get; set; }
+
         /// <summary>
         /// Set to false to enable Nagle's algorithm for all connections.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvConstants.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/LibuvConstants.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
         public const int EOF = -4095;
         public static readonly int? ECONNRESET = GetECONNRESET();
         public static readonly int? EADDRINUSE = GetEADDRINUSE();
+        public static readonly int? ENOTSUP = GetENOTSUP();
 
         private static int? GetECONNRESET()
         {
@@ -43,6 +44,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 return -48;
+            }
+            return null;
+        }
+
+        private static int? GetENOTSUP()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return -95;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return -45;
             }
             return null;
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Listener.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Listener.cs
@@ -46,9 +46,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             switch (EndPointInformation.Type)
             {
                 case ListenType.IPEndPoint:
-                    return ListenTcp(false);
+                    return ListenTcp(useFileHandle: false);
                 case ListenType.SocketPath:
-                    return ListenPipe(false);
+                    return ListenPipe(useFileHandle: false);
                 case ListenType.FileHandle:
                     return ListenHandle();
                 default:
@@ -119,16 +119,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 case FileHandleType.Auto:
                     break;
                 case FileHandleType.Tcp:
-                    return ListenTcp(true);
+                    return ListenTcp(useFileHandle: true);
                 case FileHandleType.Pipe:
-                    return ListenPipe(true);
+                    return ListenPipe(useFileHandle: true);
                 default:
                     throw new NotSupportedException();
             }
+
             UvStreamHandle handle;
             try
             {
-                handle = ListenTcp(true);
+                handle = ListenTcp(useFileHandle: true);
                 EndPointInformation.HandleType = FileHandleType.Tcp;
                 return handle;
             }
@@ -136,7 +137,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             {
                 Log.LogDebug(0, exception, "Listener.ListenHandle");
             }
-            handle = ListenPipe(true);
+
+            handle = ListenPipe(useFileHandle: true);
             EndPointInformation.HandleType = FileHandleType.Pipe;
             return handle;
         }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerContext.cs
@@ -28,17 +28,64 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             switch (EndPointInformation.Type)
             {
                 case ListenType.IPEndPoint:
-                case ListenType.FileHandle:
-                    var tcpHandle = new UvTcpHandle(TransportContext.Log);
-                    tcpHandle.Init(Thread.Loop, Thread.QueueCloseHandle);
-                    tcpHandle.NoDelay(EndPointInformation.NoDelay);
-                    return tcpHandle;
+                    return AcceptTcp();
                 case ListenType.SocketPath:
-                    var pipeHandle = new UvPipeHandle(TransportContext.Log);
-                    pipeHandle.Init(Thread.Loop, Thread.QueueCloseHandle);
-                    return pipeHandle;
+                    return AcceptPipe();
+                case ListenType.FileHandle:
+                    return AcceptHandle();
                 default:
                     throw new InvalidOperationException();
+            }
+        }
+
+        private UvTcpHandle AcceptTcp()
+        {
+            var socket = new UvTcpHandle(TransportContext.Log);
+
+            try
+            {
+                socket.Init(Thread.Loop, Thread.QueueCloseHandle);
+                socket.NoDelay(EndPointInformation.NoDelay);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+
+            return socket;
+        }
+
+        private UvPipeHandle AcceptPipe()
+        {
+            var pipe = new UvPipeHandle(TransportContext.Log);
+
+            try
+            {
+                pipe.Init(Thread.Loop, Thread.QueueCloseHandle);
+            }
+            catch
+            {
+                pipe.Dispose();
+                throw;
+            }
+
+            return pipe;
+        }
+
+        private UvStreamHandle AcceptHandle()
+        {
+            switch (EndPointInformation.HandleType)
+            {
+                case FileHandleType.Auto:
+                    //  Handle type detection must be done by listener, refreshing endpoint information
+                    throw new InvalidOperationException();
+                case FileHandleType.Tcp:
+                    return AcceptTcp();
+                case FileHandleType.Pipe:
+                    return AcceptPipe();
+                default:
+                    throw new NotSupportedException();
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerContext.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/ListenerContext.cs
@@ -78,8 +78,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             switch (EndPointInformation.HandleType)
             {
                 case FileHandleType.Auto:
-                    //  Handle type detection must be done by listener, refreshing endpoint information
-                    throw new InvalidOperationException();
+                    throw new InvalidOperationException("Cannot accept on a non-specific file handle, listen should be performed first.");
                 case FileHandleType.Tcp:
                     return AcceptTcp();
                 case FileHandleType.Pipe:

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/LibuvFunctions.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/LibuvFunctions.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networkin
             _uv_tcp_nodelay = NativeMethods.uv_tcp_nodelay;
             _uv_pipe_init = NativeMethods.uv_pipe_init;
             _uv_pipe_bind = NativeMethods.uv_pipe_bind;
+            _uv_pipe_open = NativeMethods.uv_pipe_open;
             _uv_listen = NativeMethods.uv_listen;
             _uv_accept = NativeMethods.uv_accept;
             _uv_pipe_connect = NativeMethods.uv_pipe_connect;
@@ -227,6 +228,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networkin
         {
             handle.Validate();
             ThrowIfErrored(_uv_pipe_bind(handle, name));
+        }
+
+        protected Func<UvPipeHandle, IntPtr, int> _uv_pipe_open;
+        public void pipe_open(UvPipeHandle handle, IntPtr hSocket)
+        {
+            handle.Validate();
+            ThrowIfErrored(_uv_pipe_open(handle, hSocket));
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -533,6 +541,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networkin
 
             [DllImport("libuv", CallingConvention = CallingConvention.Cdecl)]
             public static extern int uv_pipe_bind(UvPipeHandle loop, string name);
+
+            [DllImport("libuv", CallingConvention = CallingConvention.Cdecl)]
+            public static extern int uv_pipe_open(UvPipeHandle handle, IntPtr hSocket);
 
             [DllImport("libuv", CallingConvention = CallingConvention.Cdecl)]
             public static extern int uv_listen(UvStreamHandle handle, int backlog, uv_connection_cb cb);

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvPipeHandle.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/Internal/Networking/UvPipeHandle.cs
@@ -21,6 +21,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networkin
             _uv.pipe_init(loop, this, ipc);
         }
 
+        public void Open(IntPtr fileDescriptor)
+        {
+            _uv.pipe_open(this, fileDescriptor);
+        }
+
         public void Bind(string name)
         {
             _uv.pipe_bind(this, name);

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/Dockerfile
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/Dockerfile
@@ -15,7 +15,7 @@ RUN ["ln", "-s", "/usr/share/dotnet/dotnet", "/usr/bin/dotnet"]
 ADD publish/ /publish/
 
 # Expose target ports.
-EXPOSE 8080 8081 8082
+EXPOSE 8080 8081 8082 8083 8084 8085
 
 # Set entrypoint.
 COPY ./docker-entrypoint.sh /

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker-entrypoint.sh
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker-entrypoint.sh
@@ -6,5 +6,9 @@ cd /publish
 systemd-socket-activate -l 8080 -E BASE_PORT=7000 dotnet SampleApp.dll &
 socat TCP-LISTEN:8081,fork TCP-CONNECT:127.0.0.1:7000 &
 socat TCP-LISTEN:8082,fork TCP-CONNECT:127.0.0.1:7001 &
+systemd-socket-activate -l /tmp/activate-kestrel.sock -E BASE_PORT=7100 dotnet SampleApp.dll &
+socat TCP-LISTEN:8083,fork UNIX-CLIENT:/tmp/activate-kestrel.sock &
+socat TCP-LISTEN:8084,fork TCP-CONNECT:127.0.0.1:7100 &
+socat TCP-LISTEN:8085,fork TCP-CONNECT:127.0.0.1:7101 &
 trap 'exit 0' SIGTERM
 wait

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker.sh
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker.sh
@@ -15,6 +15,9 @@ for i in {1..10}; do
     curl -f http://$(docker port $container 8080/tcp) \
     && curl -f http://$(docker port $container 8081/tcp) \
     && curl -fk https://$(docker port $container 8082/tcp) \
+    && curl -f http://$(docker port $container 8083/tcp) \
+    && curl -f http://$(docker port $container 8084/tcp) \
+    && curl -fk https://$(docker port $container 8085/tcp) \
     && exit 0 || sleep 1; 
 done
 


### PR DESCRIPTION
This is the PR to solve #1906 
It deviates a little from the originally described implementation plan, as I believe that adding new ListenTypes isn't actually a great idea since the proposed changes represented a different "dimension" of file handle, so the FileHandleType (auto/tcp/pipe) was introduced. The worst (in my opinion) part of the PR is reliance on IEndpointInformation.HandleType being mutable (but since IPEndpoint was mutable and since I've added some sanity checks in place) I believe it's okay. The other, not-so-great part is requirement that both listen and accept listeners do share the same IEndpointInformation reference, but I don't believe there are reasons this should change (and if it would, the only case that will suffer is systemd one).
I tried to keep the changes to a minimum, but had to split the ListenTcp/ListenPipe/ListenHandle and its accept counterparts' due to switch code becoming cluttered after try/catch was applied.

The LibuvConstants.ENOTSUP has no value on Windows intentionally.

Tested with stock Ubuntu 16.04.2, simple cases work, more complex testing will be done tomorrow.

cc: @halter73 

Thank you for considering this.
