### PR TITLE
Add String <->AsciiBytes benchmark

### DIFF
--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/AsciiBytesToStringBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/AsciiBytesToStringBenchmark.cs
@@ -1,0 +1,305 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    [Config(typeof(CoreConfig))]
+    public class AsciiBytesToStringBenchmark
+    {
+        private const int Iterations = 5_000;
+
+        private byte[] _asciiBytes;
+        private string _asciiString = new string('\0', 1024);
+
+        [Params(
+            BenchmarkTypes.KeepAlive,
+            BenchmarkTypes.Accept,
+            BenchmarkTypes.UserAgent,
+            BenchmarkTypes.Cookie
+        )]
+        public BenchmarkTypes Type { get; set; }
+
+        [Setup]
+        public void Setup()
+        {
+            switch (Type)
+            {
+                case BenchmarkTypes.KeepAlive:
+                    _asciiBytes = Encoding.ASCII.GetBytes("keep-alive");
+                    break;
+                case BenchmarkTypes.Accept:
+                    _asciiBytes = Encoding.ASCII.GetBytes("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7");
+                    break;
+                case BenchmarkTypes.UserAgent:
+                    _asciiBytes = Encoding.ASCII.GetBytes("Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.99 Safari/537.36");
+                    break;
+                case BenchmarkTypes.Cookie:
+                    _asciiBytes = Encoding.ASCII.GetBytes("prov=20629ccd-8b0f-e8ef-2935-cd26609fc0bc; __qca=P0-1591065732-1479167353442; _ga=GA1.2.1298898376.1479167354; _gat=1; sgt=id=9519gfde_3347_4762_8762_df51458c8ec2; acct=t=why-is-%e0%a5%a7%e0%a5%a8%e0%a5%a9-numeric&s=why-is-%e0%a5%a7%e0%a5%a8%e0%a5%a9-numeric");
+                    break;
+            }
+
+            Verify();
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Iterations)]
+        public unsafe string EncodingAsciiGetChars()
+        {
+            for (uint i = 0; i < Iterations; i++)
+            {
+                fixed (byte* pBytes = &_asciiBytes[0])
+                fixed (char* pString = _asciiString)
+                {
+                    Encoding.ASCII.GetChars(pBytes, _asciiBytes.Length, pString, _asciiBytes.Length);
+                }
+            }
+
+            return _asciiString;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public unsafe byte[] KestrelBytesToString()
+        {
+            for (uint i = 0; i < Iterations; i++)
+            {
+                fixed (byte* pBytes = &_asciiBytes[0])
+                fixed (char* pString = _asciiString)
+                {
+                    TryGetAsciiString(pBytes, pString, _asciiBytes.Length);
+                }
+            }
+
+            return _asciiBytes;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public unsafe byte[] KestrelBytesToStringVectorized()
+        {
+            for (uint i = 0; i < Iterations; i++)
+            {
+                fixed (byte* pBytes = &_asciiBytes[0])
+                fixed (char* pString = _asciiString)
+                {
+                    TryGetAsciiStringVectorized(pBytes, pString, _asciiBytes.Length);
+                }
+            }
+
+            return _asciiBytes;
+        }
+
+        public static unsafe bool TryGetAsciiStringVectorized(byte* input, char* output, int count)
+        {
+            var pInput = input;
+            var pOutput = output;
+            var pEnd = pInput + count;
+
+            bool isValid = true;
+
+            if (Vector.IsHardwareAccelerated && count >= Vector<sbyte>.Count)
+            {
+                goto Vectorized;
+            }
+
+         NonVectorized:
+            while (pInput <= pEnd - sizeof(long))
+            {
+                var in0 = *(long*)(pInput);
+                isValid &= (((in0 - 0x0101010101010101L) | in0) & unchecked((long)0x8080808080808080L)) == 0;
+
+                *(pOutput) = (char)*(pInput);
+                *(pOutput + 1) = (char)*(pInput + 1);
+                *(pOutput + 2) = (char)*(pInput + 2);
+                *(pOutput + 3) = (char)*(pInput + 3);
+                *(pOutput + 4) = (char)*(pInput + 4);
+                *(pOutput + 5) = (char)*(pInput + 5);
+                *(pOutput + 6) = (char)*(pInput + 6);
+                *(pOutput + 7) = (char)*(pInput + 7);
+
+                pInput += sizeof(long);
+                pOutput += sizeof(long);
+            }
+            if (pInput <= pEnd - sizeof(int))
+            {
+                var in0 = *(int*)(pInput);
+                isValid &= (((in0 - 0x01010101) | in0) & unchecked((int)0x80808080)) == 0;
+
+                *(pOutput) = (char)*(pInput);
+                *(pOutput + 1) = (char)*(pInput + 1);
+                *(pOutput + 2) = (char)*(pInput + 2);
+                *(pOutput + 3) = (char)*(pInput + 3);
+
+                pInput += sizeof(int);
+                pOutput += sizeof(int);
+            }
+            if (pInput <= pEnd - sizeof(short))
+            {
+                var in0 = *(short*)(pInput);
+                isValid &= (((short)(in0 - 0x0101) | in0) & unchecked((short)0x8080)) == 0;
+
+                *(pOutput) = (char)*(pInput);
+                *(pOutput + 1) = (char)*(pInput + 1);
+
+                pInput += sizeof(short);
+                pOutput += sizeof(short);
+            }
+            if (pInput < pEnd)
+            {
+                isValid &= *(pInput) > 0;
+                *pOutput = (char)*pInput;
+            }
+
+            return isValid;
+
+        Vectorized:
+            do
+            {
+                var in0 = Unsafe.AsRef<Vector<sbyte>>(pInput);
+                isValid &= Vector.GreaterThanAll(in0, Vector<sbyte>.Zero);
+
+                Vector.Widen(in0, out Unsafe.AsRef<Vector<short>>(pOutput), out Unsafe.AsRef<Vector<short>>(pOutput + Vector<short>.Count));
+
+                pInput += Vector<sbyte>.Count;
+                pOutput += Vector<sbyte>.Count;
+            } while (pInput < pEnd - Vector<sbyte>.Count);
+
+            goto NonVectorized;
+        }
+
+        public static unsafe bool TryGetAsciiString(byte* input, char* output, int count)
+        {
+            var i = 0;
+            sbyte* signedInput = (sbyte*)input;
+
+            bool isValid = true;
+            while (i < count - 11)
+            {
+                isValid = isValid && *signedInput > 0 && *(signedInput + 1) > 0 && *(signedInput + 2) > 0 &&
+                    *(signedInput + 3) > 0 && *(signedInput + 4) > 0 && *(signedInput + 5) > 0 && *(signedInput + 6) > 0 &&
+                    *(signedInput + 7) > 0 && *(signedInput + 8) > 0 && *(signedInput + 9) > 0 && *(signedInput + 10) > 0 &&
+                    *(signedInput + 11) > 0;
+
+                i += 12;
+                *(output) = (char)*(signedInput);
+                *(output + 1) = (char)*(signedInput + 1);
+                *(output + 2) = (char)*(signedInput + 2);
+                *(output + 3) = (char)*(signedInput + 3);
+                *(output + 4) = (char)*(signedInput + 4);
+                *(output + 5) = (char)*(signedInput + 5);
+                *(output + 6) = (char)*(signedInput + 6);
+                *(output + 7) = (char)*(signedInput + 7);
+                *(output + 8) = (char)*(signedInput + 8);
+                *(output + 9) = (char)*(signedInput + 9);
+                *(output + 10) = (char)*(signedInput + 10);
+                *(output + 11) = (char)*(signedInput + 11);
+                output += 12;
+                signedInput += 12;
+            }
+            if (i < count - 5)
+            {
+                isValid = isValid && *signedInput > 0 && *(signedInput + 1) > 0 && *(signedInput + 2) > 0 &&
+                    *(signedInput + 3) > 0 && *(signedInput + 4) > 0 && *(signedInput + 5) > 0;
+
+                i += 6;
+                *(output) = (char)*(signedInput);
+                *(output + 1) = (char)*(signedInput + 1);
+                *(output + 2) = (char)*(signedInput + 2);
+                *(output + 3) = (char)*(signedInput + 3);
+                *(output + 4) = (char)*(signedInput + 4);
+                *(output + 5) = (char)*(signedInput + 5);
+                output += 6;
+                signedInput += 6;
+            }
+            if (i < count - 3)
+            {
+                isValid = isValid && *signedInput > 0 && *(signedInput + 1) > 0 && *(signedInput + 2) > 0 &&
+                    *(signedInput + 3) > 0;
+
+                i += 4;
+                *(output) = (char)*(signedInput);
+                *(output + 1) = (char)*(signedInput + 1);
+                *(output + 2) = (char)*(signedInput + 2);
+                *(output + 3) = (char)*(signedInput + 3);
+                output += 4;
+                signedInput += 4;
+            }
+
+            while (i < count)
+            {
+                isValid = isValid && *signedInput > 0;
+
+                i++;
+                *output = (char)*signedInput;
+                output++;
+                signedInput++;
+            }
+
+            return isValid;
+        }
+
+        private void Verify()
+        {
+            var verification = EncodingAsciiGetChars().Substring(0, _asciiBytes.Length);
+
+            BlankString('\0');
+            EncodingAsciiGetChars();
+            VerifyString(verification, '\0');
+            BlankString(' ');
+            EncodingAsciiGetChars();
+            VerifyString(verification, ' ');
+
+            BlankString('\0');
+            KestrelBytesToString();
+            VerifyString(verification, '\0');
+            BlankString(' ');
+            KestrelBytesToString();
+            VerifyString(verification, ' ');
+
+            BlankString('\0');
+            KestrelBytesToStringVectorized();
+            VerifyString(verification, '\0');
+            BlankString(' ');
+            KestrelBytesToStringVectorized();
+            VerifyString(verification, ' ');
+        }
+
+        private unsafe void BlankString(char ch)
+        {
+            fixed (char* pString = _asciiString)
+            {
+                for (var i = 0; i < _asciiString.Length; i++)
+                {
+                    *(pString + i) = ch;
+                }
+            }
+        }
+
+        private unsafe void VerifyString(string verification, char ch)
+        {
+            fixed (char* pString = _asciiString)
+            {
+                var i = 0;
+                for (; i < verification.Length; i++)
+                {
+                    if (*(pString + i) != verification[i]) throw new Exception($"Verify failed, saw {(int)*(pString + i)} expected {(int)verification[i]} at position {i}");
+                }
+                for (; i < _asciiString.Length; i++)
+                {
+                    if (*(pString + i) != ch) throw new Exception($"Verify failed, saw {(int)*(pString + i)} expected {(int)ch} at position {i}"); ;
+                }
+            }
+        }
+
+        public enum BenchmarkTypes
+        {
+            KeepAlive,
+            Accept,
+            UserAgent,
+            Cookie,
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.Kestrel.Performance/StringToAsciiBytesBenchmark.cs
+++ b/test/Microsoft.AspNetCore.Server.Kestrel.Performance/StringToAsciiBytesBenchmark.cs
@@ -1,0 +1,335 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    [Config(typeof(CoreConfig))]
+    public class StringToAsciiBytesBenchmark
+    {
+        private const int Iterations = 5_000;
+
+        private byte[] _asciiBytes = new byte[1024];
+        private string _asciiString;
+
+        [Params(
+            BenchmarkTypes.Chunked,
+            BenchmarkTypes.TextPlain,
+            BenchmarkTypes.Date,
+            BenchmarkTypes.Cookie
+        )]
+        public BenchmarkTypes Type { get; set; }
+
+        [Setup]
+        public void Setup()
+        {
+            switch (Type)
+            {
+                case BenchmarkTypes.Chunked:
+                    _asciiString = "Chunked";
+                    break;
+                case BenchmarkTypes.TextPlain:
+                    _asciiString = "text/plain";
+                    break;
+                case BenchmarkTypes.Date:
+                    _asciiString = "Wed, 22 Jun 2016 20:08:29 GMT";
+                    break;
+                case BenchmarkTypes.Cookie:
+                    _asciiString = "prov=20629ccd-8b0f-e8ef-2935-cd26609fc0bc; __qca=P0-1591065732-1479167353442; _ga=GA1.2.1298898376.1479167354; _gat=1; sgt=id=9519gfde_3347_4762_8762_df51458c8ec2; acct=t=why-is-%e0%a5%a7%e0%a5%a8%e0%a5%a9-numeric&s=why-is-%e0%a5%a7%e0%a5%a8%e0%a5%a9-numeric";
+                    break;
+            }
+
+            Verify();
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Iterations)]
+        public byte[] EncodingAsciiGetBytes()
+        {
+            for (uint i = 0; i < Iterations; i++)
+            {
+                Encoding.ASCII.GetBytes(_asciiString, 0, _asciiString.Length, _asciiBytes, 0);
+            }
+
+            return _asciiBytes;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public unsafe byte[] KestrelAsciiCharsToBytes()
+        {
+            for (uint i = 0; i < Iterations; i++)
+            {
+                fixed (byte* pBytes = &_asciiBytes[0])
+                fixed (char* pString = _asciiString)
+                {
+                    KestrelAsciiCharsToBytes(pString, pBytes, _asciiString.Length);
+                }
+            }
+
+            return _asciiBytes;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public unsafe byte[] KestrelAsciiCharsVectorized()
+        {
+            for (uint i = 0; i < Iterations; i++)
+            {
+                fixed (byte* pBytes = &_asciiBytes[0])
+                fixed (char* pString = _asciiString)
+                {
+                    KestrelAsciiCharsVectorized(pString, pBytes, _asciiString.Length);
+                }
+            }
+
+            return _asciiBytes;
+        }
+
+        private unsafe static void KestrelAsciiCharsVectorized(char* input, byte* output, int length)
+        {
+            // Note: Not BIGENDIAN or check for non-ascii
+            const int Shift16Shift24 = (1 << 16) | (1 << 24);
+            const int Shift8Identity = (1 << 8) | (1);
+
+            // Encode as bytes upto the first non-ASCII byte and return count encoded
+            int i = 0;
+            int ulongDoubleCount = 0;
+            // Use Intrinsic switch
+            if (IntPtr.Size == 8) // 64 bit
+            {
+                if (length < 4) goto trailing;
+
+                int unaligned = (int)(((ulong)input) & 0x7) >> 1;
+                // Unaligned chars
+                for (; i < unaligned; i++)
+                {
+                    char ch = *(input + i);
+                    *(output + i) = (byte)ch; // Cast convert
+                }
+
+                // Aligned
+                ulongDoubleCount = (length - i) & ~0x7;
+
+                if (Vector.IsHardwareAccelerated && i + Vector<byte>.Count <= ulongDoubleCount)
+                {
+                    goto vectorized;
+                }
+
+            nonvectorized:
+                for (; i < ulongDoubleCount; i += 8)
+                {
+                    ulong inputUlong0 = *(ulong*)(input + i);
+                    ulong inputUlong1 = *(ulong*)(input + i + 4);
+                    // Pack 16 ASCII chars into 16 bytes
+                    *(uint*)(output + i) =
+                        ((uint)((inputUlong0 * Shift16Shift24) >> 24) & 0xffff) |
+                        ((uint)((inputUlong0 * Shift8Identity) >> 24) & 0xffff0000);
+                    *(uint*)(output + i + 4) =
+                        ((uint)((inputUlong1 * Shift16Shift24) >> 24) & 0xffff) |
+                        ((uint)((inputUlong1 * Shift8Identity) >> 24) & 0xffff0000);
+                }
+                if (length - 4 > i)
+                {
+                    ulong inputUlong = *(ulong*)(input + i);
+                    // Pack 8 ASCII chars into 8 bytes
+                    *(uint*)(output + i) =
+                        ((uint)((inputUlong * Shift16Shift24) >> 24) & 0xffff) |
+                        ((uint)((inputUlong * Shift8Identity) >> 24) & 0xffff0000);
+                    i += 4;
+                }
+            trailing:
+                for (; i < length; i++)
+                {
+                    char ch = *(input + i);
+                    *(output + i) = (byte)ch; // Cast convert
+                }
+                return;
+            vectorized:
+                do
+                {
+                    Unsafe.AsRef<Vector<byte>>(output + i) = Vector.Narrow(Unsafe.AsRef<Vector<ushort>>(input + i), Unsafe.AsRef<Vector<ushort>>(input + i + Vector<ushort>.Count));
+                    i += Vector<byte>.Count;
+                } while (i + Vector<byte>.Count < ulongDoubleCount);
+
+                goto nonvectorized;
+            }
+            else // 32 bit
+            {
+                // Unaligned chars
+                if ((unchecked((int)input) & 0x2) != 0)
+                {
+                    char ch = *input;
+                    i = 1;
+                    *(output) = (byte)ch; // Cast convert
+                }
+
+                // Aligned
+                int uintCount = (length - i) & ~0x3;
+                for (; i < uintCount; i += 4)
+                {
+                    uint inputUint0 = *(uint*)(input + i);
+                    uint inputUint1 = *(uint*)(input + i + 2);
+                    // Pack 4 ASCII chars into 4 bytes
+                    *(ushort*)(output + i) = (ushort)(inputUint0 | (inputUint0 >> 8));
+                    *(ushort*)(output + i + 2) = (ushort)(inputUint1 | (inputUint1 >> 8));
+                }
+                if (length - 1 > i)
+                {
+                    uint inputUint = *(uint*)(input + i);
+                    // Pack 2 ASCII chars into 2 bytes
+                    *(ushort*)(output + i) = (ushort)(inputUint | (inputUint >> 8));
+                    i += 2;
+                }
+
+                if (i < length)
+                {
+                    char ch = *(input + i);
+                    *(output + i) = (byte)ch; // Cast convert
+                }
+            }
+        }
+
+        private unsafe static void KestrelAsciiCharsToBytes(char* input, byte* output, int length)
+        {
+            // Note: Not BIGENDIAN or check for non-ascii
+            const int Shift16Shift24 = (1 << 16) | (1 << 24);
+            const int Shift8Identity = (1 << 8) | (1);
+
+            // Encode as bytes upto the first non-ASCII byte and return count encoded
+            int i = 0;
+            // Use Intrinsic switch
+            if (IntPtr.Size == 8) // 64 bit
+            {
+                if (length < 4) goto trailing;
+
+                int unaligned = (int)(((ulong)input) & 0x7) >> 1;
+                // Unaligned chars
+                for (; i < unaligned; i++)
+                {
+                    char ch = *(input + i);
+                    *(output + i) = (byte)ch; // Cast convert
+                }
+
+                // Aligned
+                int ulongDoubleCount = (length - i) & ~0x7;
+                for (; i < ulongDoubleCount; i += 8)
+                {
+                    ulong inputUlong0 = *(ulong*)(input + i);
+                    ulong inputUlong1 = *(ulong*)(input + i + 4);
+                    // Pack 16 ASCII chars into 16 bytes
+                    *(uint*)(output + i) =
+                        ((uint)((inputUlong0 * Shift16Shift24) >> 24) & 0xffff) |
+                        ((uint)((inputUlong0 * Shift8Identity) >> 24) & 0xffff0000);
+                    *(uint*)(output + i + 4) =
+                        ((uint)((inputUlong1 * Shift16Shift24) >> 24) & 0xffff) |
+                        ((uint)((inputUlong1 * Shift8Identity) >> 24) & 0xffff0000);
+                }
+                if (length - 4 > i)
+                {
+                    ulong inputUlong = *(ulong*)(input + i);
+                    // Pack 8 ASCII chars into 8 bytes
+                    *(uint*)(output + i) =
+                        ((uint)((inputUlong * Shift16Shift24) >> 24) & 0xffff) |
+                        ((uint)((inputUlong * Shift8Identity) >> 24) & 0xffff0000);
+                    i += 4;
+                }
+
+            trailing:
+                for (; i < length; i++)
+                {
+                    char ch = *(input + i);
+                    *(output + i) = (byte)ch; // Cast convert
+                }
+            }
+            else // 32 bit
+            {
+                // Unaligned chars
+                if ((unchecked((int)input) & 0x2) != 0)
+                {
+                    char ch = *input;
+                    i = 1;
+                    *(output) = (byte)ch; // Cast convert
+                }
+
+                // Aligned
+                int uintCount = (length - i) & ~0x3;
+                for (; i < uintCount; i += 4)
+                {
+                    uint inputUint0 = *(uint*)(input + i);
+                    uint inputUint1 = *(uint*)(input + i + 2);
+                    // Pack 4 ASCII chars into 4 bytes
+                    *(ushort*)(output + i) = (ushort)(inputUint0 | (inputUint0 >> 8));
+                    *(ushort*)(output + i + 2) = (ushort)(inputUint1 | (inputUint1 >> 8));
+                }
+                if (length - 1 > i)
+                {
+                    uint inputUint = *(uint*)(input + i);
+                    // Pack 2 ASCII chars into 2 bytes
+                    *(ushort*)(output + i) = (ushort)(inputUint | (inputUint >> 8));
+                    i += 2;
+                }
+
+                if (i < length)
+                {
+                    char ch = *(input + i);
+                    *(output + i) = (byte)ch; // Cast convert
+                    i = length;
+                }
+            }
+        }
+
+        private void Verify()
+        {
+            var verification0 = _asciiString + new string('\0', _asciiBytes.Length - _asciiString.Length);
+            var verificationSpace = _asciiString + new string(' ', _asciiBytes.Length - _asciiString.Length);
+
+            BlankArray('\0');
+            EncodingAsciiGetBytes();
+            VerifyString(verification0);
+            BlankArray(' ');
+            EncodingAsciiGetBytes();
+            VerifyString(verificationSpace);
+
+            BlankArray('\0');
+            KestrelAsciiCharsToBytes();
+            VerifyString(verification0);
+            BlankArray(' ');
+            KestrelAsciiCharsToBytes();
+            VerifyString(verificationSpace);
+
+            BlankArray('\0');
+            KestrelAsciiCharsVectorized();
+            VerifyString(verification0);
+            BlankArray(' ');
+            KestrelAsciiCharsVectorized();
+            VerifyString(verificationSpace);
+        }
+
+        private void BlankArray(char ch)
+        {
+            for (var i = 0; i < _asciiBytes.Length; i++)
+            {
+                _asciiBytes[i] = (byte)ch;
+            }
+        }
+
+        private unsafe void VerifyString(string verification)
+        {
+            for (var i = 0; i < verification.Length; i++)
+            {
+                if (_asciiBytes[i] != verification[i]) throw new Exception($"Verify failed, saw {(int)_asciiBytes[i]} expected {(int)verification[i]} at position {i}");
+            }
+        }
+
+        public enum BenchmarkTypes
+        {
+            Chunked,
+            TextPlain,
+            Date,
+            Cookie,
+        }
+    }
+}


### PR DESCRIPTION
```
                          Method |      Type |        Mean |         Op/s | Scaled | Allocated |
-------------------------------- |---------- |------------ |------------- |------- |---------- |
           EncodingAsciiGetChars | KeepAlive |  15.6145 ns |  64043091.00 |   1.00 |       0 B |
            KestrelBytesToString | KeepAlive |   8.1755 ns | 122316731.05 |   0.52 |       0 B |
 KestrelBytesToStringVectorCheck | KeepAlive |   7.0620 ns | 141603067.12 |   0.45 |       0 B |
  KestrelBytesToStringVectorized | KeepAlive |   8.3682 ns | 119500235.42 |   0.54 |       0 B |
 
           EncodingAsciiGetChars |    Accept |  72.8455 ns |  13727682.94 |   1.00 |       0 B |
            KestrelBytesToString |    Accept |  43.0555 ns |  23225841.09 |   0.59 |       0 B |
 KestrelBytesToStringVectorCheck |    Accept |  30.9370 ns |  32323725.96 |   0.42 |       0 B |
  KestrelBytesToStringVectorized |    Accept | 104.5153 ns |   9567979.19 |   1.43 |       0 B |
 
           EncodingAsciiGetChars | UserAgent |  88.5750 ns |  11289873.68 |   1.00 |       0 B |
            KestrelBytesToString | UserAgent |  52.7406 ns |  18960734.80 |   0.60 |       0 B |
 KestrelBytesToStringVectorCheck | UserAgent |  34.9497 ns |  28612540.72 |   0.39 |       0 B |
  KestrelBytesToStringVectorized | UserAgent | 154.0508 ns |   6491366.52 |   1.74 |       0 B |
 
           EncodingAsciiGetChars |    Cookie | 186.4685 ns |   5362835.98 |   1.00 |       0 B |
            KestrelBytesToString |    Cookie | 118.7070 ns |   8424105.05 |   0.64 |       0 B |
 KestrelBytesToStringVectorCheck |    Cookie |  76.9637 ns |  12993136.64 |   0.41 |       0 B |
  KestrelBytesToStringVectorized |    Cookie | 403.4181 ns |   2478818.04 |   2.16 |       0 B |
```

Raised issue for Vectorization not working https://github.com/dotnet/coreclr/issues/13024