### PR TITLE
Use enum for method rather than string compares

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Frame.FeatureCollection.cs
+++ b/src/Kestrel.Core/Internal/Http/Frame.FeatureCollection.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
@@ -93,8 +94,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         string IHttpRequestFeature.Method
         {
-            get => Method;
-            set => Method = value;
+            get
+            {
+                if (_customMethod != null)
+                {
+                    return _customMethod;
+                }
+
+                _customMethod = HttpUtilities.MethodToString(Method);
+                return _customMethod;
+            }
+            set
+            {
+                _customMethod = HttpUtilities.GetKnownMethod(value, out var method) ? null : value.ToUpperInvariant();
+                Method = method;
+            }
         }
 
         string IHttpRequestFeature.PathBase

--- a/src/Kestrel.Core/Internal/Http/HttpMethod.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpMethod.cs
@@ -16,5 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         Options,
 
         Custom,
+
+        Unknown = byte.MaxValue
     }
 }

--- a/src/Kestrel.Core/Internal/Http/MessageBody.cs
+++ b/src/Kestrel.Core/Internal/Http/MessageBody.cs
@@ -7,6 +7,7 @@ using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
@@ -362,14 +363,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             // Avoid slowing down most common case
-            if (!object.ReferenceEquals(context.Method, HttpMethods.Get))
+            if (context.Method != HttpMethod.Get)
             {
                 // If we got here, request contains no Content-Length or Transfer-Encoding header.
                 // Reject with 411 Length Required.
-                if (HttpMethods.IsPost(context.Method) || HttpMethods.IsPut(context.Method))
+                if (context.Method == HttpMethod.Post || context.Method == HttpMethod.Put)
                 {
                     var requestRejectionReason = httpVersion == HttpVersion.Http11 ? RequestRejectionReason.LengthRequired : RequestRejectionReason.LengthRequiredHttp10;
-                    context.ThrowRequestRejected(requestRejectionReason, context.Method);
+                    context.ThrowRequestRejected(requestRejectionReason, ((IHttpRequestFeature)context).Method);
                 }
             }
 

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.FeatureCollection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.FeatureCollection.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
@@ -92,8 +93,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         string IHttpRequestFeature.Method
         {
-            get => Method;
-            set => Method = value;
+            get
+            {
+                if (CustomMethod != null)
+                {
+                    return CustomMethod;
+                }
+
+                CustomMethod = HttpUtilities.MethodToString(Method);
+                return CustomMethod;
+            }
+            set
+            {
+                CustomMethod = HttpUtilities.GetKnownMethod(value, out var method) ? null : value.ToUpperInvariant();
+                Method = method;
+            }
         }
 
         string IHttpRequestFeature.PathBase

--- a/src/Kestrel.Core/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2StreamOfT.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Protocols;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
@@ -26,7 +27,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             try
             {
-                Method = RequestHeaders[":method"];
+                var methodString = RequestHeaders[":method"].ToString();
+                CustomMethod = HttpUtilities.GetKnownMethod(methodString, out var method) ? null : methodString.ToUpperInvariant();
+                Method = method;
+
                 Scheme = RequestHeaders[":scheme"];
 
                 var path = RequestHeaders[":path"].ToString();

--- a/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
@@ -142,6 +142,112 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
         }
 
+        /// <summary>
+        /// Parses string <paramref name="value"/> for a known HTTP method.
+        /// </summary>
+        /// <remarks>
+        /// A "known HTTP method" can be an HTTP method name defined in the HTTP/1.1 RFC.
+        /// The Known Methods (CONNECT, DELETE, GET, HEAD, PATCH, POST, PUT, OPTIONS, TRACE)
+        /// </remarks>
+        /// <returns><c>true</c> if the input matches a known string, <c>false</c> otherwise.</returns>
+        public static bool GetKnownMethod(string value, out HttpMethod method)
+        {
+            // Only called if user code overrides and sets the Method on IHttpRequestFeature
+            // This should be a rare occurance so not performance sensitive also needs to validate inputs
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var length = value.Length;
+            if (length == 0)
+            {
+                throw new ArgumentException(nameof(value));
+            }
+
+            // Clear the 6th bit to get Upper case char. We are testing direct equality 
+            // so doesn't matter that it would garble chars outside [A-Za-z] range
+            var firstUppercaseChar = (char)(value[0] & ~0x20);
+            if (length == 3)
+            {
+                if (firstUppercaseChar == 'G' && string.Equals(value, "GET", StringComparison.OrdinalIgnoreCase))
+                {
+                    method = HttpMethod.Get;
+                    return true;
+                }
+                if (firstUppercaseChar == 'P' && string.Equals(value, "PUT", StringComparison.OrdinalIgnoreCase))
+                {
+                    method = HttpMethod.Put;
+                    return true;
+                }
+
+                method = HttpMethod.Custom;
+                return false;
+            }
+            if (length == 4)
+            {
+                if (firstUppercaseChar == 'H' && string.Equals(value, "HEAD", StringComparison.OrdinalIgnoreCase))
+                {
+                    method = HttpMethod.Head;
+                    return true;
+                }
+                if (firstUppercaseChar == 'P' && string.Equals(value, "POST", StringComparison.OrdinalIgnoreCase))
+                {
+                    method = HttpMethod.Post;
+                    return true;
+                }
+
+                method = HttpMethod.Custom;
+                return false;
+            }
+            if (length == 5)
+            {
+                if (firstUppercaseChar == 'T' && string.Equals(value, "TRACE", StringComparison.OrdinalIgnoreCase))
+                {
+                    method = HttpMethod.Trace;
+                    return true;
+                }
+                if (firstUppercaseChar == 'P' && string.Equals(value, "PATCH", StringComparison.OrdinalIgnoreCase))
+                {
+                    method = HttpMethod.Patch;
+                    return true;
+                }
+
+                method = HttpMethod.Custom;
+                return false;
+            }
+            if (length == 6)
+            {
+                if (firstUppercaseChar == 'D' && string.Equals(value, "DELETE", StringComparison.OrdinalIgnoreCase))
+                {
+                    method = HttpMethod.Delete;
+                    return true;
+                }
+
+                method = HttpMethod.Custom;
+                return false;
+            }
+            if (length == 7)
+            {
+                if (firstUppercaseChar == 'C' && string.Equals(value, "CONNECT", StringComparison.OrdinalIgnoreCase))
+                {
+                    method = HttpMethod.Connect;
+                    return true;
+                }
+                if (firstUppercaseChar == 'O' && string.Equals(value, "OPTIONS", StringComparison.OrdinalIgnoreCase))
+                {
+                    method = HttpMethod.Options;
+                    return true;
+                }
+
+                method = HttpMethod.Custom;
+                return false;
+            }
+
+            method = HttpMethod.Custom;
+            return false;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe HttpMethod GetKnownMethod(byte* data, int length, out int methodLength)
         {

--- a/test/Kestrel.Core.Tests/FrameTests.cs
+++ b/test/Kestrel.Core.Tests/FrameTests.cs
@@ -356,7 +356,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _transport.Input.Advance(_consumed, _examined);
 
             Assert.True(returnValue);
-            Assert.Equal(expectedMethod, _frame.Method);
+            Assert.Equal(expectedMethod, ((IHttpRequestFeature)_frame).Method);
             Assert.Equal(expectedRawTarget, _frame.RawTarget);
             Assert.Equal(expectedDecodedPath, _frame.Path);
             Assert.Equal(expectedQueryString, _frame.QueryString);
@@ -801,6 +801,51 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             // Assert
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ((IHttpMaxRequestBodySizeFeature)_frame).MaxRequestBodySize = -1);
             Assert.StartsWith(CoreStrings.NonNegativeNumberOrNullRequired, ex.Message);
+        }
+
+        [Theory]
+        [InlineData("g", HttpMethod.Custom, "G")]
+        [InlineData("G", HttpMethod.Custom, "G")]
+        [InlineData("get", HttpMethod.Get, "GET")]
+        [InlineData("GET", HttpMethod.Get, "GET")]
+        [InlineData("put", HttpMethod.Put, "PUT")]
+        [InlineData("PUT", HttpMethod.Put, "PUT")]
+        [InlineData("post", HttpMethod.Post, "POST")]
+        [InlineData("POST", HttpMethod.Post, "POST")]
+        [InlineData("head", HttpMethod.Head, "HEAD")]
+        [InlineData("HEAD", HttpMethod.Head, "HEAD")]
+        [InlineData("patch", HttpMethod.Patch, "PATCH")]
+        [InlineData("PATCH", HttpMethod.Patch, "PATCH")]
+        [InlineData("trace", HttpMethod.Trace, "TRACE")]
+        [InlineData("TRACE", HttpMethod.Trace, "TRACE")]
+        [InlineData("delete", HttpMethod.Delete, "DELETE")]
+        [InlineData("DELETE", HttpMethod.Delete, "DELETE")]
+        [InlineData("options", HttpMethod.Options, "OPTIONS")]
+        [InlineData("OPTIONS", HttpMethod.Options, "OPTIONS")]
+        [InlineData("connect", HttpMethod.Connect, "CONNECT")]
+        [InlineData("CONNECT", HttpMethod.Connect, "CONNECT")]
+        [InlineData("unknown", HttpMethod.Custom, "UNKNOWN")]
+        [InlineData("UNKNOWN", HttpMethod.Custom, "UNKNOWN")]
+        public void RequestFeatureMethodSetsFrameEnum(string method, HttpMethod expectedEnum, string expectedString)
+        {
+            using (var input = new TestInput())
+            {
+                ((IHttpRequestFeature)input.Frame).Method = method;
+
+                Assert.Equal(expectedEnum, input.Frame.Method);
+                Assert.Equal(expectedString, ((IHttpRequestFeature)input.Frame).Method);
+            }
+        }
+
+        [Theory]
+        [InlineData(null, typeof(ArgumentNullException))]
+        [InlineData("", typeof(ArgumentException))]
+        public void BlankMethodThrows(string method, Type exceptionType)
+        {
+            using (var input = new TestInput())
+            {
+                Assert.Throws(exceptionType, () => ((IHttpRequestFeature) input.Frame).Method = method);
+            }
         }
 
         private static async Task WaitForCondition(TimeSpan timeout, Func<bool> condition)

--- a/test/Kestrel.Core.Tests/MessageBodyTests.cs
+++ b/test/Kestrel.Core.Tests/MessageBodyTests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                input.Frame.Method = method;
+                ((IHttpRequestFeature)input.Frame).Method = method;
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
                     MessageBody.For(HttpVersion.Http11, new FrameRequestHeaders(), input.Frame));
 
@@ -354,7 +354,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                input.Frame.Method = method;
+                ((IHttpRequestFeature)input.Frame).Method = method;
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
                     MessageBody.For(HttpVersion.Http10, new FrameRequestHeaders(), input.Frame));
 


### PR DESCRIPTION
For GET method `IsHead` test is performed on the string `Method` which since `GET` isn't reference equal to `HEAD` drops through to `String.Equals` -> `OrdinalIgnoreCaseComparer.Equals`

![](https://aoa.blob.core.windows.net/aspnet/ishead.png)

However the Parser starts with it as an Enum, which then gets converted to a string; so it can just be tested with the enum.

Http/2 change isn't so good; but ti gets method from header collection, so that probably needs a more general revisit

Resolves https://github.com/aspnet/KestrelHttpServer/issues/2020