### PR TITLE
Handle EPIPE like ECONNRESET on Linux

### DIFF
--- a/src/Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                     handle.Libuv.Check(status, out var uvError);
 
                     // Log connection resets at a lower (Debug) level.
-                    if (status == LibuvConstants.ECONNRESET)
+                    if (LibuvConstants.IsConnectionReset(status))
                     {
                         Log.ConnectionReset(ConnectionId);
                         error = new ConnectionResetException(uvError.Message, uvError);

--- a/src/Kestrel.Transport.Libuv/Internal/LibuvConstants.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/LibuvConstants.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
@@ -13,6 +14,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
         public static readonly int? ECONNRESET = GetECONNRESET();
         public static readonly int? EADDRINUSE = GetEADDRINUSE();
         public static readonly int? ENOTSUP = GetENOTSUP();
+        public static readonly int? EPIPE = GetEPIPE();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsConnectionReset(int errno)
+        {
+            return errno == ECONNRESET || errno == EPIPE;
+        }
 
         private static int? GetECONNRESET()
         {
@@ -28,6 +36,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             {
                 return -54;
             }
+            return null;
+        }
+
+        private static int? GetEPIPE()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return -32;
+            }
+
             return null;
         }
 

--- a/src/Kestrel.Transport.Libuv/Internal/LibuvOutputConsumer.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/LibuvOutputConsumer.cs
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             else
             {
                 // Log connection resets at a lower (Debug) level.
-                if (status == LibuvConstants.ECONNRESET)
+                if (LibuvConstants.IsConnectionReset(status))
                 {
                     _log.ConnectionReset(_connectionId);
                 }


### PR DESCRIPTION
Prior to this change, ConnectionResetMidRequestIsLoggedAsDebug would fail on linux sometimes when an EPIPE instead of an ECONNRESET status was raised by libuv.