### PR TITLE
Fix flakiness in RejectsRequestWithContentLengthAndUpgrade (#1742)

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/UpgradeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/UpgradeTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     "Content-Length: 1",
                     "Connection: Upgrade",
                     "",
-                    "1");
+                    "");
 
                 await connection.ReceiveForcedEnd(
                     "HTTP/1.1 400 Bad Request",


### PR DESCRIPTION
Sorry @halter73 for poaching #1742 from you, but I saw it fail a number of times today and figured the fix was very simple.

Although the stack trace shown when this test fails always comes from a receive call, the problem is really in trying to send that byte in the request body. If the server sends the response and closes the connection while that byte is in still flight, the connection is reset and any subsequent operation on the socket fails.

Since we're only testing that an error is returned when there are payload headers along with a `Connection: upgrade` header, not sending a payload doesn't affect the purpose of this test. We don't even attempt to read it in the app (which never really gets to run anyways).