### PR TITLE
Updating to new toolset compiler.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="2.6.0-rdonly-ref-62101-05" PrivateAssets="All">
+    <PackageReference Include="Microsoft.NETCore.Compilers" Version="2.6.0-rdonly-ref-62106-01" PrivateAssets="All">
       <!--
         Suppresses the warning about having an explicit package version in this repo.
         We are okay with this for now as the experimental version of the compiler is unique to Kestrel (for now).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="2.6.0-rdonly-ref-61915-01" PrivateAssets="All">
+    <PackageReference Include="Microsoft.NETCore.Compilers" Version="2.6.0-rdonly-ref-62101-05" PrivateAssets="All">
       <!--
         Suppresses the warning about having an explicit package version in this repo.
         We are okay with this for now as the experimental version of the compiler is unique to Kestrel (for now).

--- a/src/Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpParser.cs
@@ -72,13 +72,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private unsafe void ParseRequestLine(TRequestHandler handler, byte* data, int length)
         {
             int offset;
-            Span<byte> customMethod = default(Span<byte>);
             // Get Method and set the offset
             var method = HttpUtilities.GetKnownMethod(data, length, out offset);
-            if (method == HttpMethod.Custom)
-            {
-                customMethod = GetUnknownMethod(data, length, out offset);
-            }
+
+            Span<byte> customMethod = method == HttpMethod.Custom ?
+                GetUnknownMethod(data, length, out offset) :
+                default;
 
             // Skip space
             offset++;


### PR DESCRIPTION
Version 2.6.0-rdonly-ref-62106-01

Now includes:
- support for stackallocated spans and 
- escape analysis to make sure spans that refer to local data do not outlive the referenced data.

The corresponding VSIX is at 
https://dotnet.myget.org/feed/roslyn/package/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7/2.6.0.6210601
