### PR TITLE
Fix flaky test: ConnectionResetMidRequestIsLoggedAsDebug

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -12,7 +12,6 @@
       Remove when fixed.
     -->
     <HasRuntimeOutput>true</HasRuntimeOutput>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp2.0'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.csproj
@@ -12,7 +12,6 @@
       Remove when fixed.
     -->
     <HasRuntimeOutput>true</HasRuntimeOutput>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp2.0'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -28,6 +28,7 @@ using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
@@ -36,6 +37,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         private const int _connectionStartedEventId = 1;
         private const int _connectionResetEventId = 19;
         private const int _semaphoreWaitTimeout = 2500;
+
+        private readonly ITestOutputHelper _output;
+       
+        public RequestTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         public static TheoryData<ListenOptions> ConnectionAdapterData => new TheoryData<ListenOptions>
         {
@@ -385,6 +393,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             var requestStarted = new SemaphoreSlim(0);
             var connectionReset = new SemaphoreSlim(0);
+            var connectionClosing = new SemaphoreSlim(0);
             var loggedHigherThanDebug = false;
 
             var mockLogger = new Mock<ILogger>();
@@ -395,6 +404,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 .Setup(logger => logger.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<object>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>()))
                 .Callback<LogLevel, EventId, object, Exception, Func<object, Exception, string>>((logLevel, eventId, state, exception, formatter) =>
                 {
+                    _output.WriteLine(logLevel + ": " + formatter(state, exception));
+
                     if (eventId.Id == _connectionResetEventId)
                     {
                         connectionReset.Release();
@@ -417,20 +428,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             using (var server = new TestServer(async context =>
                 {
                     requestStarted.Release();
-                    await context.Request.Body.ReadAsync(new byte[1], 0, 1);
+                    await connectionClosing.WaitAsync();
                 },
                 new TestServiceContext(mockLoggerFactory.Object)))
             {
                 using (var connection = server.CreateConnection())
                 {
-                    await connection.Send(
-                        "GET / HTTP/1.1",
-                        "Host:",
-                        "",
-                        "");
+                    await connection.SendEmptyGet();
 
                     // Wait until connection is established
-                    Assert.True(await requestStarted.WaitAsync(TimeSpan.FromSeconds(10)));
+                    Assert.True(await requestStarted.WaitAsync(TimeSpan.FromSeconds(30)), "request should have started");
 
                     // Force a reset
                     connection.Socket.LingerState = new LingerOption(true, 0);
@@ -440,10 +447,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 // This check MUST come before disposing the server, otherwise there's a race where the RST
                 // is still in flight when the connection is aborted, leading to the reset never being received
                 // and therefore not logged.
-                Assert.True(await connectionReset.WaitAsync(TimeSpan.FromSeconds(10)));
+                Assert.True(await connectionReset.WaitAsync(TimeSpan.FromSeconds(30)), "Connection reset event should have been logged");
+                connectionClosing.Release();
             }
 
-            Assert.False(loggedHigherThanDebug);
+            Assert.False(loggedHigherThanDebug, "Logged event should have been higher than debug.");
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/RequestTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         private const int _semaphoreWaitTimeout = 2500;
 
         private readonly ITestOutputHelper _output;
-       
+
         public RequestTests(ITestOutputHelper output)
         {
             _output = output;
@@ -451,7 +451,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 connectionClosing.Release();
             }
 
-            Assert.False(loggedHigherThanDebug, "Logged event should have been higher than debug.");
+            Assert.False(loggedHigherThanDebug, "Logged event should not have been higher than debug.");
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.csproj
@@ -13,7 +13,6 @@
       Remove when fixed.
     -->
     <HasRuntimeOutput>true</HasRuntimeOutput>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp2.0'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves https://github.com/aspnet/KestrelHttpServer/issues/1766

This test was flaky because there was a race condition in the test. The call to `await context.Request.Body.ReadAsync(new byte[1], 0, 1);` does not guarantee the request will remain open long enough for the connection to be killed externally. I changed the body of the test server to ensure it waits long enough for this to happen.