### PR TITLE
HTTP/2: close connection with COMPRESSION_ERROR on incomplete header block

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/HPack/HPackDecodingException.cs
+++ b/src/Kestrel.Core/Internal/Http2/HPack/HPackDecodingException.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack
+{
+    public class HPackDecodingException : Exception
+    {
+        public HPackDecodingException(string message)
+            : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
http://httpwg.org/specs/rfc7540.html#rfc.section.4.3

> A receiver MUST terminate the connection with a connection error (Section 5.4.1) of type COMPRESSION_ERROR if it does not decompress a header block.