### PR TITLE
Improved systemd activation tests

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace SampleApp
@@ -40,6 +41,12 @@ namespace SampleApp
                 Console.WriteLine("Unobserved exception: {0}", e.Exception);
             };
 
+            var configuration = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .Build();
+            if (!ushort.TryParse(configuration["BASE_PORT"], System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var basePort))
+                basePort = 5000;
+
             var host = new WebHostBuilder()
                 .ConfigureLogging((_, factory) =>
                 {
@@ -50,7 +57,7 @@ namespace SampleApp
                     // Run callbacks on the transport thread
                     options.ApplicationSchedulingMode = SchedulingMode.Inline;
 
-                    options.Listen(IPAddress.Loopback, 5000, listenOptions =>
+                    options.Listen(IPAddress.Loopback, basePort, listenOptions =>
                     {
                         // Uncomment the following to enable Nagle's algorithm for this endpoint.
                         //listenOptions.NoDelay = false;
@@ -58,7 +65,7 @@ namespace SampleApp
                         listenOptions.UseConnectionLogging();
                     });
 
-                    options.Listen(IPAddress.Loopback, 5001, listenOptions =>
+                    options.Listen(IPAddress.Loopback, basePort + 1, listenOptions =>
                     {
                         listenOptions.UseHttps("testCert.pfx", "testPassword");
                         listenOptions.UseConnectionLogging();

--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
@@ -44,8 +45,11 @@ namespace SampleApp
             var configuration = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
                 .Build();
-            if (!ushort.TryParse(configuration["BASE_PORT"], System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var basePort))
+
+            if (!ushort.TryParse(configuration["BASE_PORT"], NumberStyles.None, CultureInfo.InvariantCulture, out var basePort))
+            {
                 basePort = 5000;
+            }
 
             var host = new WebHostBuilder()
                 .ConfigureLogging((_, factory) =>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/Dockerfile
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/Dockerfile
@@ -3,34 +3,21 @@ FROM microsoft/dotnet-nightly:2.0-runtime-deps
 # The "container" environment variable is read by systemd.
 ENV container=docker
 
-# Install and configure systemd which requires dbus for graceful shutdown.
+# Install and configure dependencies.
 RUN ["apt-get", "-o", "Acquire::Check-Valid-Until=false", "update"]
-RUN ["apt-get", "install", "-y", "--no-install-recommends", "systemd-sysv"]
-
-# Set proper systemd default target.
-RUN ["systemctl", "set-default", "multi-user.target"]
-
-# Remove non-vital systemd services.
-RUN ["find", "/etc/systemd/system", "/lib/systemd/system", \
-    "-path", "*.wants/*", \
-    "-not", "-name", "*systemd-journald*", \
-    "-not", "-name", "*systemd-tmpfiles*", \
-    "-not", "-name", "*systemd-user-sessions*", \
-    "-delete"]
+RUN ["apt-get", "install", "-y", "--no-install-recommends", "systemd", "socat"]
 
 # Copy .NET installation.
 ADD .dotnet/ /usr/share/dotnet/
 RUN ["ln", "-s", "/usr/share/dotnet/dotnet", "/usr/bin/dotnet"]
 
-# Create activate-kestrel.service to launch the "publish" app on new requests to 8080.
-EXPOSE 8080
+# Copy "publish" app.
 ADD publish/ /publish/
-ADD activate-kestrel.service /etc/systemd/system/activate-kestrel.service
-ADD activate-kestrel.socket /etc/systemd/system/activate-kestrel.socket
 
-# Automatically start activate-kestrel.socket on boot.
-RUN ["systemctl", "enable", "activate-kestrel.socket"]
+# Expose target ports.
+EXPOSE 8080 8081 8082
 
-# Launch systemd, with workaround for docker/docker#27202, technique based on comments from docker/docker#9212.
-CMD ["/bin/bash", "-c", "exec /sbin/init --log-target=journal 3>&1"]
-STOPSIGNAL SIGRTMIN+3
+# Set entrypoint.
+COPY ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/activate-kestrel.service
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/activate-kestrel.service
@@ -1,7 +1,0 @@
-[Unit]
-Requires=activate-kestrel.socket
-
-[Service]
-ExecStart=/usr/bin/dotnet SampleApp.dll
-WorkingDirectory=/publish
-NonBlocking=true

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/activate-kestrel.socket
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/activate-kestrel.socket
@@ -1,9 +1,0 @@
-[Unit]
-PartOf=activate-kestrel.service
-
-[Socket]
-ListenStream=8080
-NoDelay=true
-
-[Install]
-WantedBy=multi-user.target

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker-entrypoint.sh
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+cd /publish
+systemd-socket-activate -l 8080 -E BASE_PORT=7000 dotnet SampleApp.dll &
+socat TCP-LISTEN:8081,fork TCP-CONNECT:127.0.0.1:7000 &
+socat TCP-LISTEN:8082,fork TCP-CONNECT:127.0.0.1:7001 &
+trap 'exit 0' SIGTERM
+wait

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker.sh
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/SystemdActivation/docker.sh
@@ -8,9 +8,14 @@ cp -R ./samples/SampleApp/bin/Debug/netcoreapp2.0/publish/ $scriptDir
 cp -R ~/.dotnet/ $scriptDir
 
 image=$(docker build -qf $scriptDir/Dockerfile $scriptDir)
-container=$(docker run -Ptd --privileged $image)
+container=$(docker run -Pd $image)
 
-# Try to connect to SampleApp once a second up to 10 times.
-for i in {1..10}; do curl $(docker port $container 8080/tcp) && exit 0 || sleep 1; done
+# Try to connect to SampleApp once a second up to 10 times via all available ports.
+for i in {1..10}; do 
+    curl -f http://$(docker port $container 8080/tcp) \
+    && curl -f http://$(docker port $container 8081/tcp) \
+    && curl -fk https://$(docker port $container 8082/tcp) \
+    && exit 0 || sleep 1; 
+done
 
 exit -1


### PR DESCRIPTION
While working on activation tests for #1922 I found a [better way to test systemd activation](https://www.freedesktop.org/software/systemd/man/systemd-socket-activate.html) that allows not running systemd itself in a container (which, at the current point, is a more or less fragile hack). Also it allows for non-privileged container which does not need access to LXC.
This PR radically simplifies the docker part of the equation, along with introducing BASE_PORT envvar to allow for specifying base ports for non-systemd listens, also testing both the systemd socket activation and explicity configured ports (this seems useful, because there is a possibility that one thing can break another).

I understand that there already was a fix at #1925, but it just got it working, this one is much less likely to break in the future, if docker or systemd get upgraded in the CI environment.

I already have #1922 test ready, but it needs this one to work better.

Thank you for reviewing this.