### PR TITLE
Reset StatusCode & ReasonPhrase directly

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Frame.cs
+++ b/src/Kestrel.Core/Internal/Http/Frame.cs
@@ -347,8 +347,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _absoluteRequestTarget = null;
             QueryString = null;
             _httpVersion = Http.HttpVersion.Unknown;
-            StatusCode = StatusCodes.Status200OK;
-            ReasonPhrase = null;
+            _statusCode = StatusCodes.Status200OK;
+            _reasonPhrase = null;
 
             RemoteIpAddress = RemoteEndPoint?.Address;
             RemotePort = RemoteEndPoint?.Port ?? 0;

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -256,8 +256,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             _requestTargetForm = HttpRequestTarget.Unknown;
             _absoluteRequestTarget = null;
             QueryString = null;
-            StatusCode = StatusCodes.Status200OK;
-            ReasonPhrase = null;
+            _statusCode = StatusCodes.Status200OK;
+            _reasonPhrase = null;
 
             RemoteIpAddress = RemoteEndPoint?.Address;
             RemotePort = RemoteEndPoint?.Port ?? 0;


### PR DESCRIPTION
Reset goes via setters for StatusCode and ReasonPhrase which check HasResponseStarted and throw an exception if so.

These methods don't inline and there is no point in checking the response state (as its just been reset)

Resolves https://github.com/aspnet/KestrelHttpServer/issues/2024