### PR TITLE
Less StringValue struct copies for header existence checks

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Frame.cs
+++ b/src/Kestrel.Core/Internal/Http/Frame.cs
@@ -881,7 +881,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             var hasConnection = responseHeaders.HasConnection;
             var connectionOptions = FrameHeaders.ParseConnection(responseHeaders.HeaderConnection);
             var hasTransferEncoding = responseHeaders.HasTransferEncoding;
-            var transferCoding = FrameHeaders.GetFinalTransferCoding(responseHeaders.HeaderTransferEncoding);
 
             if (_keepAlive && hasConnection)
             {
@@ -893,7 +892,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             // chunked is applied to a response payload body, the sender MUST either
             // apply chunked as the final transfer coding or terminate the message
             // by closing the connection.
-            if (hasTransferEncoding && transferCoding != TransferCoding.Chunked)
+            if (hasTransferEncoding && FrameHeaders.GetFinalTransferCoding(responseHeaders.HeaderTransferEncoding) != TransferCoding.Chunked)
             {
                 _keepAlive = false;
             }

--- a/src/Kestrel.Core/Internal/Http/FrameHeaders.Generated.cs
+++ b/src/Kestrel.Core/Internal/Http/FrameHeaders.Generated.cs
@@ -16,6 +16,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         private long _bits = 0;
         private HeaderReferences _headers;
+
+        public bool HasConnection => ((_bits & 2L) != 0 && _headers._Connection.Count != 0) ? true : false;
+        public bool HasTransferEncoding => ((_bits & 64L) != 0 && _headers._TransferEncoding.Count != 0) ? true : false;
         
         public StringValues HeaderCacheControl
         {
@@ -4793,6 +4796,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         private long _bits = 0;
         private HeaderReferences _headers;
+
+        public bool HasConnection => ((_bits & 2L) != 0 && _headers._Connection.Count != 0) ? true : false;
+        public bool HasDate => ((_bits & 4L) != 0 && _headers._Date.Count != 0) ? true : false;
+        public bool HasTransferEncoding => ((_bits & 64L) != 0 && _headers._TransferEncoding.Count != 0) ? true : false;
+        public bool HasServer => ((_bits & 33554432L) != 0 && _headers._Server.Count != 0) ? true : false;
         
         public StringValues HeaderCacheControl
         {

--- a/src/Kestrel.Core/Internal/Http/FrameResponseHeaders.cs
+++ b/src/Kestrel.Core/Internal/Http/FrameResponseHeaders.cs
@@ -16,14 +16,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private static readonly byte[] _CrLf = new[] { (byte)'\r', (byte)'\n' };
         private static readonly byte[] _colonSpace = new[] { (byte)':', (byte)' ' };
 
-        public bool HasConnection => HeaderConnection.Count != 0;
-
-        public bool HasTransferEncoding => HeaderTransferEncoding.Count != 0;
-
-        public bool HasServer => HeaderServer.Count != 0;
-
-        public bool HasDate => HeaderDate.Count != 0;
-
         public Enumerator GetEnumerator()
         {
             return new Enumerator(this);

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -623,14 +623,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             var hasConnection = responseHeaders.HasConnection;
             var connectionOptions = FrameHeaders.ParseConnection(responseHeaders.HeaderConnection);
             var hasTransferEncoding = responseHeaders.HasTransferEncoding;
-            var transferCoding = FrameHeaders.GetFinalTransferCoding(responseHeaders.HeaderTransferEncoding);
 
             // https://tools.ietf.org/html/rfc7230#section-3.3.1
             // If any transfer coding other than
             // chunked is applied to a response payload body, the sender MUST either
             // apply chunked as the final transfer coding or terminate the message
             // by closing the connection.
-            if (hasTransferEncoding && transferCoding == TransferCoding.Chunked)
+            if (hasTransferEncoding && FrameHeaders.GetFinalTransferCoding(responseHeaders.HeaderTransferEncoding) == TransferCoding.Chunked)
             {
                 // TODO: this is an error in HTTP/2
             }

--- a/tools/CodeGenerator/KnownHeaders.cs
+++ b/tools/CodeGenerator/KnownHeaders.cs
@@ -68,6 +68,7 @@ namespace CodeGenerator
             public byte[] Bytes => Encoding.ASCII.GetBytes($"\r\n{Name}: ");
             public int BytesOffset { get; set; }
             public int BytesCount { get; set; }
+            public bool ExistenceCheck { get; set; }
             public bool EnhancedSetter { get; set; }
             public bool PrimaryHeader { get; set; }
             public string TestBit() => $"(_bits & {1L << Index}L) != 0";
@@ -168,6 +169,11 @@ namespace CodeGenerator
                 "Access-Control-Request-Method",
                 "Access-Control-Request-Headers",
             };
+            var requestHeadersExistence = new[]
+            {
+                "Connection",
+                "Transfer-Encoding"
+            };
             var requestHeaders = commonHeaders.Concat(new[]
             {
                 "Accept",
@@ -197,7 +203,8 @@ namespace CodeGenerator
             {
                 Name = header,
                 Index = index,
-                PrimaryHeader = requestPrimaryHeaders.Contains(header)
+                PrimaryHeader = requestPrimaryHeaders.Contains(header),
+                ExistenceCheck = requestHeadersExistence.Contains(header)
             })
             .Concat(new[] { new KnownHeader
             {
@@ -209,6 +216,13 @@ namespace CodeGenerator
             Debug.Assert(requestHeaders.Length <= 64);
             Debug.Assert(requestHeaders.Max(x => x.Index) <= 62);
 
+            var responseHeadersExistence = new[]
+            {
+                "Connection",
+                "Server",
+                "Date",
+                "Transfer-Encoding"
+            };
             var enhancedHeaders = new[]
             {
                 "Connection",
@@ -245,6 +259,7 @@ namespace CodeGenerator
                 Name = header,
                 Index = index,
                 EnhancedSetter = enhancedHeaders.Contains(header),
+                ExistenceCheck = responseHeadersExistence.Contains(header),
                 PrimaryHeader = responsePrimaryHeaders.Contains(header)
             })
             .Concat(new[] { new KnownHeader
@@ -310,6 +325,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         private long _bits = 0;
         private HeaderReferences _headers;
+{Each(loop.Headers.Where(header => header.ExistenceCheck), header => $@"
+        public bool Has{header.Identifier} => ({header.TestBit()} && _headers._{header.Identifier}.Count != 0) ? true : false;")}
         {Each(loop.Headers, header => $@"
         public StringValues Header{header.Identifier}
         {{{(header.Identifier == "ContentLength" ? $@"


### PR DESCRIPTION
Less StringValue struct copies for header existence checks
- check struct in-place

Lazy calc transfer coding
- calc once existence is confirmed rather than always (since existence is checked anyway)

