### PR TITLE
Fix flakiness in MaxRequestBufferSizeTests.LargeUpload (#1850)

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs
@@ -34,7 +34,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         private readonly Action<ILoggingBuilder> _configureLoggingDelegate;
 
-        public AddressRegistrationTests(ITestOutputHelper output) => _configureLoggingDelegate = builder => builder.AddXunit(output);
+        public AddressRegistrationTests(ITestOutputHelper output)
+        {
+            _configureLoggingDelegate = builder => builder.AddXunit(output);
+        }
 
         [ConditionalFact]
         [NetworkIsReachable]

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -32,7 +32,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         private readonly Action<ILoggingBuilder> _configureLoggingDelegate;
 
-        public MaxRequestBufferSizeTests(ITestOutputHelper output) =>_configureLoggingDelegate = builder => builder.AddXunit(output);
+        public MaxRequestBufferSizeTests(ITestOutputHelper output)
+        {
+            _configureLoggingDelegate = builder => builder.AddXunit(output);
+        }
 
         public static IEnumerable<object[]> LargeUploadData
         {

--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -13,7 +13,9 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Logging;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
@@ -27,6 +29,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             $"Content-Length: {_dataLength}\r\n",
             "\r\n"
         };
+
+        private readonly Action<ILoggingBuilder> _configureLoggingDelegate;
+
+        public MaxRequestBufferSizeTests(ITestOutputHelper output) =>_configureLoggingDelegate = builder => builder.AddXunit(output);
 
         public static IEnumerable<object[]> LargeUploadData
         {
@@ -243,13 +249,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        private static IWebHost StartWebHost(long? maxRequestBufferSize,
+        private IWebHost StartWebHost(long? maxRequestBufferSize,
             byte[] expectedBody,
             bool useConnectionAdapter,
             TaskCompletionSource<object> startReadingRequestBody,
             TaskCompletionSource<object> clientFinishedSendingRequestBody)
         {
             var host = new WebHostBuilder()
+                .ConfigureLogging(_configureLoggingDelegate)
                 .UseKestrel(options =>
                 {
                     options.Listen(new IPEndPoint(IPAddress.Loopback, 0), listenOptions =>
@@ -279,7 +286,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .Configure(app => app.Run(async context =>
                 {
-                    await startReadingRequestBody.Task.TimeoutAfter(TimeSpan.FromSeconds(30));
+                    await startReadingRequestBody.Task.TimeoutAfter(TimeSpan.FromSeconds(120));
 
                     var buffer = new byte[expectedBody.Length];
                     var bytesRead = 0;


### PR DESCRIPTION
#1850

Turns out it was just a timeout issue. I suspected when I saw it passing when either increasing the timeout or increasing the client send size from 4KB to something large like 1MB per send (total payload size is 20MB). Also, it only reproed under load (running all tests).

After increasing the timeout, I measure how long it took for the task to be completed and it was around 1 minute. Giving it 2 minutes should be enough margin to avoid future issues.

Since logging helped me debug this, I'd like to leave it enabled in case we run into any issues with these tests again in the future.