### PR TITLE
HTTP/2: close connection with PROTOCOL_ERROR when receiving GOAWAY frame with non-zero stream ID

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -406,6 +406,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 throw new Http2ConnectionErrorException(Http2ErrorCode.PROTOCOL_ERROR);
             }
 
+            if (_incomingFrame.StreamId != 0)
+            {
+                throw new Http2ConnectionErrorException(Http2ErrorCode.PROTOCOL_ERROR);
+            }
+
             Stop();
             return Task.CompletedTask;
         }

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -942,6 +942,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task GOAWAY_Received_StreamIdNonZero_ConnectionError()
+        {
+            await InitializeConnectionAsync(_noopApplication);
+
+            await SendInvalidGoAwayFrameAsync();
+
+            await WaitForConnectionErrorAsync(expectedLastStreamId: 0, expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
         public async Task GOAWAY_Received_InterleavedWithHeaders_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
@@ -1481,6 +1491,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var frame = new Http2Frame();
             frame.PrepareGoAway(0, Http2ErrorCode.NO_ERROR);
+            return SendAsync(frame.Raw);
+        }
+
+        private Task SendInvalidGoAwayFrameAsync()
+        {
+            var frame = new Http2Frame();
+            frame.PrepareGoAway(0, Http2ErrorCode.NO_ERROR);
+            frame.StreamId = 1;
             return SendAsync(frame.Raw);
         }
 


### PR DESCRIPTION
http://httpwg.org/specs/rfc7540.html#rfc.section.6.8

> An endpoint MUST treat a GOAWAY frame with a stream identifier other than 0x0 as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.