### PR TITLE
HTTP/2: fix reading DATA frames with maximum length

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Data.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Data.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             var padded = padLength != null;
 
-            Length = MinAllowedMaxFrameSize - HeaderLength;
+            Length = MinAllowedMaxFrameSize;
             Type = Http2FrameType.DATA;
             DataFlags = padded ? Http2DataFrameFlags.PADDED : Http2DataFrameFlags.NONE;
             StreamId = streamId;

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private const int StreamIdOffset = 5;
         private const int PayloadOffset = 9;
 
-        private readonly byte[] _data = new byte[MinAllowedMaxFrameSize];
+        private readonly byte[] _data = new byte[HeaderLength + MinAllowedMaxFrameSize];
 
         public ArraySegment<byte> Raw => new ArraySegment<byte>(_data, 0, HeaderLength + Length);
 

--- a/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
@@ -35,6 +35,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             lock (_writeLock)
             {
+                if (_completed)
+                {
+                    return;
+                }
+
                 _completed = true;
                 _outputReader.CancelPendingRead();
                 _outputWriter.Complete(ex);


### PR DESCRIPTION
Miscalculated lengths led to bugs.