### PR TITLE
HTTP/2: connection error when receiving frames disallowed by stream states

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Http1OutputProducer.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1OutputProducer.cs
@@ -14,7 +14,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     public class Http1OutputProducer : IHttpOutputProducer
     {
-        private static readonly ArraySegment<byte> _emptyData = new ArraySegment<byte>(new byte[0]);
         private static readonly ArraySegment<byte> _continueBytes = new ArraySegment<byte>(Encoding.ASCII.GetBytes("HTTP/1.1 100 Continue\r\n\r\n"));
         private static readonly byte[] _bytesHttpVersion11 = Encoding.ASCII.GetBytes("HTTP/1.1 ");
         private static readonly byte[] _bytesEndHeaders = Encoding.ASCII.GetBytes("\r\n\r\n");
@@ -71,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return WriteAsync(_emptyData, cancellationToken);
+            return WriteAsync(Constants.EmptyData, cancellationToken);
         }
 
         public void Write<T>(Action<WritableBuffer, T> callback, T state)

--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -286,7 +286,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             _currentHeadersStream = new Http2Stream<TContext>(application, new Http2StreamContext
             {
                 ConnectionId = ConnectionId,
-                StreamId =  _incomingFrame.StreamId,
+                StreamId = _incomingFrame.StreamId,
                 ServiceContext = _context.ServiceContext,
                 ConnectionFeatures = _context.ConnectionFeatures,
                 PipeFactory = _context.PipeFactory,
@@ -454,16 +454,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 throw new Http2ConnectionErrorException(Http2ErrorCode.FRAME_SIZE_ERROR);
             }
 
-            if (_incomingFrame.StreamId == 0)
+            if (_incomingFrame.StreamId > _highestOpenedStreamId)
             {
-                if (_incomingFrame.WindowUpdateSizeIncrement == 0)
+                throw new Http2ConnectionErrorException(Http2ErrorCode.PROTOCOL_ERROR);
+            }
+
+            if (_incomingFrame.WindowUpdateSizeIncrement == 0)
+            {
+                if (_incomingFrame.StreamId == 0)
                 {
                     throw new Http2ConnectionErrorException(Http2ErrorCode.PROTOCOL_ERROR);
                 }
-            }
-            else
-            {
-                if (_incomingFrame.WindowUpdateSizeIncrement == 0)
+                else
                 {
                     return _frameWriter.WriteRstStreamAsync(_incomingFrame.StreamId, Http2ErrorCode.PROTOCOL_ERROR);
                 }

--- a/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
@@ -7,16 +7,13 @@ using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack;
-using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     public class Http2FrameWriter : IHttp2FrameWriter
     {
-        private static readonly ArraySegment<byte> _emptyData = new ArraySegment<byte>(new byte[0]);
-
         private readonly Http2Frame _outgoingFrame = new Http2Frame();
         private readonly object _writeLock = new object();
         private readonly HPackEncoder _hpackEncoder = new HPackEncoder();
@@ -48,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public Task FlushAsync(CancellationToken cancellationToken)
         {
-            return WriteAsync(_emptyData);
+            return WriteAsync(Constants.EmptyData);
         }
 
         public Task Write100ContinueAsync(int streamId)

--- a/src/Kestrel.Core/Internal/Http2/Http2MessageBody.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2MessageBody.cs
@@ -29,9 +29,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             HttpRequestHeaders headers,
             Http2Stream context)
         {
-            if (!context.ExpectData)
+            if (context.EndStreamReceived)
             {
-                return MessageBody.ZeroContentLengthClose;
+                return ZeroContentLengthClose;
             }
 
             return new ForHttp2(context);

--- a/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
@@ -6,13 +6,12 @@ using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     public class Http2OutputProducer : IHttpOutputProducer
     {
-        private static readonly ArraySegment<byte> _emptyData = new ArraySegment<byte>(new byte[0]);
-
         private readonly int _streamId;
         private readonly IHttp2FrameWriter _frameWriter;
 
@@ -47,7 +46,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public Task WriteStreamSuffixAsync(CancellationToken cancellationToken)
         {
-            return _frameWriter.WriteDataAsync(_streamId, _emptyData, endStream: true, cancellationToken: cancellationToken);
+            return _frameWriter.WriteDataAsync(_streamId, Constants.EmptyData, endStream: true, cancellationToken: cancellationToken);
         }
 
         public void WriteResponseHeaders(int statusCode, string ReasonPhrase, HttpResponseHeaders responseHeaders)

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public int StreamId => _context.StreamId;
 
-        public bool HasReceivedEndStream { get; private set; }
+        public bool EndStreamReceived { get; private set; }
 
         protected IHttp2StreamLifetimeHandler StreamLifetimeHandler => _context.StreamLifetimeHandler;
 
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
                 if (endStream)
                 {
-                    HasReceivedEndStream = true;
+                    EndStreamReceived = true;
                     RequestBodyPipe.Writer.Complete();
                 }
             }

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -28,8 +28,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         protected IHttp2StreamLifetimeHandler StreamLifetimeHandler => _context.StreamLifetimeHandler;
 
-        public bool ExpectData { get; set; }
-
         public override bool IsUpgradableRequest => false;
 
         protected override void OnReset()

--- a/src/Kestrel.Core/Internal/Infrastructure/Constants.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/Constants.cs
@@ -32,5 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public const string ServerName = "Kestrel";
 
         public static readonly TimeSpan RequestBodyDrainTimeout = TimeSpan.FromSeconds(5);
+
+        public static readonly ArraySegment<byte> EmptyData = new ArraySegment<byte>(new byte[0]);
     }
 }

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -1076,6 +1076,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task WINDOW_UPDATE_Received_StreamIdle_ConnectionError()
+        {
+            await InitializeConnectionAsync(_waitForAbortApplication);
+
+            await SendWindowUpdateAsync(1, sizeIncrement: 1);
+
+            await WaitForConnectionErrorAsync(expectedLastStreamId: 0, expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
         public async Task WINDOW_UPDATE_Received_OnStream_SizeIncrementZero_StreamError()
         {
             await InitializeConnectionAsync(_waitForAbortApplication);

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -809,6 +809,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForConnectionErrorAsync(expectedLastStreamId: 0, expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR, ignoreNonGoAwayFrames: false);
         }
 
+        [Fact]
+        public async Task RST_STREAM_Received_StreamIdle_ConnectionError()
+        {
+            await InitializeConnectionAsync(_noopApplication);
+
+            await SendRstStreamAsync(1);
+
+            await WaitForConnectionErrorAsync(expectedLastStreamId: 0, expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR, ignoreNonGoAwayFrames: false);
+        }
+
         [Theory]
         [InlineData(3)]
         [InlineData(5)]

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -467,15 +467,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public async Task DATA_Received_StreamIdle_StreamError()
+        public async Task DATA_Received_StreamIdle_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
 
             await SendDataAsync(1, _helloWorldBytes, endStream: false);
 
-            await WaitForStreamErrorAsync(expectedStreamId: 1, expectedErrorCode: Http2ErrorCode.STREAM_CLOSED, ignoreNonRstStreamFrames: false);
-
-            await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
+            await WaitForConnectionErrorAsync(expectedLastStreamId: 0, expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR, ignoreNonGoAwayFrames: false);
         }
 
         [Fact]


### PR DESCRIPTION
http://httpwg.org/specs/rfc7540.html#rfc.section.5.1

> idle:
> ...
> Receiving any frame other than HEADERS or PRIORITY on a stream in this state MUST be treated as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.