### PR TITLE
Updating toolset compiler

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="2.6.0-rdonly-ref-62106-01" PrivateAssets="All">
+    <PackageReference Include="Microsoft.NETCore.Compilers" Version="2.6.0-rdonly-ref-62111-06" PrivateAssets="All">
       <!--
         Suppresses the warning about having an explicit package version in this repo.
         We are okay with this for now as the experimental version of the compiler is unique to Kestrel (for now).


### PR DESCRIPTION
- minor bug fixes
- recent merge from Roslyn master   
- should be running on 2.0 

The corresponding VSIX is:  
https://dotnet.myget.org/F/roslyn/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7-2.6.0.6211106.vsix

