### PR TITLE
HTTP/2: validate request headers prior to starting new stream

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             Path = 0x4,
             Scheme = 0x8,
             Status = 0x10,
-            Unknown = -1
+            Unknown = 0x40000000
         }
 
         public static byte[] ClientPreface { get; } = Encoding.ASCII.GetBytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");

--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -18,7 +18,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     public class Http2Connection : ITimeoutControl, IHttp2StreamLifetimeHandler, IHttpHeadersHandler
     {
+        private enum RequestHeaderParsingState
+        {
+            Ready,
+            PseudoHeaderFields,
+            Headers,
+            Trailers
+        }
+
+        [Flags]
+        private enum PseudoHeaderFields
+        {
+            None = 0x0,
+            Authority = 0x1,
+            Method = 0x2,
+            Path = 0x4,
+            Scheme = 0x8,
+            Status = 0x10,
+            Unknown = -1
+        }
+
         public static byte[] ClientPreface { get; } = Encoding.ASCII.GetBytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
+
+        private static readonly PseudoHeaderFields _mandatoryRequestPseudoHeaderFields =
+            PseudoHeaderFields.Method | PseudoHeaderFields.Path | PseudoHeaderFields.Scheme;
 
         private readonly Http2ConnectionContext _context;
         private readonly Http2FrameWriter _frameWriter;
@@ -30,6 +53,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private readonly Http2Frame _incomingFrame = new Http2Frame();
 
         private Http2Stream _currentHeadersStream;
+        private RequestHeaderParsingState _requestHeaderParsingState;
+        private PseudoHeaderFields _parsedPseudoHeaderFields;
+        private bool _isMethodConnect;
         private int _highestOpenedStreamId;
 
         private bool _stopping;
@@ -318,6 +344,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 {
                     throw new Http2ConnectionErrorException(Http2ErrorCode.STREAM_CLOSED);
                 }
+
                 // TODO: trailers
             }
             else if (_incomingFrame.StreamId <= _highestOpenedStreamId)
@@ -362,18 +389,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 {
                     _hpackDecoder.Decode(_incomingFrame.HeadersPayload, endHeaders, handler: this);
                 }
-                catch (Http2StreamErrorException ex)
+                catch (Http2StreamErrorException)
                 {
                     // TODO: log
-                    await _frameWriter.WriteRstStreamAsync(ex.StreamId, Http2ErrorCode.PROTOCOL_ERROR);
+                    await _frameWriter.WriteRstStreamAsync(_currentHeadersStream.StreamId, Http2ErrorCode.PROTOCOL_ERROR);
                     return;
                 }
 
                 if (endHeaders)
                 {
+                    if (!_isMethodConnect && (_parsedPseudoHeaderFields & _mandatoryRequestPseudoHeaderFields) != _mandatoryRequestPseudoHeaderFields)
+                    {
+                        // TODO: log
+
+                        // All HTTP/2 requests MUST include exactly one valid value for the :method, :scheme, and :path pseudo-header
+                        // fields, unless it is a CONNECT request (Section 8.3). An HTTP request that omits mandatory pseudo-header
+                        // fields is malformed (Section 8.1.2.6).
+                        await _frameWriter.WriteRstStreamAsync(_currentHeadersStream.StreamId, Http2ErrorCode.PROTOCOL_ERROR);
+                        return;
+                    }
+
                     _highestOpenedStreamId = _incomingFrame.StreamId;
                     _ = _currentHeadersStream.ProcessRequestsAsync();
                     _currentHeadersStream = null;
+                    _requestHeaderParsingState = RequestHeaderParsingState.Ready;
+                    _parsedPseudoHeaderFields = PseudoHeaderFields.None;
+                    _isMethodConnect = false;
                 }
             }
         }
@@ -550,6 +591,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 _highestOpenedStreamId = _currentHeadersStream.StreamId;
                 _ = _currentHeadersStream.ProcessRequestsAsync();
                 _currentHeadersStream = null;
+                _requestHeaderParsingState = RequestHeaderParsingState.Ready;
+                _parsedPseudoHeaderFields = PseudoHeaderFields.None;
+                _isMethodConnect = false;
             }
 
             return Task.CompletedTask;
@@ -591,6 +635,61 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public void OnHeader(Span<byte> name, Span<byte> value)
         {
+            ValidateHeader(name, value);
+            _currentHeadersStream.OnHeader(name, value);
+        }
+
+        private void ValidateHeader(Span<byte> name, Span<byte> value)
+        {
+            // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.1
+            if (IsPseudoHeaderField(name, out var headerField))
+            {
+                if (_requestHeaderParsingState == RequestHeaderParsingState.Headers ||
+                    _requestHeaderParsingState == RequestHeaderParsingState.Trailers)
+                {
+                    // Pseudo-header fields MUST NOT appear in trailers.
+                    // ...
+                    // All pseudo-header fields MUST appear in the header block before regular header fields.
+                    // Any request or response that contains a pseudo-header field that appears in a header
+                    // block after a regular header field MUST be treated as malformed (Section 8.1.2.6).
+                    throw new Http2StreamErrorException(_currentHeadersStream.StreamId, Http2ErrorCode.PROTOCOL_ERROR);
+                }
+
+                _requestHeaderParsingState = RequestHeaderParsingState.PseudoHeaderFields;
+
+                if (headerField == PseudoHeaderFields.Unknown)
+                {
+                    // Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header
+                    // fields as malformed (Section 8.1.2.6).
+                    throw new Http2StreamErrorException(_currentHeadersStream.StreamId, Http2ErrorCode.PROTOCOL_ERROR);
+                }
+
+                if (headerField == PseudoHeaderFields.Status)
+                {
+                    // Pseudo-header fields defined for requests MUST NOT appear in responses; pseudo-header fields
+                    // defined for responses MUST NOT appear in requests.
+                    throw new Http2StreamErrorException(_currentHeadersStream.StreamId, Http2ErrorCode.PROTOCOL_ERROR);
+                }
+
+                if ((_parsedPseudoHeaderFields & headerField) == headerField)
+                {
+                    // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.3
+                    // All HTTP/2 requests MUST include exactly one valid value for the :method, :scheme, and :path pseudo-header fields
+                    throw new Http2StreamErrorException(_currentHeadersStream.StreamId, Http2ErrorCode.PROTOCOL_ERROR);
+                }
+
+                if (headerField == PseudoHeaderFields.Method)
+                {
+                    _isMethodConnect = IsConnect(value);
+                }
+
+                _parsedPseudoHeaderFields |= headerField;
+            }
+            else if (_requestHeaderParsingState != RequestHeaderParsingState.Trailers)
+            {
+                _requestHeaderParsingState = RequestHeaderParsingState.Headers;
+            }
+
             // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2
             // A request or response containing uppercase header field names MUST be treated as malformed (Section 8.1.2.6).
             for (var i = 0; i < name.Length; i++)
@@ -600,8 +699,86 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     throw new Http2StreamErrorException(_currentHeadersStream.StreamId, Http2ErrorCode.PROTOCOL_ERROR);
                 }
             }
+        }
 
-            _currentHeadersStream.OnHeader(name, value);
+        private static readonly ulong _authoritLong = HttpUtilities.GetAsciiStringAsLong("authorit");
+        private static readonly uint _methInt = HttpUtilities.GetAsciiStringAsInt("meth");
+        private static readonly ushort _odShort = HttpUtilities.GetAsciiStringAsShort("od");
+        private static readonly uint _pathInt = HttpUtilities.GetAsciiStringAsInt("path");
+        private static readonly uint _scheInt = HttpUtilities.GetAsciiStringAsInt("sche");
+        private static readonly ushort _meShort = HttpUtilities.GetAsciiStringAsShort("me");
+        private static readonly uint _statInt = HttpUtilities.GetAsciiStringAsInt("stat");
+        private static readonly ushort _usShort = HttpUtilities.GetAsciiStringAsShort("us");
+
+        private unsafe bool IsPseudoHeaderField(Span<byte> name, out PseudoHeaderFields headerField)
+        {
+            headerField = PseudoHeaderFields.None;
+
+            if (name.IsEmpty || name[0] != (byte)':')
+            {
+                return false;
+            }
+
+            // Skip ':'
+            name = name.Slice(1);
+
+            fixed (byte* ptr = &name.DangerousGetPinnableReference())
+            {
+                var longPtr = (ulong*)ptr;
+                var intPtr = (uint*)ptr;
+                var shortPtr = (ushort*)(ptr + 4);
+
+                switch (name.Length)
+                {
+                    case 4:
+                        if (*intPtr == _pathInt)
+                        {
+                            headerField = PseudoHeaderFields.Path;
+                        }
+                        break;
+                    case 6:
+                        if (*intPtr == _methInt && *shortPtr == _odShort)
+                        {
+                            headerField = PseudoHeaderFields.Method;
+                        }
+                        else if (*intPtr == _scheInt && *shortPtr == _meShort)
+                        {
+                            headerField = PseudoHeaderFields.Scheme;
+                        }
+                        else if (*intPtr == _statInt && *shortPtr == _usShort)
+                        {
+                            headerField = PseudoHeaderFields.Method;
+                        }
+                        break;
+                    case 9:
+                        if (*longPtr == _authoritLong && *(ptr + 8) == 'y')
+                        {
+                            headerField = PseudoHeaderFields.Authority;
+                        }
+                        break;
+                }
+            }
+
+            return true;
+        }
+
+        private static readonly ulong _connInt = HttpUtilities.GetAsciiStringAsInt("CONN");
+        private static readonly ushort _ecShort = HttpUtilities.GetAsciiStringAsShort("EC");
+
+        private static unsafe bool IsConnect(Span<byte> value)
+        {
+            if (value.Length != 7)
+            {
+                return false;
+            }
+
+            fixed (byte* ptr = &value.DangerousGetPinnableReference())
+            {
+                var intPtr = (uint*)ptr;
+                var shortPtr = (ushort*)(ptr + 4);
+
+                return *intPtr == _connInt && *shortPtr == _ecShort && *(ptr + 6) == 'T';
+            }
         }
 
         void ITimeoutControl.SetTimeout(long ticks, TimeoutAction timeoutAction)

--- a/src/Kestrel.Core/Internal/Http2/Http2StreamErrorException.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2StreamErrorException.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
+{
+    public class Http2StreamErrorException : Exception
+    {
+        public Http2StreamErrorException(int streamId, Http2ErrorCode errorCode)
+            : base($"HTTP/2 stream ID {streamId} error: {errorCode}")
+        {
+            StreamId = streamId;
+            ErrorCode = errorCode;
+        }
+
+        public int StreamId { get; }
+
+        public Http2ErrorCode ErrorCode { get; }
+    }
+}

--- a/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
         }
 
-        public static unsafe ulong GetAsciiStringAsLong(string str)
+        private static unsafe ulong GetAsciiStringAsLong(string str)
         {
             Debug.Assert(str.Length == 8, "String must be exactly 8 (ASCII) characters long.");
 
@@ -59,19 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
         }
 
-        public static unsafe ushort GetAsciiStringAsShort(string str)
-        {
-            Debug.Assert(str.Length == 2, "String must be exactly 2 (ASCII) characters long.");
-
-            var bytes = Encoding.ASCII.GetBytes(str);
-
-            fixed (byte* ptr = &bytes[0])
-            {
-                return *(ushort*)ptr;
-            }
-        }
-
-        public static unsafe uint GetAsciiStringAsInt(string str)
+        private static unsafe uint GetAsciiStringAsInt(string str)
         {
             Debug.Assert(str.Length == 4, "String must be exactly 4 (ASCII) characters long.");
 

--- a/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
         }
 
-        private static unsafe ulong GetAsciiStringAsLong(string str)
+        public static unsafe ulong GetAsciiStringAsLong(string str)
         {
             Debug.Assert(str.Length == 8, "String must be exactly 8 (ASCII) characters long.");
 
@@ -59,7 +59,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
         }
 
-        private static unsafe uint GetAsciiStringAsInt(string str)
+        public static unsafe ushort GetAsciiStringAsShort(string str)
+        {
+            Debug.Assert(str.Length == 2, "String must be exactly 2 (ASCII) characters long.");
+
+            var bytes = Encoding.ASCII.GetBytes(str);
+
+            fixed (byte* ptr = &bytes[0])
+            {
+                return *(ushort*)ptr;
+            }
+        }
+
+        public static unsafe uint GetAsciiStringAsInt(string str)
         {
             Debug.Assert(str.Length == 4, "String must be exactly 4 (ASCII) characters long.");
 

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -870,6 +870,48 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public Task HEADERS_Received_HeaderBlockContainsConnectionSpecificHeader_StreamError()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(":method", "GET"),
+                new KeyValuePair<string, string>(":path", "/"),
+                new KeyValuePair<string, string>(":scheme", "http"),
+                new KeyValuePair<string, string>("connection", "keep-alive")
+            };
+
+            return HEADERS_Received_InvalidHeaderFields_StreamError(headers);
+        }
+
+        [Fact]
+        public Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsNotTrailers_StreamError()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(":method", "GET"),
+                new KeyValuePair<string, string>(":path", "/"),
+                new KeyValuePair<string, string>(":scheme", "http"),
+                new KeyValuePair<string, string>("te", "trailers, deflate")
+            };
+
+            return HEADERS_Received_InvalidHeaderFields_StreamError(headers);
+        }
+
+        [Fact]
+        public Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsTrailers_NoError()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(":method", "GET"),
+                new KeyValuePair<string, string>(":path", "/"),
+                new KeyValuePair<string, string>(":scheme", "http"),
+                new KeyValuePair<string, string>("te", "trailers, deflate")
+            };
+
+            return HEADERS_Received_InvalidHeaderFields_StreamError(headers);
+        }
+
+        [Fact]
         public async Task PRIORITY_Received_StreamIdZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);


### PR DESCRIPTION
Addresses the error cases described in [Section 8.1.2](http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2).

The error cases are:

* Uppercase characters in header name
* Pseudo-header fields (header names starting with ':') appearing after regular headers (i.e. they should appear first in a header block)
* Missing mandatory request pseudo-header fields (:method, :path and :scheme - :authority is optional)
* Response pseudo-header field (:status) in request headers
* Duplicate pseudo-header fields
* Connection-specific headers (`Connection`, or `TE` with value different than `trailers`)