### PR TITLE
Re-enable TestKeepAliveTimeout.

### DIFF
--- a/test/Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
+++ b/test/Kestrel.FunctionalTests/KeepAliveTimeoutTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
+using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
@@ -20,10 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         private static readonly TimeSpan LongDelay = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan ShortDelay = TimeSpan.FromSeconds(LongDelay.TotalSeconds / 10);
 
-        // This test is particularly flaky on some teamcity agents, so skip there for now.
-        // https://github.com/aspnet/KestrelHttpServer/issues/1684
-        [ConditionalFact]
-        [EnvironmentVariableSkipCondition("TEAMCITY_VERSION", null)]
+        [Fact]
         public Task TestKeepAliveTimeout()
         {
             // Delays in these tests cannot be much longer than expected.


### PR DESCRIPTION
Re-enabling as requested by @muratg in https://github.com/aspnet/KestrelHttpServer/issues/1684#issuecomment-327314332. Will keep an eye on the CI to check if the flakiness comes back.