### PR TITLE
Fix flaky MaxRequestBodySizeTest

### DIFF
--- a/test/Kestrel.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/test/Kestrel.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         "Host:",
                         "Content-Length: 1",
                         "",
-                        "A");
+                        "");
                     await connection.ReceiveForcedEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",


### PR DESCRIPTION
- Don't attempt to send any data after the request might already be rejected.

#1926