### PR TITLE
HTTP/2: close the connection with PROTOCOL_ERROR when a PUSH_PROMISE frame is received

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -208,6 +208,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     return ProcessRstStreamFrameAsync();
                 case Http2FrameType.SETTINGS:
                     return ProcessSettingsFrameAsync();
+                case Http2FrameType.PUSH_PROMISE:
+                    throw new Http2ConnectionErrorException(Http2ErrorCode.PROTOCOL_ERROR);
                 case Http2FrameType.PING:
                     return ProcessPingFrameAsync();
                 case Http2FrameType.GOAWAY:

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -853,6 +853,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task PUSH_PROMISE_Received_ConnectionError()
+        {
+            await InitializeConnectionAsync(_noopApplication);
+
+            await SendPushPromiseFrameAsync();
+
+            await WaitForConnectionErrorAsync(expectedLastStreamId: 0, expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
         public async Task PING_Received_Sends_ACK()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1277,6 +1287,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             frame.Payload[4] = (byte)(value >> 8);
             frame.Payload[5] = (byte)value;
 
+            return SendAsync(frame.Raw);
+        }
+
+        private Task SendPushPromiseFrameAsync()
+        {
+            var frame = new Http2Frame();
+            frame.Length = 0;
+            frame.Type = Http2FrameType.PUSH_PROMISE;
+            frame.StreamId = 1;
             return SendAsync(frame.Raw);
         }
 


### PR DESCRIPTION
http://httpwg.org/specs/rfc7540.html#rfc.section.8.2

> A client cannot push. Thus, servers MUST treat the receipt of a PUSH_PROMISE frame as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.