### PR TITLE
Upgrade to xunit 2.3.0-beta3

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,7 +10,7 @@
     <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
     <MicrosoftNETCoreCompilersVersion>2.6.0-rdonly-ref-61915-01</MicrosoftNETCoreCompilersVersion>
-    <TestSdkVersion>15.3.0-*</TestSdkVersion>
-    <XunitVersion>2.3.0-beta2-*</XunitVersion>
+    <TestSdkVersion>15.3.0</TestSdkVersion>
+    <XunitVersion>2.3.0-beta3-build3705</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/test/Kestrel.Core.Tests/FrameHeadersTests.cs
+++ b/test/Kestrel.Core.Tests/FrameHeadersTests.cs
@@ -217,11 +217,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void ValidContentLengthsAccepted()
         {
-            ValidContentLengthsAccepted(new FrameRequestHeaders());
-            ValidContentLengthsAccepted(new FrameResponseHeaders());
+            ValidContentLengthsAcceptedImpl(new FrameRequestHeaders());
+            ValidContentLengthsAcceptedImpl(new FrameResponseHeaders());
         }
 
-        private static void ValidContentLengthsAccepted(FrameHeaders frameHeaders)
+        private static void ValidContentLengthsAcceptedImpl(FrameHeaders frameHeaders)
         {
             IDictionary<string, StringValues> headers = frameHeaders;
 
@@ -252,11 +252,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void InvalidContentLengthsRejected()
         {
-            InvalidContentLengthsRejected(new FrameRequestHeaders());
-            InvalidContentLengthsRejected(new FrameResponseHeaders());
+            InvalidContentLengthsRejectedImpl(new FrameRequestHeaders());
+            InvalidContentLengthsRejectedImpl(new FrameResponseHeaders());
         }
 
-        private static void InvalidContentLengthsRejected(FrameHeaders frameHeaders)
+        private static void InvalidContentLengthsRejectedImpl(FrameHeaders frameHeaders)
         {
             IDictionary<string, StringValues> headers = frameHeaders;
 

--- a/test/Kestrel.Core.Tests/FrameTests.cs
+++ b/test/Kestrel.Core.Tests/FrameTests.cs
@@ -590,7 +590,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await _input.Writer.WriteAsync(data);
 
             _frame.Stop();
-            Assert.IsNotType(typeof(Task<Task>), requestProcessingTask);
+            Assert.IsNotType<Task<Task>>(requestProcessingTask);
 
             await requestProcessingTask.TimeoutAfter(TimeSpan.FromSeconds(10));
             _input.Writer.Complete();
@@ -812,9 +812,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 .Select(i => $"Header-{startAt + i}: value{startAt + i}\r\n"));
         }
 
-        public static IEnumerable<object> RequestLineValidData => HttpParsingData.RequestLineValidData;
+        public static IEnumerable<object[]> RequestLineValidData => HttpParsingData.RequestLineValidData;
 
-        public static IEnumerable<object> RequestLineDotSegmentData => HttpParsingData.RequestLineDotSegmentData;
+        public static IEnumerable<object[]> RequestLineDotSegmentData => HttpParsingData.RequestLineDotSegmentData;
 
         public static TheoryData<string> TargetWithEncodedNullCharData
         {

--- a/test/Kestrel.Core.Tests/HttpParserTests.cs
+++ b/test/Kestrel.Core.Tests/HttpParserTests.cs
@@ -419,7 +419,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         private IHttpParser<RequestHandler> CreateParser(IKestrelTrace log) => new HttpParser<RequestHandler>(log.IsEnabled(LogLevel.Information));
 
-        public static IEnumerable<string[]> RequestLineValidData => HttpParsingData.RequestLineValidData;
+        public static IEnumerable<object[]> RequestLineValidData => HttpParsingData.RequestLineValidData;
 
         public static IEnumerable<object[]> RequestLineIncompleteData => HttpParsingData.RequestLineIncompleteData.Select(requestLine => new[] { requestLine });
 

--- a/test/Kestrel.Core.Tests/KestrelServerTests.cs
+++ b/test/Kestrel.Core.Tests/KestrelServerTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 StartDummyApplication(server);
 
                 var warning = testLogger.Messages.Single(log => log.LogLevel == LogLevel.Warning);
-                Assert.True(warning.Message.Contains("Overriding"));
+                Assert.Contains("Overriding", warning.Message);
             }
         }
 
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         private static KestrelServer CreateServer(KestrelServerOptions options, ILogger testLogger)
         {
-            return new KestrelServer(Options.Create(options), new MockTransportFactory(), new LoggerFactory(new [] { new KestrelTestLoggerProvider(testLogger)} ));
+            return new KestrelServer(Options.Create(options), new MockTransportFactory(), new LoggerFactory(new[] { new KestrelTestLoggerProvider(testLogger) }));
         }
 
         private static void StartDummyApplication(IServer server)


### PR DESCRIPTION
Fixes the issue with Test Explorer not navigating to tests in source.

Require few changes to code because xunit.analyzers keeps finding more ways to correct us.

cc @mikeharder 