### PR TITLE
[PoC] Implement IHttpSendFileFeature

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Http1Connection.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1Connection.cs
@@ -402,7 +402,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         protected override void OnReset()
         {
             FastFeatureSet(typeof(IHttpUpgradeFeature), this);
-
+#if NETCOREAPP2_1
+            FastFeatureSet(typeof(IHttpSendFileFeature), this);
+#endif
             _requestTimedOut = false;
             _requestTargetForm = HttpRequestTarget.Unknown;
             _absoluteRequestTarget = null;

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.SendFileFeature.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.SendFileFeature.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
+{
+    public partial class HttpProtocol : IHttpSendFileFeature
+    {
+        async Task IHttpSendFileFeature.SendFileAsync(string path, long offset, long? count, CancellationToken cancellationToken)
+        {
+            var contentLength = ResponseHeaders.ContentLength;
+            if (contentLength.HasValue && count.HasValue && contentLength.Value < _responseBytesWritten + count.Value)
+            {
+                // throw
+            }
+
+            using (var fileStream = new FileStream(path,
+                                 FileMode.Open,
+                                 FileAccess.Read,
+                                 FileShare.ReadWrite,
+                                 bufferSize: 1, // Don't create internal buffer
+                                 FileOptions.Asynchronous | FileOptions.SequentialScan))
+            {
+                if (offset > 0)
+                {
+                    fileStream.Seek(offset, SeekOrigin.Begin);
+                }
+
+                // Write the filestream directly into the output
+                await Output.WriteAsync(fileStream, count ?? long.MaxValue, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/Kestrel.Core/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Kestrel.Core/Internal/Http/IHttpOutputProducer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     {
         void Abort(Exception error);
         Task WriteAsync<T>(Action<PipeWriter, T> callback, T state);
+        Task WriteAsync(Stream stream, long? count, CancellationToken cancellationToken);
         Task FlushAsync(CancellationToken cancellationToken);
         Task Write100ContinueAsync(CancellationToken cancellationToken);
         void WriteResponseHeaders(int statusCode, string ReasonPhrase, HttpResponseHeaders responseHeaders);

--- a/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,6 +53,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         public void WriteResponseHeaders(int statusCode, string ReasonPhrase, HttpResponseHeaders responseHeaders)
         {
             _frameWriter.WriteResponseHeaders(_streamId, statusCode, responseHeaders);
+        }
+
+        public Task WriteAsync(Stream stream, long? count, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
With "Add Memory-based Stream overloads to coreclr" https://github.com/dotnet/coreclr/pull/13769

Can read directly from the `FileStream` into the `Pipeline` output buffer to implement a lower copy SendFile than is done by [`StreamCopyOperation.CopyToAsync`](https://github.com/aspnet/HttpAbstractions/blob/1e8a22dae3dd2828bcaca936821be8efa47824e2/src/Microsoft.AspNetCore.Http.Extensions/StreamCopyOperation.cs#L36-L84)

i.e. Read Stream -> array -> Write Stream -> copy to Pipeline

May want to bypass the feature if the Transport has something https://github.com/aspnet/KestrelHttpServer/issues/1673

/cc @halter73 @davidfowl @stephentoub @tmds @Tratcher