### PR TITLE
Add support for connection scopes if logging is enabled

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ConnectionLogScope.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ConnectionLogScope.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ConnectionLogScope.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/ConnectionLogScope.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
+{
+    public class ConnectionLogScope : IReadOnlyList<KeyValuePair<string, object>>
+    {
+        private readonly string _connectionId;
+
+        private string _cachedToString;
+
+        public ConnectionLogScope(string connectionId)
+        {
+            _connectionId = connectionId;
+        }
+
+        public KeyValuePair<string, object> this[int index]
+        {
+            get
+            {
+                if (index == 0)
+                {
+                    return new KeyValuePair<string, object>("ConnectionId", _connectionId);
+                }
+
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+
+        public int Count => 1;
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            for (int i = 0; i < Count; ++i)
+            {
+                yield return this[i];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public override string ToString()
+        {
+            if (_cachedToString == null)
+            {
+                _cachedToString = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "ConnectionId:{0}",
+                    _connectionId);
+            }
+
+            return _cachedToString;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
@@ -81,10 +81,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         public void StartRequestProcessing<TContext>(IHttpApplication<TContext> application)
         {
-            _lifetimeTask = ProcessRequestsAsync<TContext>(application);
+            _lifetimeTask = ProcessRequestsAsync(application);
         }
 
-        internal async Task ProcessRequestsAsync<TContext>(IHttpApplication<TContext> application)
+        private async Task ProcessRequestsAsync<TContext>(IHttpApplication<TContext> application)
         {
             using (BeginConnectionScope())
             {

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Core/Internal/FrameConnection.cs
@@ -84,13 +84,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             _lifetimeTask = ProcessRequestsAsync<TContext>(application);
         }
 
-        private async Task ProcessRequestsAsync<TContext>(IHttpApplication<TContext> application)
+        internal async Task ProcessRequestsAsync<TContext>(IHttpApplication<TContext> application)
         {
             using (BeginConnectionScope())
             {
                 try
                 {
-
                     Log.ConnectionStart(ConnectionId);
                     KestrelEventSource.Log.ConnectionStart(this, _context.ConnectionInformation);
 
@@ -465,63 +464,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         {
             if (Log.IsEnabled(LogLevel.Critical))
             {
-                return Log.BeginScope(new ConnectionScope(ConnectionId));
+                return Log.BeginScope(new ConnectionLogScope(ConnectionId));
             }
 
             return null;
-        }
-
-        private class ConnectionScope : IReadOnlyList<KeyValuePair<string, object>>
-        {
-            private readonly string _connectionId;
-
-            private string _cachedToString;
-
-            public ConnectionScope(string connectionId)
-            {
-                _connectionId = connectionId;
-            }
-
-            public KeyValuePair<string, object> this[int index]
-            {
-                get
-                {
-                    if (index == 0)
-                    {
-                        return new KeyValuePair<string, object>("ConnectionId", _connectionId);
-                    }
-
-                    throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-
-            public int Count => 1;
-
-            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
-            {
-                for (int i = 0; i < Count; ++i)
-                {
-                    yield return this[i];
-                }
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-
-            public override string ToString()
-            {
-                if (_cachedToString == null)
-                {
-                    _cachedToString = string.Format(
-                        CultureInfo.InvariantCulture,
-                        "ConnectionId:{0}",
-                        _connectionId);
-                }
-
-                return _cachedToString;
-            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameConnectionTests.cs
@@ -529,5 +529,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(_frameConnection.TimedOut);
             Assert.True(aborted.Wait(TimeSpan.FromSeconds(10)));
         }
+
+        [Fact]
+        public async Task StartRequestProcessingCreatesLogScopeWithConnectionId()
+        {
+            await _frameConnection.ProcessRequestsAsync(new DummyApplication());
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests/FrameConnectionTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal;
@@ -533,7 +534,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task StartRequestProcessingCreatesLogScopeWithConnectionId()
         {
-            await _frameConnection.ProcessRequestsAsync(new DummyApplication());
+            _frameConnection.StartRequestProcessing(new DummyApplication());
+
+            _frameConnection.OnConnectionClosed(ex: null);
+
+            await _frameConnection.StopAsync().TimeoutAfter(TimeSpan.FromSeconds(5));
+            
+            var scopeObjects = ((TestKestrelTrace)_frameConnectionContext.ServiceContext.Log)
+                                    .Logger
+                                    .Scopes
+                                    .OfType<IReadOnlyList<KeyValuePair<string, object>>>()
+                                    .ToList();
+
+            Assert.Equal(1, scopeObjects.Count);
+            var pairs = scopeObjects[0].ToDictionary(p => p.Key, p => p.Value);
+            Assert.True(pairs.ContainsKey("ConnectionId"));
+            Assert.Equal(_frameConnection.ConnectionId, pairs["ConnectionId"]);
         }
     }
 }

--- a/test/shared/TestApplicationErrorLogger.cs
+++ b/test/shared/TestApplicationErrorLogger.cs
@@ -19,6 +19,8 @@ namespace Microsoft.AspNetCore.Testing
 
         public ConcurrentBag<LogMessage> Messages { get; } = new ConcurrentBag<LogMessage>();
 
+        public ConcurrentBag<object> Scopes { get; } = new ConcurrentBag<object>();
+
         public int TotalErrorsLogged => Messages.Count(message => message.LogLevel == LogLevel.Error);
 
         public int CriticalErrorsLogged => Messages.Count(message => message.LogLevel == LogLevel.Critical);
@@ -27,6 +29,7 @@ namespace Microsoft.AspNetCore.Testing
 
         public IDisposable BeginScope<TState>(TState state)
         {
+            Scopes.Add(state);
             return new Disposable(() => { });
         }
 

--- a/test/shared/TestServiceContext.cs
+++ b/test/shared/TestServiceContext.cs
@@ -16,17 +16,9 @@ namespace Microsoft.AspNetCore.Testing
         {
             var logger = new TestApplicationErrorLogger();
             var kestrelTrace = new TestKestrelTrace(logger);
-            LoggerFactory = new LoggerFactory(new[] { new KestrelTestLoggerProvider(logger) });
-            Log = kestrelTrace;
-            ThreadPool = new LoggingThreadPool(Log);
-            SystemClock = new MockSystemClock();
-            DateHeaderValueManager = new DateHeaderValueManager(SystemClock);
-            ConnectionManager = new FrameConnectionManager(Log, ResourceCounter.Unlimited, ResourceCounter.Unlimited);
-            HttpParserFactory = frameAdapter => new HttpParser<FrameAdapter>(frameAdapter.Frame.ServiceContext.Log.IsEnabled(LogLevel.Information));
-            ServerOptions = new KestrelServerOptions
-            {
-                AddServerHeader = false
-            };
+            var loggerFactory = new LoggerFactory(new[] { new KestrelTestLoggerProvider(logger) });
+
+            Initialize(loggerFactory, kestrelTrace);
         }
 
         public TestServiceContext(ILoggerFactory loggerFactory)
@@ -35,6 +27,11 @@ namespace Microsoft.AspNetCore.Testing
         }
 
         public TestServiceContext(ILoggerFactory loggerFactory, IKestrelTrace kestrelTrace)
+        {
+            Initialize(loggerFactory, kestrelTrace);
+        }
+
+        private void Initialize(ILoggerFactory loggerFactory, IKestrelTrace kestrelTrace)
         {
             LoggerFactory = loggerFactory;
             Log = kestrelTrace;
@@ -49,7 +46,7 @@ namespace Microsoft.AspNetCore.Testing
             };
         }
 
-        public ILoggerFactory LoggerFactory { get; }
+        public ILoggerFactory LoggerFactory { get; set; }
 
         public string DateHeaderValue => DateHeaderValueManager.GetDateHeaderValues().String;
     }


### PR DESCRIPTION
- Don't create a scope if logging isn't on
- Copied the pattern we use in Hosting

Questions:
- Should we remove the connection id parameter from the logs? I'd suggesting removing it only if the log message is readable without it. For e.g we could say "Connected started" instead of "Connection {ConnectionId} started" but it doesn't really hurt.

Before:

![image](https://user-images.githubusercontent.com/95136/28052870-4b438602-65c2-11e7-89da-d3b2e98b6c55.png)

After:

![image](https://user-images.githubusercontent.com/95136/28052913-8174bbe2-65c2-11e7-9b2c-2a16352ff260.png)

#640