### PR TITLE
Disable test ConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate on Linux

### DIFF
--- a/test/Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Kestrel.FunctionalTests/ResponseTests.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -2443,7 +2444,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "Flaky test (https://github.com/aspnet/KestrelHttpServer/issues/1955)")]
         public async Task ConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate()
         {
             var chunkSize = 64 * 1024;


### PR DESCRIPTION
Flaky test: https://github.com/aspnet/KestrelHttpServer/issues/1955

I haven't been able to repro the failure yet, so I'm disabling the test for now to reduce CI pain.