### PR TITLE
HTTP/2: close connection on PING frame with non-zero stream ID

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -384,6 +384,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 throw new Http2ConnectionErrorException(Http2ErrorCode.PROTOCOL_ERROR);
             }
 
+            if (_incomingFrame.StreamId != 0)
+            {
+                throw new Http2ConnectionErrorException(Http2ErrorCode.PROTOCOL_ERROR);
+            }
+
             if (_incomingFrame.Length != 8)
             {
                 throw new Http2ConnectionErrorException(Http2ErrorCode.FRAME_SIZE_ERROR);

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -877,6 +877,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForConnectionErrorAsync(expectedLastStreamId: 0, expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR, ignoreNonGoAwayFrames: false);
         }
 
+        [Fact]
+        public async Task PING_Received_StreamIdNotZero_ConnectionError()
+        {
+            await InitializeConnectionAsync(_noopApplication);
+
+            await SendPingWithInvalidStreamIdAsync(streamId: 1);
+
+            await WaitForConnectionErrorAsync(expectedLastStreamId: 0, expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR, ignoreNonGoAwayFrames: false);
+        }
+
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
@@ -1377,6 +1387,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var pingFrame = new Http2Frame();
             pingFrame.PreparePing(Http2PingFrameFlags.NONE);
             pingFrame.Length = length;
+            return SendAsync(pingFrame.Raw);
+        }
+
+        private Task SendPingWithInvalidStreamIdAsync(int streamId)
+        {
+            Assert.NotEqual(0, streamId);
+
+            var pingFrame = new Http2Frame();
+            pingFrame.PreparePing(Http2PingFrameFlags.NONE);
+            pingFrame.StreamId = streamId;
             return SendAsync(pingFrame.Raw);
         }
 


### PR DESCRIPTION
http://httpwg.org/specs/rfc7540.html#rfc.section.6.7

> PING frames are not associated with any individual stream. If a PING frame is received with a stream identifier field value other than 0x0, the recipient MUST respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.