### PR TITLE
Increase default request min rate to 240 bytes/second (#1929)

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerLimits.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerLimits.cs
@@ -260,6 +260,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// <remarks>
         /// Defaults to 240 bytes/second with a 5 second grace period.
         /// </remarks>
-        public MinDataRate MinRequestBodyDataRate { get; set; } = new MinDataRate(bytesPerSecond: 240, gracePeriod: TimeSpan.FromSeconds(5));
+        public MinDataRate MinRequestBodyDataRate { get; set; } =
+            // Matches the default IIS minBytesPerSecond
+            new MinDataRate(bytesPerSecond: 240, gracePeriod: TimeSpan.FromSeconds(5));
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerLimits.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/KestrelServerLimits.cs
@@ -258,8 +258,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// This can be overridden per-request via <see cref="IHttpMinRequestBodyDataRateFeature"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to 1 byte/second with a 5 second grace period.
+        /// Defaults to 240 bytes/second with a 5 second grace period.
         /// </remarks>
-        public MinDataRate MinRequestBodyDataRate { get; set; } = new MinDataRate(bytesPerSecond: 1, gracePeriod: TimeSpan.FromSeconds(5));
+        public MinDataRate MinRequestBodyDataRate { get; set; } = new MinDataRate(bytesPerSecond: 240, gracePeriod: TimeSpan.FromSeconds(5));
     }
 }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/KestrelServerLimitsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/KestrelServerLimitsTests.cs
@@ -296,7 +296,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void MinRequestBodyDataRateDefault()
         {
             Assert.NotNull(new KestrelServerLimits().MinRequestBodyDataRate);
-            Assert.Equal(1, new KestrelServerLimits().MinRequestBodyDataRate.BytesPerSecond);
+            Assert.Equal(240, new KestrelServerLimits().MinRequestBodyDataRate.BytesPerSecond);
             Assert.Equal(TimeSpan.FromSeconds(5), new KestrelServerLimits().MinRequestBodyDataRate.GracePeriod);
         }
 


### PR DESCRIPTION
#1929