### PR TITLE
HTTP/2: close connection with PROTOCOL_ERROR when an unknown frame type is interleaved with headers

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -216,9 +216,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     return ProcessWindowUpdateFrameAsync();
                 case Http2FrameType.CONTINUATION:
                     return ProcessContinuationFrameAsync<TContext>(application);
+                default:
+                    return ProcessUnknownFrameAsync();
             }
-
-            return Task.CompletedTask;
         }
 
         private Task ProcessDataFrameAsync()
@@ -447,6 +447,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 _lastStreamId = _currentHeadersStream.StreamId;
                 _ = _currentHeadersStream.ProcessRequestsAsync();
                 _currentHeadersStream = null;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private Task ProcessUnknownFrameAsync()
+        {
+            if (_currentHeadersStream != null)
+            {
+                throw new Http2ConnectionErrorException(Http2ErrorCode.PROTOCOL_ERROR);
             }
 
             return Task.CompletedTask;

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -1053,6 +1053,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task UnknownFrameType_Received_Ignored()
+        {
+            await InitializeConnectionAsync(_noopApplication);
+
+            await SendUnknownFrameTypeAsync(streamId: 1);
+
+            // Check that the connection is still alive
+            await SendPingAsync();
+            await ExpectAsync(Http2FrameType.PING,
+                withLength: 8,
+                withFlags: (byte)Http2PingFrameFlags.ACK,
+                withStreamId: 0);
+
+            await StopConnectionAsync(0, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
+        public async Task UnknownFrameType_Received_InterleavedWithHeaders_ConnectionError()
+        {
+            await InitializeConnectionAsync(_noopApplication);
+
+            await SendHeadersAsync(1, Http2HeadersFrameFlags.NONE, _browserRequestHeaders);
+            await SendUnknownFrameTypeAsync(streamId: 1);
+
+            await WaitForConnectionErrorAsync(expectedLastStreamId: 0, expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
         public async Task ConnectionError_AbortsAllStreams()
         {
             await InitializeConnectionAsync(_waitForAbortApplication);
@@ -1429,6 +1457,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var frame = new Http2Frame();
             frame.PrepareWindowUpdate(streamId, sizeIncrement);
             frame.Length = length;
+            return SendAsync(frame.Raw);
+        }
+
+        private Task SendUnknownFrameTypeAsync(int streamId)
+        {
+            var frame = new Http2Frame();
+            frame.StreamId = streamId;
+            frame.Type = (Http2FrameType)42;
+            frame.Length = 0;
             return SendAsync(frame.Raw);
         }
 


### PR DESCRIPTION
http://httpwg.org/specs/rfc7540.html#rfc.section.5.5

> However, extension frames that appear in the middle of a header block (Section 4.3) are not permitted; these MUST be treated as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.