### PR TITLE
HTTP/2: do not ACK PING frames received with ACK set

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -413,6 +413,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 throw new Http2ConnectionErrorException(Http2ErrorCode.FRAME_SIZE_ERROR);
             }
 
+            if ((_incomingFrame.PingFlags & Http2PingFrameFlags.ACK) == Http2PingFrameFlags.ACK)
+            {
+                return Task.CompletedTask;
+            }
+
             return _frameWriter.WritePingAsync(Http2PingFrameFlags.ACK, _incomingFrame.Payload);
         }
 


### PR DESCRIPTION
http://httpwg.org/specs/rfc7540.html#rfc.section.6.7

> The PING frame defines the following flags:
> 
> ACK (0x1): When set, bit 0 indicates that this PING frame is a PING response. An endpoint MUST set this flag in PING responses. **An endpoint MUST NOT respond to PING frames containing this flag.**