### PR TITLE
React to changes in BenchmarkDotNet 0.10.9

### DIFF
--- a/benchmarks/Kestrel.Performance/FrameFeatureCollection.cs
+++ b/benchmarks/Kestrel.Performance/FrameFeatureCollection.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             _frame = new Frame<object>(application: null, frameContext: frameContext);
         }
 
-        [GlobalSetup]
+        [IterationSetup]
         public void Setup()
         {
             _collection = _frame;

--- a/benchmarks/Kestrel.Performance/FrameFeatureCollection.cs
+++ b/benchmarks/Kestrel.Performance/FrameFeatureCollection.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             _frame = new Frame<object>(application: null, frameContext: frameContext);
         }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             _collection = _frame;

--- a/benchmarks/Kestrel.Performance/FrameParsingOverheadBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/FrameParsingOverheadBenchmark.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         public ReadableBuffer _buffer;
         public Frame<object> _frame;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             var serviceContext = new ServiceContext

--- a/benchmarks/Kestrel.Performance/FrameParsingOverheadBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/FrameParsingOverheadBenchmark.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         public ReadableBuffer _buffer;
         public Frame<object> _frame;
 
-        [GlobalSetup]
+        [IterationSetup]
         public void Setup()
         {
             var serviceContext = new ServiceContext

--- a/benchmarks/Kestrel.Performance/FrameWritingBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/FrameWritingBenchmark.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         [Params(Startup.None, Startup.Sync, Startup.Async)]
         public Startup OnStarting { get; set; }
 
-        [GlobalSetup]
+        [IterationSetup]
         public void Setup()
         {
             _frame.Reset();
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             return frame;
         }
 
-        [GlobalCleanup]
+        [IterationCleanup]
         public void Cleanup()
         {
             var reader = _outputPipe.Reader;

--- a/benchmarks/Kestrel.Performance/FrameWritingBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/FrameWritingBenchmark.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         [Params(Startup.None, Startup.Sync, Startup.Async)]
         public Startup OnStarting { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             _frame.Reset();
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             return frame;
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             var reader = _outputPipe.Reader;

--- a/benchmarks/Kestrel.Performance/Kestrel.Performance.csproj
+++ b/benchmarks/Kestrel.Performance/Kestrel.Performance.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.9" NoWarn="KRB4002" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/Kestrel.Performance/PipeThroughputBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/PipeThroughputBenchmark.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         private IPipe _pipe;
         private PipeFactory _pipelineFactory;
 
-        [GlobalSetup]
+        [IterationSetup]
         public void Setup()
         {
             _pipelineFactory = new PipeFactory();

--- a/benchmarks/Kestrel.Performance/PipeThroughputBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/PipeThroughputBenchmark.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         private IPipe _pipe;
         private PipeFactory _pipelineFactory;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             _pipelineFactory = new PipeFactory();

--- a/benchmarks/Kestrel.Performance/RequestParsingBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/RequestParsingBenchmark.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         public PipeFactory PipeFactory { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             PipeFactory = new PipeFactory();

--- a/benchmarks/Kestrel.Performance/RequestParsingBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/RequestParsingBenchmark.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
         public PipeFactory PipeFactory { get; set; }
 
-        [GlobalSetup]
+        [IterationSetup]
         public void Setup()
         {
             PipeFactory = new PipeFactory();

--- a/benchmarks/Kestrel.Performance/ResponseHeaderCollectionBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/ResponseHeaderCollectionBenchmark.cs
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             }
         }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             var serviceContext = new ServiceContext

--- a/benchmarks/Kestrel.Performance/ResponseHeaderCollectionBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/ResponseHeaderCollectionBenchmark.cs
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             }
         }
 
-        [GlobalSetup]
+        [IterationSetup]
         public void Setup()
         {
             var serviceContext = new ServiceContext

--- a/benchmarks/Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             return _frame.WriteAsync(new ArraySegment<byte>(_helloWorldPayload), default(CancellationToken));
         }
 
-        [GlobalSetup]
+        [IterationSetup]
         public void Setup()
         {
             var pipeFactory = new PipeFactory();

--- a/benchmarks/Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/ResponseHeadersWritingBenchmark.cs
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             return _frame.WriteAsync(new ArraySegment<byte>(_helloWorldPayload), default(CancellationToken));
         }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             var pipeFactory = new PipeFactory();


### PR DESCRIPTION
setup/cleanup are obsolete in favor of globalsetup/globalcleanup and iterationsetup/cleanup https://github.com/dotnet/BenchmarkDotNet/issues/325

cc @halter73 