### PR TITLE
Always start the response before draining the request.

### DIFF
--- a/test/Kestrel.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/test/Kestrel.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
@@ -140,7 +141,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task DoesNotRejectBodylessGetRequestWithZeroMaxRequestBodySize()
         {
-            using (var server = new TestServer(context => Task.CompletedTask,
+            using (var server = new TestServer(context => context.Request.Body.CopyToAsync(Stream.Null),
                 new TestServiceContext { ServerOptions = { Limits = { MaxRequestBodySize = 0 } } }))
             {
                 using (var connection = server.CreateConnection())


### PR DESCRIPTION
#2102 This design issue was negating the purpose of 100-Continue by sending it even when the app didn't read the body such as 401s, 404s, 301s, etc., and it added latency to responses without bodies. It was designed that way to allow reporting request body errors to the client. However, most request body errors are caused by client disconnects or timeouts and require the connection to be closed anyways. Regardless the app's response should be given priority over body drain errors.

Only six tests were affected by the change. Two were testing this specific functionality. The other four were only using this as a means to report test results. We may need to re-work some of these tests to verify the results another way.

New tests in https://github.com/aspnet/KestrelHttpServer/pull/2106 may also need to be updated.