### PR TITLE
Commit a snapshot of corefxlab source code to ensure patch builds are reproducible

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,7 +8,6 @@
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.0.1-rtm-105</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
     <MicrosoftAspNetCoreHttpFeaturesPackageVersion>2.0.1-rtm-105</MicrosoftAspNetCoreHttpFeaturesPackageVersion>
     <MicrosoftAspNetCoreHttpPackageVersion>2.0.1-rtm-105</MicrosoftAspNetCoreHttpPackageVersion>
-    <MicrosoftAspNetCoreInternalCoreFxLabSourcesPackageVersion>2.0.0-rtm-21470</MicrosoftAspNetCoreInternalCoreFxLabSourcesPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>2.0.0</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftAspNetCoreWebUtilitiesPackageVersion>2.0.1-rtm-105</MicrosoftAspNetCoreWebUtilitiesPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.0.0</MicrosoftExtensionsLoggingAbstractionsPackageVersion>

--- a/shared/corefxlab/SR.cs
+++ b/shared/corefxlab/SR.cs
@@ -1,0 +1,114 @@
+namespace System
+{
+    // This is generated as part of corefx build process
+    internal static class SR
+    {
+        internal static string ArrayTypeMustBeExactMatch
+        {
+            get
+            {
+                return System.SR.GetResourceString("ArrayTypeMustBeExactMatch", null);
+            }
+        }
+
+        internal static string CannotCallEqualsOnSpan
+        {
+            get
+            {
+                return System.SR.GetResourceString("CannotCallEqualsOnSpan", null);
+            }
+        }
+
+        internal static string CannotCallGetHashCodeOnSpan
+        {
+            get
+            {
+                return System.SR.GetResourceString("CannotCallGetHashCodeOnSpan", null);
+            }
+        }
+
+        internal static string Argument_InvalidTypeWithPointersNotSupported
+        {
+            get
+            {
+                return System.SR.GetResourceString("Argument_InvalidTypeWithPointersNotSupported", null);
+            }
+        }
+
+        internal static string Argument_DestinationTooShort
+        {
+            get
+            {
+                return System.SR.GetResourceString("Argument_DestinationTooShort", null);
+            }
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static bool UsingResourceKeys()
+        {
+            return false;
+        }
+
+        internal static string GetResourceString(string resourceKey, string defaultString)
+        {
+            return resourceKey;
+        }
+
+        internal static string Format(string resourceFormat, params object[] args)
+        {
+             return resourceFormat + string.Join(", ", args);
+        }
+
+        internal static string Format(string resourceFormat, object p1)
+        {
+            if (System.SR.UsingResourceKeys())
+            {
+                return string.Join(", ", new object[]
+                {
+                    resourceFormat,
+                    p1
+                });
+            }
+            return string.Format(resourceFormat, p1);
+        }
+
+        internal static string Format(string resourceFormat, object p1, object p2)
+        {
+            if (System.SR.UsingResourceKeys())
+            {
+                return string.Join(", ", new object[]
+                {
+                    resourceFormat,
+                    p1,
+                    p2
+                });
+            }
+            return string.Format(resourceFormat, p1, p2);
+        }
+
+        internal static string Format(string resourceFormat, object p1, object p2, object p3)
+        {
+            if (System.SR.UsingResourceKeys())
+            {
+                return string.Join(", ", new object[]
+                {
+                    resourceFormat,
+                    p1,
+                    p2,
+                    p3
+                });
+            }
+            return string.Format(resourceFormat, p1, p2, p3);
+        }
+    }
+}
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers.Internal
+{
+    // We don't want to pull System.Buffers required by ManagedBufferPool implemenation
+    // and BufferPool depends on ManagedBufferPool.Shared
+    internal class ManagedBufferPool
+    {
+        public static BufferPool Shared { get; } = null;
+    }
+}

--- a/shared/corefxlab/System.Binary/System/Binary/BufferReader.cs
+++ b/shared/corefxlab/System.Binary/System/Binary/BufferReader.cs
@@ -1,0 +1,115 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Binary
+{
+    /// <summary>
+    /// Reads bytes as primitives with specific endianness
+    /// </summary>
+    /// <remarks>
+    /// For native formats, SpanExtensions.Read<T> should be used.
+    /// Use these helpers when you need to read specific endinanness.
+    /// </remarks>
+    public static class BufferReader
+    {
+        /// <summary>
+        /// Reads a structure of type <typeparamref name="T"/> out of a span of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ReadBigEndian<[Primitive]T>(this ReadOnlySpan<byte> span) where T : struct
+            => BitConverter.IsLittleEndian ? UnsafeUtilities.Reverse(span.Read<T>()) : span.Read<T>();
+
+        /// <summary>
+        /// Reads a structure of type <typeparamref name="T"/> out of a span of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ReadLittleEndian<[Primitive]T>(this ReadOnlySpan<byte> span) where T : struct
+            => BitConverter.IsLittleEndian ? span.Read<T>() : UnsafeUtilities.Reverse(span.Read<T>());
+
+        /// <summary>
+        /// Reads a structure of type <typeparamref name="T"/> out of a span of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ReadBigEndian<[Primitive]T>(this Span<byte> span) where T : struct
+            => BitConverter.IsLittleEndian ? UnsafeUtilities.Reverse(span.Read<T>()) : span.Read<T>();
+
+        /// <summary>
+        /// Reads a structure of type <typeparamref name="T"/> out of a span of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ReadLittleEndian<[Primitive]T>(this Span<byte> span) where T : struct
+            => BitConverter.IsLittleEndian ? span.Read<T>() : UnsafeUtilities.Reverse(span.Read<T>());
+
+        /// <summary>
+        /// Reads a structure of type T out of a slice of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Read<[Primitive]T>(this Span<byte> slice)
+            where T : struct
+        {
+            RequiresInInclusiveRange(Unsafe.SizeOf<T>(), (uint)slice.Length);
+            return Unsafe.ReadUnaligned<T>(ref slice.DangerousGetPinnableReference());
+        }
+
+        /// <summary>
+        /// Reads a structure of type T out of a slice of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Read<[Primitive]T>(this ReadOnlySpan<byte> slice)
+            where T : struct
+        {
+            RequiresInInclusiveRange(Unsafe.SizeOf<T>(), (uint)slice.Length);
+            return Unsafe.ReadUnaligned<T>(ref slice.DangerousGetPinnableReference());
+        }
+
+        /// <summary>
+        /// Reads a structure of type T out of a slice of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryRead<[Primitive]T>(this ReadOnlySpan<byte> slice, out T value)
+            where T : struct
+        {
+            if (Unsafe.SizeOf<T>() > (uint)slice.Length)
+            {
+                value = default(T);
+                return false;
+            }
+            value = Unsafe.ReadUnaligned<T>(ref slice.DangerousGetPinnableReference());
+            return true;
+        }
+
+        /// <summary>
+        /// Reads a structure of type T out of a slice of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryRead<[Primitive]T>(this Span<byte> slice, out T value)
+            where T : struct
+        {
+            if (Unsafe.SizeOf<T>() > (uint)slice.Length)
+            {
+                value = default(T);
+                return false;
+            }
+            value = Unsafe.ReadUnaligned<T>(ref slice.DangerousGetPinnableReference());
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInInclusiveRange(int start, uint length)
+        {
+            if ((uint)start > length)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.Binary/System/Binary/BufferWriter.cs
+++ b/shared/corefxlab/System.Binary/System/Binary/BufferWriter.cs
@@ -1,0 +1,68 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Binary
+{
+    /// <summary>
+    /// Writes endian-specific primitives into spans.
+    /// </summary>
+    /// <remarks>
+    /// Use these helpers when you need to write specific endinaness.
+    /// </remarks>
+    public static class BufferWriter
+    {
+        /// <summary>
+        /// Writes a structure of type T to a span of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteBigEndian<[Primitive]T>(this Span<byte> span, T value) where T : struct
+            => span.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.Reverse(value) : value);
+
+        /// <summary>
+        /// Writes a structure of type T to a span of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteLittleEndian<[Primitive]T>(this Span<byte> span, T value) where T : struct
+            => span.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.Reverse(value));
+
+
+
+        /// <summary>
+        /// Writes a structure of type T into a slice of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Write<[Primitive]T>(this Span<byte> slice, T value)
+            where T : struct
+        {
+            if ((uint)Unsafe.SizeOf<T>() > (uint)slice.Length)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+            Unsafe.WriteUnaligned<T>(ref slice.DangerousGetPinnableReference(), value);
+        }
+
+        /// <summary>
+        /// Writes a structure of type T into a slice of bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWrite<[Primitive]T>(this Span<byte> slice, T value)
+            where T : struct
+        {
+            if (Unsafe.SizeOf<T>() > (uint)slice.Length)
+            {
+                return false;
+            }
+            Unsafe.WriteUnaligned<T>(ref slice.DangerousGetPinnableReference(), value);
+            return true;
+        }
+    }
+}

--- a/shared/corefxlab/System.Binary/System/Binary/UnsafeUtilities.cs
+++ b/shared/corefxlab/System.Binary/System/Binary/UnsafeUtilities.cs
@@ -1,0 +1,74 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime
+{
+    /// <summary>
+    /// A collection of unsafe helper methods that we cannot implement in C#.
+    /// NOTE: these can be used for VeryBadThings(tm), so tread with care...
+    /// </summary>
+    internal static class UnsafeUtilities
+    {
+        /// <summary>
+        /// Reverses a primitive value - performs an endianness swap
+        /// </summary> 
+        public static unsafe T Reverse<[Primitive]T>(T value) where T : struct
+        {
+            // note: relying on JIT goodness here!
+            if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte)) {
+                return value;
+            }
+            else if (typeof(T) == typeof(ushort) || typeof(T) == typeof(short)) {
+                ushort val = 0;
+                Unsafe.Write(&val, value);
+                val = (ushort)((val >> 8) | (val << 8));
+                return Unsafe.Read<T>(&val);
+            }
+            else if (typeof(T) == typeof(uint) || typeof(T) == typeof(int)
+                || typeof(T) == typeof(float)) {
+                uint val = 0;
+                Unsafe.Write(&val, value);
+                val = (val << 24)
+                    | ((val & 0xFF00) << 8)
+                    | ((val & 0xFF0000) >> 8)
+                    | (val >> 24);
+                return Unsafe.Read<T>(&val);
+            }
+            else if (typeof(T) == typeof(ulong) || typeof(T) == typeof(long)
+                || typeof(T) == typeof(double)) {
+                ulong val = 0;
+                Unsafe.Write(&val, value);
+                val = (val << 56)
+                    | ((val & 0xFF00) << 40)
+                    | ((val & 0xFF0000) << 24)
+                    | ((val & 0xFF000000) << 8)
+                    | ((val & 0xFF00000000) >> 8)
+                    | ((val & 0xFF0000000000) >> 24)
+                    | ((val & 0xFF000000000000) >> 40)
+                    | (val >> 56);
+                return Unsafe.Read<T>(&val);
+            }
+            else {
+                // default implementation
+                int len = Unsafe.SizeOf<T>();
+                var val = stackalloc byte[len];
+                Unsafe.Write(val, value);
+                int to = len >> 1, dest = len - 1;
+                for (int i = 0; i < to; i++) {
+                    var tmp = val[i];
+                    val[i] = val[dest];
+                    val[dest--] = tmp;
+                }
+                return Unsafe.Read<T>(val);
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -1,0 +1,167 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers
+{
+    [DebuggerTypeProxy(typeof(BufferDebuggerView<>))]
+    public struct Buffer<T> : IEquatable<Buffer<T>>, IEquatable<ReadOnlyBuffer<T>>
+    {
+        readonly OwnedBuffer<T> _owner;
+        readonly int _index;
+        readonly int _length;
+
+        internal Buffer(OwnedBuffer<T> owner, int index, int length)
+        {
+            _owner = owner;
+            _index = index;
+            _length = length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator ReadOnlyBuffer<T>(Buffer<T> buffer)
+        {
+            return new ReadOnlyBuffer<T>(buffer._owner, buffer._index, buffer._length);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator Buffer<T>(T[] array)
+        {
+            var owner = new Internal.OwnedArray<T>(array);
+            return owner.Buffer;
+        }
+
+        public static Buffer<T> Empty { get; } = Internal.OwnerEmptyMemory<T>.Shared.Buffer;
+
+        public int Length => _length;
+
+        public bool IsEmpty => Length == 0;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Buffer<T> Slice(int index)
+        {
+            return new Buffer<T>(_owner, _index + index, _length - index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Buffer<T> Slice(int index, int length)
+        {
+            return new Buffer<T>(_owner, _index + index, length);
+        }
+
+        public Span<T> Span => _owner.Span.Slice(_index, _length);
+
+        public DisposableReservation<T> Reserve() => new DisposableReservation<T>(_owner);
+
+        public BufferHandle Pin() => _owner.Pin(_index);
+
+        public bool TryGetArray(out ArraySegment<T> buffer)
+        {
+            if (!_owner.TryGetArrayInternal(out buffer)) {
+                return false;
+            }
+            buffer = new ArraySegment<T>(buffer.Array, buffer.Offset + _index, _length);
+            return true;
+        }
+
+        public unsafe bool TryGetPointer(out void* pointer)
+        {
+            if (!_owner.TryGetPointerInternal(out pointer))
+            {
+                return false;
+            }
+            pointer = Add(pointer, _index);
+            return true;
+        }
+
+        internal static unsafe void* Add(void* pointer, int offset)
+        {
+            return (byte*)pointer + ((ulong)Unsafe.SizeOf<T>() * (ulong)offset);
+        }
+
+        public T[] ToArray() => Span.ToArray();
+
+        public void CopyTo(Span<T> span) => Span.CopyTo(span);
+
+        public void CopyTo(Buffer<T> buffer) => Span.CopyTo(buffer.Span);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            if(!(obj is Buffer<T>)) {
+                return false;
+            }
+
+            var other = (Buffer<T>)obj;
+            return Equals(other);
+        }
+        public bool Equals(Buffer<T> other)
+        {
+            return
+                _owner == other._owner &&
+                _index == other._index &&
+                _length == other._length;
+        }
+        public bool Equals(ReadOnlyBuffer<T> other)
+        {
+            return other.Equals(this);
+        }
+        public static bool operator==(Buffer<T> left, Buffer<T> right)
+        {
+            return left.Equals(right);
+        }
+        public static bool operator!=(Buffer<T> left, Buffer<T> right)
+        {
+            return !left.Equals(right);
+        }
+        public static bool operator ==(Buffer<T> left, ReadOnlyBuffer<T> right)
+        {
+            return left.Equals(right);
+        }
+        public static bool operator !=(Buffer<T> left, ReadOnlyBuffer<T> right)
+        {
+            return !left.Equals(right);
+        }
+
+        [EditorBrowsable( EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            return HashingHelper.CombineHashCodes(_owner.GetHashCode(), _index.GetHashCode(), _length.GetHashCode());
+        }
+
+        // TODO: this is taken from SpanHelpers. If we move this type to System.Memory, we should remove this helper
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static IntPtr Add(IntPtr start, int index)
+        {
+            Debug.Assert(start.ToInt64() >= 0);
+            Debug.Assert(index >= 0);
+
+            unsafe
+            {
+                if (sizeof(IntPtr) == sizeof(int))
+                {
+                    // 32-bit path.
+                    uint byteLength = (uint)index * (uint)Unsafe.SizeOf<T>();
+                    return (IntPtr)(((byte*)start) + byteLength);
+                }
+                else
+                {
+                    // 64-bit path.
+                    ulong byteLength = (ulong)index * (ulong)Unsafe.SizeOf<T>();
+                    return (IntPtr)(((byte*)start) + byteLength);
+                }
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Buffers/BufferHandle.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Buffers/BufferHandle.cs
@@ -1,0 +1,73 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers
+{
+    public unsafe struct BufferHandle
+    {
+        IKnown _owner;
+        GCHandle _handle;
+        void* _pointer;
+
+        public static BufferHandle Create<T>(OwnedBuffer<T> owner, int index, GCHandle handle = default(GCHandle))
+        {
+            void* pointer;
+            if (owner.TryGetPointerInternal(out pointer))
+            {
+                pointer = Buffer<T>.Add(pointer, index);
+            }
+            else
+            {
+                ArraySegment<T> buffer;
+                if (owner.TryGetArrayInternal(out buffer))
+                {
+                    handle = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
+                    pointer = Buffer<T>.Add((void*)handle.AddrOfPinnedObject(), buffer.Offset + index);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Memory cannot be pinned");
+                }
+            }
+
+            owner.AddReference();
+
+            return new BufferHandle {
+                _owner = owner,
+                _handle = handle,
+                _pointer = pointer
+            };
+        }
+
+        public void* PinnedPointer
+        {
+            get
+            {
+                return _pointer;
+            }
+        }
+
+        public void Free()
+        {
+            if (_owner != null)
+            {
+                if (_handle.IsAllocated)
+                {
+                    _handle.Free();
+                }
+
+                _owner.Release();
+                _owner = null;
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Buffers/BufferPool.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Buffers/BufferPool.cs
@@ -1,0 +1,31 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers
+{
+    public abstract class BufferPool : IDisposable
+    {
+        public static BufferPool Default => Internal.ManagedBufferPool.Shared;
+
+        public abstract OwnedBuffer<byte> Rent(int minimumBufferSize);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~BufferPool()
+        {
+            Dispose(false);
+        }
+
+        protected abstract void Dispose(bool disposing);
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Buffers/DisposableReservation.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Buffers/DisposableReservation.cs
@@ -1,0 +1,53 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers
+{
+    public struct DisposableReservation<T> : IDisposable
+    {
+        OwnedBuffer<T> _owner;
+
+        internal DisposableReservation(OwnedBuffer<T> owner)
+        {
+            _owner = owner;
+            switch (ReferenceCountingSettings.OwnedMemory)
+            {
+                case ReferenceCountingMethod.Interlocked:
+                    ((IKnown)_owner).AddReference();
+                    break;
+                case ReferenceCountingMethod.ReferenceCounter:
+                    ReferenceCounter.AddReference(_owner);
+                    break;
+                case ReferenceCountingMethod.None:
+                    break;
+            }
+        }
+
+        public Span<T> Span => _owner.Span;
+
+        public void Dispose()
+        {
+            switch (ReferenceCountingSettings.OwnedMemory)
+            {
+                case ReferenceCountingMethod.Interlocked:
+                    ((IKnown)_owner).Release();
+                    break;
+                case ReferenceCountingMethod.ReferenceCounter:
+                    ReferenceCounter.Release(_owner);
+                    break;
+                case ReferenceCountingMethod.None:
+                    break;
+            }
+            _owner = null;
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Buffers/IKnown.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Buffers/IKnown.cs
@@ -1,0 +1,17 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers
+{
+    internal interface IKnown
+    {
+        void AddReference();
+        void Release();
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Buffers/IOutput.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Buffers/IOutput.cs
@@ -1,0 +1,20 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers
+{
+    public interface IOutput
+    {
+        Span<byte> Buffer { get; }
+        void Advance(int bytes);
+
+        /// <summary>desiredBufferLength == 0 means "i don't care"</summary>
+        void Enlarge(int desiredBufferLength = 0);
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
@@ -1,0 +1,81 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime;
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers
+{
+    public abstract class OwnedBuffer<T> : IDisposable, IKnown
+    {
+        protected OwnedBuffer() { }
+
+        public abstract int Length { get; }
+
+        public abstract Span<T> Span { get; }
+
+        public Buffer<T> Buffer => new Buffer<T>(this, 0, Length);
+
+        public ReadOnlyBuffer<T> ReadOnlyBuffer => new ReadOnlyBuffer<T>(this, 0, Length);
+
+        public static implicit operator OwnedBuffer<T>(T[] array) => new Internal.OwnedArray<T>(array);
+
+        #region Lifetime Management
+        public bool IsDisposed => _disposed;
+
+        public void Dispose()
+        {
+            if (HasOutstandingReferences) throw new InvalidOperationException("outstanding references detected.");
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            _disposed = disposing;
+        }
+
+        public bool HasOutstandingReferences
+        {
+            get
+            {
+                return Volatile.Read(ref _referenceCount) > 0
+                        || (ReferenceCountingSettings.OwnedMemory == ReferenceCountingMethod.ReferenceCounter
+                            && ReferenceCounter.HasReference(this));
+            }
+        }
+
+        public void AddReference()
+        {
+            Interlocked.Increment(ref _referenceCount);
+        }
+
+        public void Release()
+        {
+            if (Interlocked.Decrement(ref _referenceCount) == 0)
+                OnZeroReferences();
+        }
+
+        protected virtual void OnZeroReferences()
+        { }
+
+        public virtual BufferHandle Pin(int index = 0)
+        {
+            return BufferHandle.Create(this, index);
+        }
+        #endregion
+
+        internal protected abstract bool TryGetArrayInternal(out ArraySegment<T> buffer);
+
+        internal protected abstract unsafe bool TryGetPointerInternal(out void* pointer);
+
+        bool _disposed;
+        int _referenceCount;
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -1,0 +1,138 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers
+{
+    [DebuggerTypeProxy(typeof(ReadOnlyBufferDebuggerView<>))]
+    public struct ReadOnlyBuffer<T> : IEquatable<ReadOnlyBuffer<T>>, IEquatable<Buffer<T>>
+    {
+        readonly OwnedBuffer<T> _owner;
+        readonly int _index;
+        readonly int _length;
+
+        internal ReadOnlyBuffer(OwnedBuffer<T> owner,int index, int length)
+        {
+            _owner = owner;
+            _index = index;
+            _length = length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator ReadOnlyBuffer<T>(T[] array)
+        {
+            var owner = new Internal.OwnedArray<T>(array);
+            return owner.Buffer;
+        }
+
+        public static ReadOnlyBuffer<T> Empty { get; } = Internal.OwnerEmptyMemory<T>.Shared.Buffer;
+
+        public int Length => _length;
+
+        public bool IsEmpty => Length == 0;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlyBuffer<T> Slice(int index)
+        {
+            return new ReadOnlyBuffer<T>(_owner, _index + index, _length - index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlyBuffer<T> Slice(int index, int length)
+        {
+            return new ReadOnlyBuffer<T>(_owner, _index + index, length);
+        }
+
+        public ReadOnlySpan<T> Span => _owner.Span.Slice(_index, _length);
+
+        public DisposableReservation<T> Reserve()
+        {
+            return _owner.Buffer.Reserve();
+        }
+
+        public BufferHandle Pin() => _owner.Pin(_index);
+   
+        public unsafe bool TryGetPointer(out void* pointer)
+        {
+            if (!_owner.TryGetPointerInternal(out pointer)) {
+                return false;
+            }
+            pointer = Buffer<T>.Add(pointer, _index);
+            return true;
+        }
+
+        public unsafe bool TryGetArray(out ArraySegment<T> buffer)
+        {
+            if (!_owner.TryGetArrayInternal(out buffer)) {
+                return false;
+            }
+            buffer = new ArraySegment<T>(buffer.Array, buffer.Offset + _index, _length);
+            return true;
+        }
+
+        public T[] ToArray() => Span.ToArray();
+
+        public void CopyTo(Span<T> span) => Span.CopyTo(span);
+
+        public void CopyTo(Buffer<T> buffer) => Span.CopyTo(buffer.Span);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Buffer<T>)) {
+                return false;
+            }
+
+            var other = (Buffer<T>)obj;
+            return Equals(other);
+        }
+
+        public bool Equals(Buffer<T> other)
+        {
+            return Equals((ReadOnlyBuffer<T>)other);
+        }
+
+        public bool Equals(ReadOnlyBuffer<T> other)
+        {
+            return
+                _owner == other._owner &&
+                _index == other._index &&
+                _length == other._length;
+        }
+
+        public static bool operator ==(ReadOnlyBuffer<T> left, Buffer<T> right)
+        {
+            return left.Equals(right);
+        }
+        public static bool operator !=(ReadOnlyBuffer<T> left, Buffer<T> right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator ==(ReadOnlyBuffer<T> left, ReadOnlyBuffer<T> right)
+        {
+            return left.Equals(right);
+        }
+        public static bool operator !=(ReadOnlyBuffer<T> left, ReadOnlyBuffer<T> right)
+        {
+            return left.Equals(right);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            return HashingHelper.CombineHashCodes(_owner.GetHashCode(), _index.GetHashCode(), _length.GetHashCode());
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Internal/OwnedArray.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Internal/OwnedArray.cs
@@ -1,0 +1,72 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers.Internal
+{
+    internal sealed class OwnedArray<T> : OwnedBuffer<T>
+    {
+        public OwnedArray(int length)
+        {
+            _array = new T[length];
+        }
+
+        public OwnedArray(T[] array)
+        {
+            _array = array;
+        }
+
+        public OwnedArray(ArraySegment<T> segment)
+        {
+            _array = segment.AsSpan().ToArray();
+        }
+
+        public static implicit operator T[] (OwnedArray<T> owner)
+        {
+            return owner._array;
+        }
+
+        public static implicit operator OwnedArray<T>(T[] array)
+        {
+            return new OwnedArray<T>(array);
+        }
+
+        public static implicit operator OwnedArray<T>(ArraySegment<T> segment)
+        {
+            return new OwnedArray<T>(segment);
+        }
+
+        public override int Length => _array.Length;
+
+        public override Span<T> Span
+        {
+            get
+            {
+                if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnedArray<T>));
+                return _array;
+            }
+        }
+
+        protected internal override bool TryGetArrayInternal(out ArraySegment<T> buffer)
+        {
+            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnedArray<T>));
+            buffer = new ArraySegment<T>(_array);
+            return true;
+        }
+
+        protected internal override unsafe bool TryGetPointerInternal(out void* pointer)
+        {
+            pointer = null;
+            return false;
+        }
+
+        T[] _array;
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Internal/OwnerEmptyMemory.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Internal/OwnerEmptyMemory.cs
@@ -1,0 +1,46 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers.Internal
+{
+    internal class OwnerEmptyMemory<T> : OwnedBuffer<T>
+    {
+        readonly static T[] s_empty = new T[0];
+        public readonly static OwnedBuffer<T> Shared = new OwnerEmptyMemory<T>();
+
+        public override int Length => s_empty.Length;
+
+        public override Span<T> Span
+        {
+            get
+            {
+                if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnerEmptyMemory<T>));
+                return s_empty;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {}
+
+        protected internal override bool TryGetArrayInternal(out ArraySegment<T> buffer)
+        {
+            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnerEmptyMemory<T>));
+            buffer = new ArraySegment<T>(s_empty);
+            return true;
+        }
+
+        protected internal override unsafe bool TryGetPointerInternal(out void* pointer)
+        {
+            pointer = null;
+            return false;
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Runtime/BufferDebuggerView.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Runtime/BufferDebuggerView.cs
@@ -1,0 +1,32 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime
+{
+    internal class BufferDebuggerView<T>
+    {
+        private ReadOnlyBuffer<T> _buffer;
+
+        public BufferDebuggerView(Buffer<T> buffer)
+        {
+            _buffer = buffer;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            get {
+                return _buffer.ToArray();
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Runtime/BufferPrimitivesThrowHelper.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Runtime/BufferPrimitivesThrowHelper.cs
@@ -1,0 +1,120 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime
+{
+    public static class BufferPrimitivesThrowHelper
+    {
+        public static void ThrowArgumentNullException(ExceptionArgument argument)
+        {
+            throw GetArgumentNullException(argument);
+        }
+
+        public static void ThrowArgumentException()
+        {
+            throw GetArgumentException();
+        }
+
+        public static void ThrowArgumentException(ExceptionArgument argument)
+        {
+            throw GetArgumentException(argument);
+        }
+
+        public static void ThrowArgumentOutOfRangeException()
+        {
+            throw GetArgumentOutOfRangeException();
+        }
+
+        public static void ThrowArgumentOutOfRangeException(ExceptionArgument argument)
+        {
+            throw GetArgumentOutOfRangeException(argument);
+        }
+
+        public static void ThrowInvalidOperationException()
+        {
+            throw GetInvalidOperationException();
+        }
+
+        public static void ThrowInvalidOperationException_ForBoxingSpans()
+        {
+            throw GetInvalidOperationException_ForBoxingSpans();
+        }
+
+        public static void ThrowObjectDisposedException(string objectName)
+        {
+            throw GetObjectDisposedException(objectName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentNullException GetArgumentNullException(ExceptionArgument argument)
+        {
+            return new ArgumentNullException(GetArgumentName(argument));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentException GetArgumentException()
+        {
+            return new ArgumentException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentException GetArgumentException(ExceptionArgument argument)
+        {
+            return new ArgumentException(GetArgumentName(argument));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+        {
+            return new ArgumentOutOfRangeException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument)
+        {
+            return new ArgumentOutOfRangeException(GetArgumentName(argument));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException()
+        {
+            return new InvalidOperationException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException_ForBoxingSpans()
+        {
+            return new InvalidOperationException("Spans must not be boxed");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ObjectDisposedException GetObjectDisposedException(string objectName)
+        {
+            return new ObjectDisposedException(objectName);
+        }
+
+        private static string GetArgumentName(ExceptionArgument argument)
+        {
+            Debug.Assert(Enum.IsDefined(typeof(ExceptionArgument), argument),
+                "The enum value is not defined, please check the ExceptionArgument Enum.");
+
+            return argument.ToString();
+        }
+    }
+
+    public enum ExceptionArgument
+    {
+        pointer,
+        array
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Runtime/Contract.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Runtime/Contract.cs
@@ -1,0 +1,128 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime
+{
+    internal static class Contract
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Requires(bool condition)
+        {
+            if (!condition)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentException();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresNotNull<T>(ExceptionArgument argument, T obj) where T : class 
+        {
+            if (obj == null)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(argument);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void RequiresNotNull(ExceptionArgument argument, void* ptr)
+        {
+            if (ptr == null)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(argument);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void RequiresSameReference(void* ptr0, void* ptr1)
+        {
+            if (ptr0 != ptr1)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentException(ExceptionArgument.pointer);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresNonNegative(int n)
+        {
+            if (n < 0)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInRange(int start, uint length)
+        {
+            if ((uint)start >= length)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException();
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInRange(uint start, uint length)
+        {
+            if (start >= length)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInInclusiveRange(int start, uint length)
+        {
+            if ((uint)start > length)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe void RequiresOneNotNull<T>(T[] array, void* pointer)
+        {
+            if (array == null && pointer == null)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentException();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInInclusiveRange( uint start, uint length)
+        {
+            if (start > length)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInInclusiveRange(int start, int length, uint existingLength)
+        {
+            if ((uint)start > existingLength
+                || length < 0
+                || (uint)(start + length) > existingLength)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException();
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInInclusiveRange(uint start, uint length, uint existingLength)
+        {
+            if (start > existingLength
+                || (start + length) > existingLength)
+            {
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException();
+            }
+        }
+    }
+}
+

--- a/shared/corefxlab/System.Buffers.Primitives/System/Runtime/HashingHelper.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Runtime/HashingHelper.cs
@@ -1,0 +1,29 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime
+{
+    static class HashingHelper
+    {
+        public static int CombineHashCodes(int left, int right)
+        {
+            return ((left << 5) + left) ^ right;
+        }
+
+        public static int CombineHashCodes(int h1, int h2, int h3)
+        {
+            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
+        }
+
+        public static int CombineHashCodes(int h1, int h2, int h3, int h4)
+        {
+            return CombineHashCodes(CombineHashCodes(h1, h2), CombineHashCodes(h3, h4));
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Runtime/PrimitiveAttribute.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Runtime/PrimitiveAttribute.cs
@@ -1,0 +1,17 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime
+{
+    [AttributeUsage(AttributeTargets.GenericParameter)]
+    public sealed class PrimitiveAttribute : Attribute
+    {
+    }
+}
+

--- a/shared/corefxlab/System.Buffers.Primitives/System/Runtime/ReadOnlyBufferDebuggerView.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Runtime/ReadOnlyBufferDebuggerView.cs
@@ -1,0 +1,32 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime
+{
+    internal class ReadOnlyBufferDebuggerView<T>
+    {
+        private ReadOnlyBuffer<T> _buffer;
+
+        public ReadOnlyBufferDebuggerView(ReadOnlyBuffer<T> buffer)
+        {
+            _buffer = buffer;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            get {
+                return _buffer.ToArray();
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Runtime/ReferenceCounter.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Runtime/ReferenceCounter.cs
@@ -1,0 +1,176 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime
+{
+    /// <summary>
+    /// Make sure the struct is not copied, i.e. pass it only by reference
+    /// </summary>
+    /// <remarks>
+    /// The  counter is not completly race-free. Reading GetGlobalCount and AddReference/Release are subject to a race.
+    /// </remarks>
+    public struct ReferenceCounter
+    {
+        // thread local counts that can be updated very efficiently
+        [ThreadStatic]
+        static ObjectTable t_threadLocalCounts;
+
+        // all thread local counts; these are tallied up when global count is comupted
+        static ObjectTable[] s_allTables = new ObjectTable[Environment.ProcessorCount];
+        static int s_allTablesCount;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static public void AddReference(object obj)
+        {
+            var localCounts = t_threadLocalCounts;
+            if (localCounts == null)
+            {
+                localCounts = AddThreadLocalTable();
+            }
+            localCounts.Increment(obj);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static public void Release(object obj)
+        {
+            var localCounts = t_threadLocalCounts;
+            localCounts.Decrement(obj);
+        }
+
+        // TODO: can we detect if the object was only refcounted on one thread and its the current thread? If yes, we don't need to synchronize?
+        static public bool HasReference(object obj)
+        {
+            var allTables = s_allTables;
+            lock (allTables)
+            {
+                for (int index = 0; index < s_allTablesCount; index++)
+                {
+                    if (allTables[index].HasReference(obj)) return true;
+                }
+                return false;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static public bool HasThreadLocalReference(object obj)
+        {
+            var localCounts = t_threadLocalCounts;
+            if (localCounts == null) return false;
+            return localCounts.HasReference(obj);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ObjectTable AddThreadLocalTable()
+        {
+            Debug.Assert(t_threadLocalCounts == null);
+            var localCounts = new ObjectTable();
+            t_threadLocalCounts = localCounts;
+            lock (s_allTables)
+            {
+                    var allTables = s_allTables;
+                    if (s_allTablesCount >= allTables.Length)
+                    {
+                        var newAllTables = new ObjectTable[allTables.Length << 1];
+                        allTables.CopyTo(newAllTables, 0);
+                        s_allTables = newAllTables;
+                        allTables = newAllTables;
+                    }
+                    allTables[s_allTablesCount++] = localCounts;
+            }
+            return localCounts;
+        }
+    }
+
+    // This datastructure holds a collection of objects to reference count mappings
+    // Uses repetition of entries to represent the count.
+    sealed class ObjectTable
+    {
+        // if you change this constant, update ResizingObjectTableWorks test.
+        const int DefaultTableCapacity = 16;
+
+        object[] _items;
+        int _first;
+        
+        public ObjectTable()
+        {
+            _items = new object[DefaultTableCapacity];
+            _first = _items.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void Increment(object obj)
+        {
+            if (_first == 0)
+            {
+                // No space left, we must grow the table.
+                var oldLength = _items.Length;
+                var larger = new object[oldLength << 1];
+                _items.CopyTo(larger, oldLength);
+                // The copy must occur before the table is published.
+                Volatile.Write(ref _items, larger);
+                // _items must be updated before the value of _first is changed
+                // If this is not the case, then we could effectively make the
+                // table empty temporarily.
+                _items[oldLength - 1] = obj;
+                Volatile.Write(ref _first, oldLength - 1);
+                return;
+            }
+
+            _items[_first - 1] = obj;
+            // _items entry must update before we update the value of _first
+            // If this is not the case, then a stale reference could
+            // be observed.
+            Volatile.Write(ref _first, _first - 1);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void Decrement(object obj)
+        {
+            for (int index = _first; index < _items.Length; index++)
+            {
+                if (ReferenceEquals(_items[index], obj))
+                {
+                    if (index != _first) {
+                        //Condense the table
+                        _items[index] = _items[_first];
+                    }
+                    // The condense must be visible before we update _first.
+                    // If this is not the case, then we could lose a reference
+                    // temporarily.
+                    Volatile.Write(ref _first, _first + 1);
+                    return;
+                }
+            }
+
+            ThrowCountNotPositive();
+        }
+
+        private void ThrowCountNotPositive()
+        {
+            throw new InvalidOperationException("the object's count is not greater than zero");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool HasReference(object obj)
+        {
+            for (int index = _first; index < _items.Length; index++)
+            {
+                if (ReferenceEquals(_items[index], obj))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/shared/corefxlab/System.Buffers.Primitives/System/Runtime/ReferenceCountingSettings.cs
+++ b/shared/corefxlab/System.Buffers.Primitives/System/Runtime/ReferenceCountingSettings.cs
@@ -1,0 +1,23 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Runtime
+{
+    public enum ReferenceCountingMethod
+    {
+        Interlocked,
+        ReferenceCounter,
+        None
+    };
+
+    public class ReferenceCountingSettings
+    {
+        public static ReferenceCountingMethod OwnedMemory = ReferenceCountingMethod.Interlocked;
+    }
+}

--- a/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/ArrayList.cs
+++ b/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/ArrayList.cs
@@ -1,0 +1,47 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Collections.Sequences
+{
+    // This type is illustrating how to implement the new enumerable on index based datastructure
+    public sealed class ArrayList<T> : ISequence<T>
+    {
+        ResizableArray<T> _items;
+
+        public ArrayList()
+        {
+            _items = new ResizableArray<T>(0);
+        }
+        public ArrayList(int capacity)
+        {
+            _items = new ResizableArray<T>(capacity);
+        }
+
+        public int Length => _items.Count;
+
+        public T this[int index] => _items[index];
+
+        public void Add(T item)
+        {
+            _items.Add(item);
+        }
+
+        public SequenceEnumerator<T> GetEnumerator()
+        {
+            return new SequenceEnumerator<T>(this);
+        }
+
+        public bool TryGet(ref Position position, out T item, bool advance = true)
+        {
+            return _items.TryGet(ref position, out item, advance);
+        }
+    }
+}

--- a/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/ISequence.cs
+++ b/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/ISequence.cs
@@ -1,0 +1,24 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Collections.Sequences
+{
+    // new interface
+    public interface ISequence<T>
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="advance"></param>
+        /// <returns></returns>
+        /// <remarks></remarks>
+        bool TryGet(ref Position position, out T item, bool advance = true);
+    }
+}

--- a/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/Position.cs
+++ b/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/Position.cs
@@ -1,0 +1,53 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Collections.Sequences
+{
+    public struct Position : IEquatable<Position>
+    {
+        public object ObjectPosition;
+        public int IntegerPosition;
+        public int Tag;
+
+        public static readonly Position First = new Position();
+        public static readonly Position AfterLast = new Position() { IntegerPosition = int.MaxValue - 1 };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator==(Position left, Position right)
+        {
+            return left.Equals(right);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator!=(Position left, Position right)
+        {
+            return left.Equals(right);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Equals(Position other)
+        {
+            return IntegerPosition == other.IntegerPosition && ObjectPosition == other.ObjectPosition;
+        }
+
+        public override int GetHashCode()
+        {
+            return ObjectPosition == null ? IntegerPosition.GetHashCode() : ObjectPosition.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if(obj is Position)
+                return base.Equals((Position)obj);
+            return false;
+        }
+    }
+}

--- a/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
+++ b/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
@@ -1,0 +1,131 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Collections.Sequences
+{
+    // a List<T> like type designed to be embeded in other types
+    public struct ResizableArray<T>
+    {
+        private T[] _array;
+        private int _count;
+
+        public ResizableArray(int capacity)
+        {
+            _array = new T[capacity];
+            _count = 0;
+        }
+
+        public ResizableArray(T[] array, int count = 0)
+        {
+            _array = array;
+            _count = count;
+        }
+
+        public T[] Items
+        {
+            get { return _array; }
+            set { _array = value; }
+        }
+        public int Count
+        {
+            get { return _count; }
+            set { _count = value; }
+        }
+
+        public int Capacity => _array.Length;
+
+        public T this[int index]
+        {
+            get {
+                if (index > _count - 1) throw new IndexOutOfRangeException();
+                return _array[index];
+            }
+            set {
+                if (index > _count - 1) throw new IndexOutOfRangeException();
+                _array[index] = value;
+            }
+        }
+
+        public void Add(T item)
+        {
+            if (_array.Length == _count) {
+                Resize();
+            }
+            _array[_count++] = item;
+        }
+
+        public void AddAll(T[] items)
+        {
+            if (items.Length > _array.Length - _count) {
+                Resize(items.Length + _count);
+            }
+            items.CopyTo(_array, _count);
+            _count += items.Length;
+        }
+
+        public void AddAll(ReadOnlySpan<T> items)
+        {
+            if (items.Length > _array.Length - _count) {
+                Resize(items.Length + _count);
+            }
+            items.CopyTo(new Span<T>(_array, _count));
+            _count += items.Length;
+        }
+
+        public void Clear()
+        {
+            _count = 0;
+        }
+
+        public T[] Resize(int newSize = -1)
+        {
+            var oldArray = _array;
+            if (newSize == -1) {
+                if(_array == null || _array.Length == 0) {
+                    newSize = 4;
+                }
+                else {
+                    newSize = _array.Length << 1;
+                }
+            }           
+
+            var newArray = new T[newSize];
+            new Span<T>(_array, 0, _count).CopyTo(newArray);
+            _array = newArray;
+            return oldArray;
+        }
+
+        public T[] Resize(T[] newArray)
+        {
+            if (newArray.Length < _count) throw new ArgumentOutOfRangeException(nameof(newArray));
+            var oldArray = _array;
+            Array.Copy(_array, 0, newArray, 0, _count);
+            _array = newArray;
+            return oldArray;
+        }
+
+        public bool TryGet(ref Position position, out T item, bool advance = true)
+        {
+            if (position.IntegerPosition < _count) {
+                item = _array[position.IntegerPosition];
+                if (advance) { position.IntegerPosition++; }
+                return true;
+            }
+
+            item = default(T);
+            position = Position.AfterLast;
+            return false;
+        }
+
+        public ArraySegment<T> Full => new ArraySegment<T>(_array, 0, _count);
+        public ArraySegment<T> Free => new ArraySegment<T>(_array, _count, _array.Length - _count);
+    }
+}

--- a/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/SequenceEnumerator.cs
+++ b/shared/corefxlab/System.Collections.Sequences/System/Collections/Sequences/SequenceEnumerator.cs
@@ -1,0 +1,37 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Collections.Sequences
+{
+    public struct SequenceEnumerator<T>
+    {
+        Position _position;
+        ISequence<T> _sequence;
+        T _current;
+        bool first; // this is needed so that MoveNext does not advance the first time it's called
+
+        public SequenceEnumerator(ISequence<T> sequence) {
+            _sequence = sequence;
+            _position = Position.First;
+            _current = default(T);
+            first = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext() {
+            var result = _sequence.TryGet(ref _position, out _current, advance: !first);
+            first = false;
+            return result;
+        }
+
+        public T Current => _current;
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/BufferSegment.cs
+++ b/shared/corefxlab/System.IO.Pipelines/BufferSegment.cs
@@ -1,0 +1,149 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    // TODO: Pool segments
+    internal class BufferSegment : IDisposable
+    {
+        /// <summary>
+        /// The Start represents the offset into Array where the range of "active" bytes begins. At the point when the block is leased
+        /// the Start is guaranteed to be equal to 0. The value of Start may be assigned anywhere between 0 and
+        /// Buffer.Length, and must be equal to or less than End.
+        /// </summary>
+        public int Start;
+
+        /// <summary>
+        /// The End represents the offset into Array where the range of "active" bytes ends. At the point when the block is leased
+        /// the End is guaranteed to be equal to Start. The value of Start may be assigned anywhere between 0 and
+        /// Buffer.Length, and must be equal to or less than End.
+        /// </summary>
+        public int End;
+
+        /// <summary>
+        /// Reference to the next block of data when the overall "active" bytes spans multiple blocks. At the point when the block is
+        /// leased Next is guaranteed to be null. Start, End, and Next are used together in order to create a linked-list of discontiguous 
+        /// working memory. The "active" memory is grown when bytes are copied in, End is increased, and Next is assigned. The "active" 
+        /// memory is shrunk when bytes are consumed, Start is increased, and blocks are returned to the pool.
+        /// </summary>
+        public BufferSegment Next;
+
+        /// <summary>
+        /// The buffer being tracked
+        /// </summary>
+        private OwnedBuffer<byte> _owned;
+
+        private Buffer<byte> _buffer;
+
+        public BufferSegment(OwnedBuffer<byte> buffer)
+        {
+            _owned = buffer;
+            Start = 0;
+            End = 0;
+
+            _owned.AddReference();
+            _buffer = _owned.Buffer;
+        }
+
+        public BufferSegment(OwnedBuffer<byte> buffer, int start, int end)
+        {
+            _owned = buffer;
+            Start = start;
+            End = end;
+            ReadOnly = true;
+
+            // For unowned buffers, we need to make a copy here so that the caller can 
+            // give up the give this buffer back to the caller
+            var unowned = buffer as UnownedBuffer;
+            if (unowned != null)
+            {
+                _owned = unowned.MakeCopy(start, end - start, out Start, out End);
+            }
+
+            _owned.AddReference();
+            _buffer = _owned.Buffer;
+        }
+
+        public Buffer<byte> Buffer => _buffer;
+
+        /// <summary>
+        /// If true, data should not be written into the backing block after the End offset. Data between start and end should never be modified
+        /// since this would break cloning.
+        /// </summary>
+        public bool ReadOnly { get; }
+
+        /// <summary>
+        /// The amount of readable bytes in this segment. Is is the amount of bytes between Start and End.
+        /// </summary>
+        public int ReadableBytes => End - Start;
+
+        /// <summary>
+        /// The amount of writable bytes in this segment. It is the amount of bytes between Length and End
+        /// </summary>
+        public int WritableBytes => _buffer.Length - End;
+
+        public void Dispose()
+        {
+            Debug.Assert(_owned.HasOutstandingReferences);
+
+            _owned.Release();
+        }
+
+
+        /// <summary>
+        /// ToString overridden for debugger convenience. This displays the "active" byte information in this block as ASCII characters.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            var data = _owned.Buffer.Slice(Start, ReadableBytes).Span;
+
+            for (int i = 0; i < ReadableBytes; i++)
+            {
+                builder.Append((char)data[i]);
+            }
+            return builder.ToString();
+        }
+
+        public static BufferSegment Clone(ReadCursor beginBuffer, ReadCursor endBuffer, out BufferSegment lastSegment)
+        {
+            var beginOrig = beginBuffer.Segment;
+            var endOrig = endBuffer.Segment;
+
+            if (beginOrig == endOrig)
+            {
+                lastSegment = new BufferSegment(beginOrig._owned, beginBuffer.Index, endBuffer.Index);
+                return lastSegment;
+            }
+
+            var beginClone = new BufferSegment(beginOrig._owned, beginBuffer.Index, beginOrig.End);
+            var endClone = beginClone;
+
+            beginOrig = beginOrig.Next;
+
+            while (beginOrig != endOrig)
+            {
+                endClone.Next = new BufferSegment(beginOrig._owned, beginOrig.Start, beginOrig.End);
+
+                endClone = endClone.Next;
+                beginOrig = beginOrig.Next;
+            }
+
+            lastSegment = new BufferSegment(endOrig._owned, endOrig.Start, endBuffer.Index);
+            endClone.Next = lastSegment;
+
+            return beginClone;
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/FlushResult.cs
+++ b/shared/corefxlab/System.IO.Pipelines/FlushResult.cs
@@ -1,0 +1,26 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public struct FlushResult
+    {
+        internal ResultFlags ResultFlags;
+
+        /// <summary>
+        /// True if the currrent flush was cancelled
+        /// </summary>
+        public bool IsCancelled => (ResultFlags & ResultFlags.Cancelled) != 0;
+
+        /// <summary>
+        /// True if the <see cref="IPipeWriter"/> is complete
+        /// </summary>
+        public bool IsCompleted => (ResultFlags & ResultFlags.Completed) != 0;
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/IPipe.cs
+++ b/shared/corefxlab/System.IO.Pipelines/IPipe.cs
@@ -1,0 +1,19 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public interface IPipe
+    {
+        IPipeReader Reader { get; }
+        IPipeWriter Writer { get; }
+        void Reset();
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/IPipeConnection.cs
+++ b/shared/corefxlab/System.IO.Pipelines/IPipeConnection.cs
@@ -1,0 +1,27 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Defines a class that provides a connection from which data can be read from and written to.
+    /// </summary>
+    public interface IPipeConnection : IDisposable
+    {
+        /// <summary>
+        /// Gets the <see cref="IPipeReader"/> half of the duplex connection.
+        /// </summary>
+        IPipeReader Input { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IPipeWriter"/> half of the duplex connection.
+        /// </summary>
+        IPipeWriter Output { get; }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/IPipeReader.cs
+++ b/shared/corefxlab/System.IO.Pipelines/IPipeReader.cs
@@ -1,0 +1,60 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Defines a class that provides a pipeline from which data can be read.
+    /// </summary>
+    public interface IPipeReader
+    {
+        /// <summary>
+        /// Attempt to synchronously read data the <see cref="IPipeReader"/>.
+        /// </summary>
+        /// <param name="result">The <see cref="ReadResult"/></param>
+        /// <returns>True if data was available, or if the call was cancelled or the writer completed with an error.</returns>
+        /// <remarks>If the pipe returns false, there's no need to call Advance.</remarks>
+        bool TryRead(out ReadResult result);
+
+        /// <summary>
+        /// Asynchronously reads a sequence of bytes from the current <see cref="IPipeReader"/>.
+        /// </summary>
+        /// <returns>A <see cref="ReadableBufferAwaitable"/> representing the asynchronous read operation.</returns>
+        ReadableBufferAwaitable ReadAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Moves forward the pipeline's read cursor to after the consumed data.
+        /// </summary>
+        /// <param name="consumed">Marks the extent of the data that has been succesfully proceesed.</param>
+        /// <param name="examined">Marks the extent of the data that has been read and examined.</param>
+        /// <remarks>
+        /// The memory for the consumed data will be released and no longer available.
+        /// The examined data communicates to the pipeline when it should signal more data is available.
+        /// </remarks>
+        void Advance(ReadCursor consumed, ReadCursor examined);
+
+        /// <summary>
+        /// Cancel to currently pending or next call to <see cref="ReadAsync"/> if none is pending, without completing the <see cref="IPipeReader"/>.
+        /// </summary>
+        void CancelPendingRead();
+
+        /// <summary>
+        /// Signal to the producer that the consumer is done reading.
+        /// </summary>
+        /// <param name="exception">Optional Exception indicating a failure that's causing the pipeline to complete.</param>
+        void Complete(Exception exception = null);
+
+        /// <summary>
+        /// Registers callback that gets executed when writer side of pipe completes.
+        /// </summary>
+        void OnWriterCompleted(Action<Exception, object> callback, object state);
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/IPipeWriter.cs
+++ b/shared/corefxlab/System.IO.Pipelines/IPipeWriter.cs
@@ -1,0 +1,40 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Defines a class that provides a pipeline to which data can be written.
+    /// </summary>
+    public interface IPipeWriter
+    {
+        /// <summary>
+        /// Allocates memory from the pipeline to write into.
+        /// </summary>
+        /// <param name="minimumSize">The minimum size buffer to allocate</param>
+        /// <returns>A <see cref="WritableBuffer"/> that can be written to.</returns>
+        WritableBuffer Alloc(int minimumSize = 0);
+
+        /// <summary>
+        /// Marks the pipeline as being complete, meaning no more items will be written to it.
+        /// </summary>
+        /// <param name="exception">Optional Exception indicating a failure that's causing the pipeline to complete.</param>
+        void Complete(Exception exception = null);
+
+        /// <summary>
+        /// Cancel to currently pending or next call to <see cref="ReadAsync"/> if none is pending, without completing the <see cref="IPipeReader"/>.
+        /// </summary>
+        void CancelPendingFlush();
+
+        /// <summary>
+        /// Registers callback that gets executed when reader side of pipe completes.
+        /// </summary>
+        void OnReaderCompleted(Action<Exception, object> callback, object state);
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/IReadableBufferAwaiter.cs
+++ b/shared/corefxlab/System.IO.Pipelines/IReadableBufferAwaiter.cs
@@ -1,0 +1,20 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public interface IReadableBufferAwaiter
+    {
+        bool IsCompleted { get; }
+
+        ReadResult GetResult();
+
+        void OnCompleted(Action continuation);
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/IScheduler.cs
+++ b/shared/corefxlab/System.IO.Pipelines/IScheduler.cs
@@ -1,0 +1,16 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public interface IScheduler
+    {
+        void Schedule(Action<object> action, object state);
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/IWritableBufferAwaiter.cs
+++ b/shared/corefxlab/System.IO.Pipelines/IWritableBufferAwaiter.cs
@@ -1,0 +1,20 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public interface IWritableBufferAwaiter
+    {
+        bool IsCompleted { get; }
+
+        FlushResult GetResult();
+
+        void OnCompleted(Action continuation);
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/InlineScheduler.cs
+++ b/shared/corefxlab/System.IO.Pipelines/InlineScheduler.cs
@@ -1,0 +1,22 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public class InlineScheduler : IScheduler
+    {
+        public static readonly InlineScheduler Default = new InlineScheduler();
+
+        public void Schedule(Action<object> action, object state)
+        {
+            action(state);
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/MemoryEnumerator.cs
+++ b/shared/corefxlab/System.IO.Pipelines/MemoryEnumerator.cs
@@ -1,0 +1,61 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// An enumerator over the <see cref="ReadableBuffer"/>
+    /// </summary>
+    public struct BufferEnumerator
+    {
+        private SegmentEnumerator _segmentEnumerator;
+        private Buffer<byte> _current;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public BufferEnumerator(ReadCursor start, ReadCursor end)
+        {
+            _segmentEnumerator = new SegmentEnumerator(start, end);
+            _current = default(Buffer<byte>);
+        }
+
+        /// <summary>
+        /// The current <see cref="Buffer{Byte}"/>
+        /// </summary>
+        public Buffer<byte> Current => _current;
+
+        /// <summary>
+        /// Moves to the next <see cref="Buffer{Byte}"/> in the <see cref="ReadableBuffer"/>
+        /// </summary>
+        /// <returns></returns>
+        public bool MoveNext()
+        {
+            if (!_segmentEnumerator.MoveNext())
+            {
+                _current = default(Buffer<byte>);
+                return false;
+            }
+            var current = _segmentEnumerator.Current;
+            _current = current.Segment.Buffer.Slice(current.Start, current.Length);
+
+            return true;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void Reset()
+        {
+            PipelinesThrowHelper.ThrowNotSupportedException();
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/MemoryPool.cs
+++ b/shared/corefxlab/System.IO.Pipelines/MemoryPool.cs
@@ -1,0 +1,233 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Used to allocate and distribute re-usable blocks of memory.
+    /// </summary>
+    public class MemoryPool : BufferPool
+    {
+        /// <summary>
+        /// The gap between blocks' starting address. 4096 is chosen because most operating systems are 4k pages in size and alignment.
+        /// </summary>
+        private const int _blockStride = 4096;
+
+        /// <summary>
+        /// The last 64 bytes of a block are unused to prevent CPU from pre-fetching the next 64 byte into it's memory cache. 
+        /// See https://github.com/aspnet/KestrelHttpServer/issues/117 and https://www.youtube.com/watch?v=L7zSU9HI-6I
+        /// </summary>
+        private const int _blockUnused = 64;
+
+        /// <summary>
+        /// Allocating 32 contiguous blocks per slab makes the slab size 128k. This is larger than the 85k size which will place the memory
+        /// in the large object heap. This means the GC will not try to relocate this array, so the fact it remains pinned does not negatively
+        /// affect memory management's compactification.
+        /// </summary>
+        private const int _blockCount = 32;
+
+        /// <summary>
+        /// 4096 - 64 gives you a blockLength of 4032 usable bytes per block.
+        /// </summary>
+        private const int _blockLength = _blockStride - _blockUnused;
+
+        /// <summary>
+        /// Max allocation block size for pooled blocks, 
+        /// larger values can be leased but they will be disposed after use rather than returned to the pool.
+        /// </summary>
+        public const int MaxPooledBlockLength = _blockLength;
+
+        /// <summary>
+        /// 4096 * 32 gives you a slabLength of 128k contiguous bytes allocated per slab
+        /// </summary>
+        private const int _slabLength = _blockStride * _blockCount;
+
+        /// <summary>
+        /// Thread-safe collection of blocks which are currently in the pool. A slab will pre-allocate all of the block tracking objects
+        /// and add them to this collection. When memory is requested it is taken from here first, and when it is returned it is re-added.
+        /// </summary>
+        private readonly ConcurrentQueue<MemoryPoolBlock> _blocks = new ConcurrentQueue<MemoryPoolBlock>();
+
+        /// <summary>
+        /// Thread-safe collection of slabs which have been allocated by this pool. As long as a slab is in this collection and slab.IsActive, 
+        /// the blocks will be added to _blocks when returned.
+        /// </summary>
+        private readonly ConcurrentStack<MemoryPoolSlab> _slabs = new ConcurrentStack<MemoryPoolSlab>();
+
+        /// <summary>
+        /// This is part of implementing the IDisposable pattern.
+        /// </summary>
+        private bool _disposedValue = false; // To detect redundant calls
+
+        private Action<MemoryPoolSlab> _slabAllocationCallback;
+
+        private Action<MemoryPoolSlab> _slabDeallocationCallback;
+
+        public override OwnedBuffer<byte> Rent(int size)
+        {
+            if (size > _blockLength)
+            {
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException_BufferRequestTooLarge(_blockLength);
+            }
+
+            var block = Lease();
+            return block;
+        }
+
+        public void RegisterSlabAllocationCallback(Action<MemoryPoolSlab> callback)
+        {
+            _slabAllocationCallback = callback;
+        }
+
+        public void RegisterSlabDeallocationCallback(Action<MemoryPoolSlab> callback)
+        {
+            _slabDeallocationCallback = callback;
+        }
+
+        /// <summary>
+        /// Called to take a block from the pool.
+        /// </summary>
+        /// <returns>The block that is reserved for the called. It must be passed to Return when it is no longer being used.</returns>
+#if DEBUG
+        private MemoryPoolBlock Lease()
+        {
+            Debug.Assert(!_disposedValue, "Block being leased from disposed pool!");
+#else
+        private MemoryPoolBlock Lease()
+        {
+#endif
+            MemoryPoolBlock block;
+            if (_blocks.TryDequeue(out block))
+            {
+                // block successfully taken from the stack - return it
+
+#if BLOCK_LEASE_TRACKING
+                block.Leaser = Environment.StackTrace;
+                block.IsLeased = true;
+#endif
+                return block;
+            }
+            // no blocks available - grow the pool
+            block = AllocateSlab();
+
+#if BLOCK_LEASE_TRACKING
+            block.Leaser = Environment.StackTrace;
+            block.IsLeased = true;
+#endif
+            return block;
+        }
+
+        /// <summary>
+        /// Internal method called when a block is requested and the pool is empty. It allocates one additional slab, creates all of the 
+        /// block tracking objects, and adds them all to the pool.
+        /// </summary>
+        private MemoryPoolBlock AllocateSlab()
+        {
+            var slab = MemoryPoolSlab.Create(_slabLength);
+            _slabs.Push(slab);
+
+            _slabAllocationCallback?.Invoke(slab);
+            slab._deallocationCallback = _slabDeallocationCallback;
+
+            var basePtr = slab.NativePointer;
+            var firstOffset = (int)((_blockStride - 1) - ((ulong)(basePtr + _blockStride - 1) % _blockStride));
+
+            var poolAllocationLength = _slabLength - _blockStride;
+
+            var offset = firstOffset;
+            for (;
+                offset + _blockLength < poolAllocationLength;
+                offset += _blockStride)
+            {
+                var block = MemoryPoolBlock.Create(
+                    offset,
+                    _blockLength,
+                    this,
+                    slab);
+#if BLOCK_LEASE_TRACKING
+                block.IsLeased = true;
+#endif
+                Return(block);
+            }
+
+            // return last block rather than adding to pool
+            var newBlock = MemoryPoolBlock.Create(
+                    offset,
+                    _blockLength,
+                    this,
+                    slab);
+
+            return newBlock;
+        }
+
+        /// <summary>
+        /// Called to return a block to the pool. Once Return has been called the memory no longer belongs to the caller, and
+        /// Very Bad Things will happen if the memory is read of modified subsequently. If a caller fails to call Return and the
+        /// block tracking object is garbage collected, the block tracking object's finalizer will automatically re-create and return
+        /// a new tracking object into the pool. This will only happen if there is a bug in the server, however it is necessary to avoid
+        /// leaving "dead zones" in the slab due to lost block tracking objects.
+        /// </summary>
+        /// <param name="block">The block to return. It must have been acquired by calling Lease on the same memory pool instance.</param>
+        public void Return(MemoryPoolBlock block)
+        {
+#if BLOCK_LEASE_TRACKING
+            Debug.Assert(block.Pool == this, "Returned block was not leased from this pool");
+            Debug.Assert(block.IsLeased, $"Block being returned to pool twice: {block.Leaser}{Environment.NewLine}");
+            block.IsLeased = false;
+#endif
+
+            if (block.Slab != null && block.Slab.IsActive)
+            {
+                _blocks.Enqueue(block);
+            }
+            else
+            {
+                GC.SuppressFinalize(block);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                _disposedValue = true;
+#if DEBUG
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+#endif
+                if (disposing)
+                {
+                    MemoryPoolSlab slab;
+                    while (_slabs.TryPop(out slab))
+                    {
+                        // dispose managed state (managed objects).
+                        slab.Dispose();
+                    }
+                }
+
+                // Discard blocks in pool
+                MemoryPoolBlock block;
+                while (_blocks.TryDequeue(out block))
+                {
+                    GC.SuppressFinalize(block);
+                }
+
+                // N/A: free unmanaged resources (unmanaged objects) and override a finalizer below.
+
+                // N/A: set large fields to null.
+
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/MemoryPoolBlock.cs
+++ b/shared/corefxlab/System.IO.Pipelines/MemoryPoolBlock.cs
@@ -1,0 +1,129 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Text;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Block tracking object used by the byte buffer memory pool. A slab is a large allocation which is divided into smaller blocks. The
+    /// individual blocks are then treated as independent array segments.
+    /// </summary>
+    public class MemoryPoolBlock : OwnedBuffer<byte>
+    {
+        private readonly int _offset;
+        private readonly int _length;
+
+        /// <summary>
+        /// This object cannot be instantiated outside of the static Create method
+        /// </summary>
+        protected MemoryPoolBlock(MemoryPool pool, MemoryPoolSlab slab, int offset, int length)
+        {
+            _offset = offset;
+            _length = length;
+
+            Pool = pool;
+            Slab = slab;
+        }
+
+        /// <summary>
+        /// Back-reference to the memory pool which this block was allocated from. It may only be returned to this pool.
+        /// </summary>
+        public MemoryPool Pool { get; }
+
+        /// <summary>
+        /// Back-reference to the slab from which this block was taken, or null if it is one-time-use memory.
+        /// </summary>
+        public MemoryPoolSlab Slab { get; }
+
+        public override int Length => _length;
+
+        public override Span<byte> Span
+        {
+            get
+            {
+                if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(MemoryPoolBlock));
+                return new Span<byte>(Slab.Array, _offset, _length);
+            }
+        }
+
+#if BLOCK_LEASE_TRACKING
+        public bool IsLeased { get; set; }
+        public string Leaser { get; set; }
+#endif
+
+        ~MemoryPoolBlock()
+        {
+            if (Slab != null && Slab.IsActive)
+            {
+#if DEBUG
+                Debug.Assert(false, $"{Environment.NewLine}{Environment.NewLine}*** Block being garbage collected instead of returned to pool" +
+#if BLOCK_LEASE_TRACKING
+                    $": {Leaser}" +
+#endif
+                    $" ***{ Environment.NewLine}");
+#endif
+
+                // Need to make a new object because this one is being finalized
+                Pool.Return(new MemoryPoolBlock(Pool, Slab, _offset, _length));
+            }
+        }
+
+        internal static MemoryPoolBlock Create(
+            int offset,
+            int length,
+            MemoryPool pool,
+            MemoryPoolSlab slab)
+        {
+            return new MemoryPoolBlock(pool, slab, offset, length);
+        }
+
+        /// <summary>
+        /// ToString overridden for debugger convenience. This displays the "active" byte information in this block as ASCII characters.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            SpanExtensions.AppendAsLiteral(Buffer.Span, builder);
+            return builder.ToString();
+        }
+
+        protected override void OnZeroReferences()
+        {
+            Pool.Return(this);
+        }
+
+// In kestrel both MemoryPoolBlock and OwnedBuffer end up in the same assembly so
+// this method access modifiers need to be `protected internal`
+#if KESTREL_BY_SOURCE
+        internal
+#endif
+        protected override bool TryGetArrayInternal(out ArraySegment<byte> buffer)
+        {
+            if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(MemoryPoolBlock));
+            buffer = new ArraySegment<byte>(Slab.Array, _offset, _length);
+            return true;
+        }
+
+// In kestrel both MemoryPoolBlock and OwnedBuffer end up in the same assembly so
+// this method access modifiers need to be `protected internal`
+#if KESTREL_BY_SOURCE
+        internal
+#endif
+        protected override unsafe bool TryGetPointerInternal(out void* pointer)
+        {
+            if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(MemoryPoolBlock));
+            pointer = (Slab.NativePointer + _offset).ToPointer();
+            return true;
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/MemoryPoolSlab.cs
+++ b/shared/corefxlab/System.IO.Pipelines/MemoryPoolSlab.cs
@@ -1,0 +1,106 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Slab tracking object used by the byte buffer memory pool. A slab is a large allocation which is divided into smaller blocks. The
+    /// individual blocks are then treated as independant array segments.
+    /// </summary>
+    public class MemoryPoolSlab : IDisposable
+    {
+        /// <summary>
+        /// This handle pins the managed array in memory until the slab is disposed. This prevents it from being
+        /// relocated and enables any subsections of the array to be used as native memory pointers to P/Invoked API calls.
+        /// </summary>
+        private readonly GCHandle _gcHandle;
+        private readonly IntPtr _nativePointer;
+        private byte[] _data;
+
+        private bool _isActive;
+        internal Action<MemoryPoolSlab> _deallocationCallback;
+        private bool _disposedValue;
+
+        public MemoryPoolSlab(byte[] data)
+        {
+            _data = data;
+            _gcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            _nativePointer = _gcHandle.AddrOfPinnedObject();
+            _isActive = true;
+        }
+
+        /// <summary>
+        /// True as long as the blocks from this slab are to be considered returnable to the pool. In order to shrink the 
+        /// memory pool size an entire slab must be removed. That is done by (1) setting IsActive to false and removing the
+        /// slab from the pool's _slabs collection, (2) as each block currently in use is Return()ed to the pool it will
+        /// be allowed to be garbage collected rather than re-pooled, and (3) when all block tracking objects are garbage
+        /// collected and the slab is no longer references the slab will be garbage collected and the memory unpinned will
+        /// be unpinned by the slab's Dispose.
+        /// </summary>
+        public bool IsActive => _isActive;
+
+        public IntPtr NativePointer => _nativePointer;
+
+        public byte[] Array => _data;
+
+        public int Length => _data.Length;
+
+        public static MemoryPoolSlab Create(int length)
+        {
+            // allocate and pin requested memory length
+            var array = new byte[length];
+
+            // allocate and return slab tracking object
+            return new MemoryPoolSlab(array);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    // N/A: dispose managed state (managed objects).
+                }
+
+                _isActive = false;
+
+                _deallocationCallback?.Invoke(this);
+
+                if (_gcHandle.IsAllocated)
+                {
+                    _gcHandle.Free();
+                }
+
+                // set large fields to null.
+                _data = null;
+
+                _disposedValue = true;
+            }
+        }
+
+        // override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        ~MemoryPoolSlab()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // uncomment the following line if the finalizer is overridden above.
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/Pipe.cs
+++ b/shared/corefxlab/System.IO.Pipelines/Pipe.cs
@@ -1,0 +1,837 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Default <see cref="IPipeWriter"/> and <see cref="IPipeReader"/> implementation.
+    /// </summary>
+    internal class Pipe : IPipe, IPipeReader, IPipeWriter, IReadableBufferAwaiter, IWritableBufferAwaiter
+    {
+        private static readonly Action<object> _signalReaderAwaitable = state => ((Pipe)state).ReaderCancellationRequested();
+        private static readonly Action<object> _signalWriterAwaitable = state => ((Pipe)state).WriterCancellationRequested();
+        private static readonly Action<object> _invokeCompletionCallbacks = state => ((PipeCompletionCallbacks)state).Execute();
+        private static readonly Action<object> _scheduleContinuation = o => ((Action)o)();
+
+        // This sync objects protects the following state:
+        // 1. _commitHead & _commitHeadIndex
+        // 2. _length
+        // 3. _readerAwaitable & _writerAwaitable
+        private readonly object _sync = new object();
+
+        private readonly BufferPool _pool;
+        private readonly long _maximumSizeHigh;
+        private readonly long _maximumSizeLow;
+
+        private readonly IScheduler _readerScheduler;
+        private readonly IScheduler _writerScheduler;
+
+        private long _length;
+        private long _currentWriteLength;
+
+        private PipeAwaitable _readerAwaitable;
+        private PipeAwaitable _writerAwaitable;
+
+        private PipeCompletion _writerCompletion;
+        private PipeCompletion _readerCompletion;
+
+        // The read head which is the extent of the IPipelineReader's consumed bytes
+        private BufferSegment _readHead;
+
+        // The commit head which is the extent of the bytes available to the IPipelineReader to consume
+        private BufferSegment _commitHead;
+        private int _commitHeadIndex;
+
+        // The write head which is the extent of the IPipelineWriter's written bytes
+        private BufferSegment _writingHead;
+
+        private PipeOperationState _readingState;
+        private PipeOperationState _writingState;
+
+        private bool _disposed;
+
+        internal long Length => _length;
+
+        /// <summary>
+        /// Initializes the <see cref="Pipe"/> with the specifed <see cref="IBufferPool"/>.
+        /// </summary>
+        /// <param name="pool"></param>
+        /// <param name="options"></param>
+        public Pipe(BufferPool pool, PipeOptions options = null)
+        {
+            if (pool == null)
+            {
+                throw new ArgumentNullException(nameof(pool));
+            }
+
+            options = options ?? new PipeOptions();
+
+            if (options.MaximumSizeLow < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.MaximumSizeLow));
+            }
+
+            if (options.MaximumSizeHigh < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.MaximumSizeHigh));
+            }
+
+            if (options.MaximumSizeLow > options.MaximumSizeHigh)
+            {
+                throw new ArgumentException(nameof(options.MaximumSizeHigh) + " should be greater or equal to " + nameof(options.MaximumSizeLow), nameof(options.MaximumSizeHigh));
+            }
+
+            _pool = pool;
+            _maximumSizeHigh = options.MaximumSizeHigh;
+            _maximumSizeLow = options.MaximumSizeLow;
+            _readerScheduler = options.ReaderScheduler ?? InlineScheduler.Default;
+            _writerScheduler = options.WriterScheduler ?? InlineScheduler.Default;
+            _readerAwaitable = new PipeAwaitable(completed: false);
+            _writerAwaitable = new PipeAwaitable(completed: true);
+        }
+
+        private void ResetState()
+        {
+            _readerCompletion.Reset();
+            _writerCompletion.Reset();
+            _commitHeadIndex = 0;
+            _currentWriteLength = 0;
+            _length = 0;
+        }
+
+        internal Buffer<byte> Buffer => _writingHead?.Buffer.Slice(_writingHead.End, _writingHead.WritableBytes) ?? Buffer<byte>.Empty;
+
+        /// <summary>
+        /// Allocates memory from the pipeline to write into.
+        /// </summary>
+        /// <param name="minimumSize">The minimum size buffer to allocate</param>
+        /// <returns>A <see cref="WritableBuffer"/> that can be written to.</returns>
+        WritableBuffer IPipeWriter.Alloc(int minimumSize)
+        {
+            if (_writerCompletion.IsCompleted)
+            {
+                PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.NoWritingAllowed, _writerCompletion.Location);
+            }
+
+            if (minimumSize < 0)
+            {
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumSize);
+            }
+
+            lock (_sync)
+            {
+                // CompareExchange not required as its setting to current value if test fails
+                _writingState.Begin(ExceptionResource.AlreadyWriting);
+
+                if (minimumSize > 0)
+                {
+                    try
+                    {
+                        AllocateWriteHeadUnsynchronized(minimumSize);
+                    }
+                    catch (Exception)
+                    {
+                        // Reset producing state if allocation failed
+                        _writingState.End(ExceptionResource.NoWriteToComplete);
+                        throw;
+                    }
+                }
+
+                _currentWriteLength = 0;
+                return new WritableBuffer(this);
+            }
+        }
+
+        internal void Ensure(int count = 1)
+        {
+            EnsureAlloc();
+
+            var segment = _writingHead;
+            if (segment == null)
+            {
+                // Changing commit head shared with Reader
+                lock (_sync)
+                {
+                    segment = AllocateWriteHeadUnsynchronized(count);
+                }
+            }
+
+            var bytesLeftInBuffer = segment.WritableBytes;
+
+            // If inadequate bytes left or if the segment is readonly
+            if (bytesLeftInBuffer == 0 || bytesLeftInBuffer < count || segment.ReadOnly)
+            {
+                var nextBuffer = _pool.Rent(count);
+                var nextSegment = new BufferSegment(nextBuffer);
+
+                segment.Next = nextSegment;
+
+                _writingHead = nextSegment;
+            }
+        }
+
+        private BufferSegment AllocateWriteHeadUnsynchronized(int count)
+        {
+            BufferSegment segment = null;
+
+            if (_commitHead != null && !_commitHead.ReadOnly)
+            {
+                // Try to return the tail so the calling code can append to it
+                int remaining = _commitHead.WritableBytes;
+
+                if (count <= remaining)
+                {
+                    // Free tail space of the right amount, use that
+                    segment = _commitHead;
+                }
+            }
+
+            if (segment == null)
+            {
+                // No free tail space, allocate a new segment
+                segment = new BufferSegment(_pool.Rent(count));
+            }
+
+            if (_commitHead == null)
+            {
+                // No previous writes have occurred
+                _commitHead = segment;
+            }
+            else if (segment != _commitHead && _commitHead.Next == null)
+            {
+                // Append the segment to the commit head if writes have been committed
+                // and it isn't the same segment (unused tail space)
+                _commitHead.Next = segment;
+            }
+
+            // Set write head to assigned segment
+            _writingHead = segment;
+
+            return segment;
+        }
+
+        internal void Append(ReadableBuffer buffer)
+        {
+            if (buffer.IsEmpty)
+            {
+                return; // nothing to do
+            }
+
+            EnsureAlloc();
+
+            BufferSegment clonedEnd;
+            var clonedBegin = BufferSegment.Clone(buffer.Start, buffer.End, out clonedEnd);
+
+            if (_writingHead == null)
+            {
+                // No active write
+                lock (_sync)
+                {
+                    if (_commitHead == null)
+                    {
+                        // No allocated buffers yet, not locking as _readHead will be null
+                        _commitHead = clonedBegin;
+                    }
+                    else
+                    {
+                        Debug.Assert(_commitHead.Next == null);
+                        // Allocated buffer, append as next segment
+                        _commitHead.Next = clonedBegin;
+                    }
+                }
+            }
+            else
+            {
+                Debug.Assert(_writingHead.Next == null);
+                // Active write, append as next segment
+                _writingHead.Next = clonedBegin;
+            }
+
+            // Move write head to end of buffer
+            _writingHead = clonedEnd;
+            _currentWriteLength += buffer.Length;
+        }
+
+        private void EnsureAlloc()
+        {
+            if (!_writingState.IsActive)
+            {
+                PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.NotWritingNoAlloc);
+            }
+        }
+
+        internal void Commit()
+        {
+            // Changing commit head shared with Reader
+            lock (_sync)
+            {
+                CommitUnsynchronized();
+            }
+        }
+
+        internal void CommitUnsynchronized()
+        {
+            _writingState.End(ExceptionResource.NoWriteToComplete);
+
+            if (_writingHead == null)
+            {
+                // Nothing written to commit
+                return;
+            }
+
+            if (_readHead == null)
+            {
+                // Update the head to point to the head of the buffer.
+                // This happens if we called alloc(0) then write
+                _readHead = _commitHead;
+            }
+
+            // Always move the commit head to the write head
+            _commitHead = _writingHead;
+            _commitHeadIndex = _writingHead.End;
+            _length += _currentWriteLength;
+
+            // Do not reset if reader is complete
+            if (_maximumSizeHigh > 0 &&
+                _length >= _maximumSizeHigh &&
+                !_readerCompletion.IsCompleted)
+            {
+                _writerAwaitable.Reset();
+            }
+            // Clear the writing state
+            _writingHead = null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void AdvanceWriter(int bytesWritten)
+        {
+            EnsureAlloc();
+            if (bytesWritten > 0)
+            {
+                if (_writingHead == null)
+                {
+                    PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.AdvancingWithNoBuffer);
+                }
+
+                Debug.Assert(!_writingHead.ReadOnly);
+                Debug.Assert(_writingHead.Next == null);
+
+                var buffer = _writingHead.Buffer;
+                var bufferIndex = _writingHead.End + bytesWritten;
+
+                if (bufferIndex > buffer.Length)
+                {
+                    PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.AdvancingPastBufferSize);
+                }
+
+                _writingHead.End = bufferIndex;
+                _currentWriteLength += bytesWritten;
+            }
+            else if (bytesWritten < 0)
+            {
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.bytesWritten);
+            } // and if zero, just do nothing; don't need to validate tail etc
+        }
+
+        internal WritableBufferAwaitable FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Action awaitable;
+            CancellationTokenRegistration cancellationTokenRegistration;
+            lock (_sync)
+            {
+                if (_writingState.IsActive)
+                {
+                    // Commit the data as not already committed
+                    CommitUnsynchronized();
+                }
+
+                awaitable = _readerAwaitable.Complete();
+
+                cancellationTokenRegistration = _writerAwaitable.AttachToken(cancellationToken, _signalWriterAwaitable, this);
+            }
+
+            cancellationTokenRegistration.Dispose();
+
+            TrySchedule(_readerScheduler, awaitable);
+
+            return new WritableBufferAwaitable(this);
+        }
+
+        internal ReadableBuffer AsReadableBuffer()
+        {
+            if (_writingHead == null)
+            {
+                return new ReadableBuffer(); // Nothing written return empty
+            }
+
+            ReadCursor readStart;
+            lock (_sync)
+            {
+                readStart = new ReadCursor(_commitHead, _commitHeadIndex);
+            }
+
+            return new ReadableBuffer(readStart, new ReadCursor(_writingHead, _writingHead.End));
+        }
+
+        /// <summary>
+        /// Marks the pipeline as being complete, meaning no more items will be written to it.
+        /// </summary>
+        /// <param name="exception">Optional Exception indicating a failure that's causing the pipeline to complete.</param>
+        void IPipeWriter.Complete(Exception exception)
+        {
+            if (_writingState.IsActive)
+            {
+                PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.CompleteWriterActiveWriter, _writingState.Location);
+            }
+
+            Action awaitable;
+            PipeCompletionCallbacks completionCallbacks;
+            bool readerCompleted;
+
+            lock (_sync)
+            {
+                completionCallbacks = _writerCompletion.TryComplete(exception);
+                awaitable = _readerAwaitable.Complete();
+                readerCompleted = _readerCompletion.IsCompleted;
+            }
+
+            if (completionCallbacks != null)
+            {
+                TrySchedule(_readerScheduler, _invokeCompletionCallbacks, completionCallbacks);
+            }
+
+            TrySchedule(_readerScheduler, awaitable);
+
+            if (readerCompleted)
+            {
+                Dispose();
+            }
+        }
+
+
+        // Reading
+
+        void IPipeReader.Advance(ReadCursor consumed, ReadCursor examined)
+        {
+            BufferSegment returnStart = null;
+            BufferSegment returnEnd = null;
+
+            // Reading commit head shared with writer
+            Action continuation = null;
+            lock (_sync)
+            {
+                var examinedEverything = examined.Segment == _commitHead && examined.Index == _commitHeadIndex;
+
+                if (!consumed.IsDefault)
+                {
+                    if (_readHead == null)
+                    {
+                        PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.AdvanceToInvalidCursor);
+                        return;
+                    }
+
+                    returnStart = _readHead;
+                    returnEnd = consumed.Segment;
+
+                    // Check if we crossed _maximumSizeLow and complete backpressure
+                    var consumedBytes = ReadCursor.GetLength(returnStart, returnStart.Start, consumed.Segment, consumed.Index);
+                    var oldLength = _length;
+                    _length -= consumedBytes;
+
+                    if (oldLength >= _maximumSizeLow &&
+                        _length < _maximumSizeLow)
+                    {
+                        continuation = _writerAwaitable.Complete();
+                    }
+
+                    // Check if we consumed entire last segment
+                    // if we are going to return commit head
+                    // we need to check that there is no writing operation that
+                    // might be using tailspace
+                    if (consumed.Index == returnEnd.End &&
+                        !(_commitHead == returnEnd && _writingState.IsActive))
+                    {
+                        var nextBlock = returnEnd.Next;
+                        if (_commitHead == returnEnd)
+                        {
+                            _commitHead = nextBlock;
+                            _commitHeadIndex = nextBlock?.Start ?? 0;
+                        }
+
+                        _readHead = nextBlock;
+                        returnEnd = nextBlock;
+                    }
+                    else
+                    {
+                        _readHead = consumed.Segment;
+                        _readHead.Start = consumed.Index;
+                    }
+                }
+
+                // We reset the awaitable to not completed if we've examined everything the producer produced so far
+                // but only if writer is not completed yet
+                if (examinedEverything && !_writerCompletion.IsCompleted)
+                {
+                    // Prevent deadlock where reader awaits new data and writer await backpressure
+                    if (!_writerAwaitable.IsCompleted)
+                    {
+                        PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.BackpressureDeadlock);
+                    }
+                    _readerAwaitable.Reset();
+                }
+
+                _readingState.End(ExceptionResource.NoReadToComplete);
+            }
+
+            while (returnStart != null && returnStart != returnEnd)
+            {
+                returnStart.Dispose();
+                returnStart = returnStart.Next;
+            }
+
+            TrySchedule(_writerScheduler, continuation);
+        }
+
+        /// <summary>
+        /// Signal to the producer that the consumer is done reading.
+        /// </summary>
+        /// <param name="exception">Optional Exception indicating a failure that's causing the pipeline to complete.</param>
+        void IPipeReader.Complete(Exception exception)
+        {
+            if (_readingState.IsActive)
+            {
+                PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.CompleteReaderActiveReader, _readingState.Location);
+            }
+
+            PipeCompletionCallbacks completionCallbacks;
+            Action awaitable;
+            bool writerCompleted;
+
+            lock (_sync)
+            {
+                completionCallbacks = _readerCompletion.TryComplete(exception);
+                awaitable = _writerAwaitable.Complete();
+                writerCompleted = _writerCompletion.IsCompleted;
+            }
+
+            if (completionCallbacks != null)
+            {
+                TrySchedule(_writerScheduler, _invokeCompletionCallbacks, completionCallbacks);
+            }
+
+            TrySchedule(_writerScheduler, awaitable);
+
+            if (writerCompleted)
+            {
+                Dispose();
+            }
+        }
+
+        void IPipeReader.OnWriterCompleted(Action<Exception, object> callback, object state)
+        {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
+            PipeCompletionCallbacks completionCallbacks;
+            lock (_sync)
+            {
+                completionCallbacks = _writerCompletion.AddCallback(callback, state);
+            }
+
+            if (completionCallbacks != null)
+            {
+                TrySchedule(_readerScheduler, _invokeCompletionCallbacks, completionCallbacks);
+            }
+        }
+
+        /// <summary>
+        /// Cancel to currently pending call to <see cref="ReadAsync"/> without completing the <see cref="IPipeReader"/>.
+        /// </summary>
+        void IPipeReader.CancelPendingRead()
+        {
+            Action awaitable;
+            lock (_sync)
+            {
+                awaitable = _readerAwaitable.Cancel();
+            }
+            TrySchedule(_readerScheduler, awaitable);
+        }
+
+        /// <summary>
+        /// Cancel to currently pending call to <see cref="WritableBuffer.FlushAsync"/> without completing the <see cref="IPipeWriter"/>.
+        /// </summary>
+        void IPipeWriter.CancelPendingFlush()
+        {
+            Action awaitable;
+            lock (_sync)
+            {
+                awaitable = _writerAwaitable.Cancel();
+            }
+            TrySchedule(_writerScheduler, awaitable);
+        }
+
+        void IPipeWriter.OnReaderCompleted(Action<Exception, object> callback, object state)
+        {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
+            PipeCompletionCallbacks completionCallbacks;
+            lock (_sync)
+            {
+                completionCallbacks = _readerCompletion.AddCallback(callback, state);
+            }
+
+            if (completionCallbacks != null)
+            {
+                TrySchedule(_writerScheduler, _invokeCompletionCallbacks, completionCallbacks);
+            }
+        }
+
+        ReadableBufferAwaitable IPipeReader.ReadAsync(CancellationToken token)
+        {
+            CancellationTokenRegistration cancellationTokenRegistration;
+            if (_readerCompletion.IsCompleted)
+            {
+                PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.NoReadingAllowed, _readerCompletion.Location);
+            }
+            lock (_sync)
+            {
+                cancellationTokenRegistration = _readerAwaitable.AttachToken(token, _signalReaderAwaitable, this);
+            }
+            cancellationTokenRegistration.Dispose();
+            return new ReadableBufferAwaitable(this);
+        }
+
+        bool IPipeReader.TryRead(out ReadResult result)
+        {
+            lock (_sync)
+            {
+                if (_readerCompletion.IsCompleted)
+                {
+                    PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.NoReadingAllowed, _readerCompletion.Location);
+                }
+
+                result = new ReadResult();
+                if (_length > 0 || _readerAwaitable.IsCompleted)
+                {
+                    GetResult(ref result);
+                    return true;
+                }
+
+                if (_readerAwaitable.HasContinuation)
+                {
+                    PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.AlreadyReading);
+                }
+                return false;
+            }
+        }
+
+        private static void TrySchedule(IScheduler scheduler, Action action)
+        {
+            if (action != null)
+            {
+                scheduler.Schedule(_scheduleContinuation, action);
+            }
+        }
+
+        private static void TrySchedule(IScheduler scheduler, Action<object> action, object state)
+        {
+            if (action != null)
+            {
+                scheduler.Schedule(action, state);
+            }
+        }
+
+        private void Dispose()
+        {
+            lock (_sync)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                // Return all segments
+                var segment = _readHead;
+                while (segment != null)
+                {
+                    var returnSegment = segment;
+                    segment = segment.Next;
+
+                    returnSegment.Dispose();
+                }
+
+                _readHead = null;
+                _commitHead = null;
+            }
+        }
+
+        // IReadableBufferAwaiter members
+
+        bool IReadableBufferAwaiter.IsCompleted => _readerAwaitable.IsCompleted;
+
+        void IReadableBufferAwaiter.OnCompleted(Action continuation)
+        {
+            Action awaitable;
+            bool doubleCompletion;
+            lock (_sync)
+            {
+                awaitable = _readerAwaitable.OnCompleted(continuation, out doubleCompletion);
+            }
+            if (doubleCompletion)
+            {
+                Writer.Complete(PipelinesThrowHelper.GetInvalidOperationException(ExceptionResource.NoConcurrentOperation));
+            }
+            TrySchedule(_readerScheduler, awaitable);
+        }
+
+        ReadResult IReadableBufferAwaiter.GetResult()
+        {
+            if (!_readerAwaitable.IsCompleted)
+            {
+                PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.GetResultNotCompleted);
+            }
+
+            var result = new ReadResult();
+            lock (_sync)
+            {
+                GetResult(ref result);
+            }
+            return result;
+        }
+
+        private void GetResult(ref ReadResult result)
+        {
+            if (_writerCompletion.IsCompletedOrThrow())
+            {
+                result.ResultFlags |= ResultFlags.Completed;
+            }
+
+            var isCancelled = _readerAwaitable.ObserveCancelation();
+            if (isCancelled)
+            {
+                result.ResultFlags |= ResultFlags.Cancelled;
+            }
+
+            // No need to read end if there is no head
+            var head = _readHead;
+
+            if (head != null)
+            {
+                // Reading commit head shared with writer
+                result.ResultBuffer.BufferEnd.Segment = _commitHead;
+                result.ResultBuffer.BufferEnd.Index = _commitHeadIndex;
+                result.ResultBuffer.BufferLength = ReadCursor.GetLength(head, head.Start, _commitHead, _commitHeadIndex);
+
+                result.ResultBuffer.BufferStart.Segment = head;
+                result.ResultBuffer.BufferStart.Index = head.Start;
+            }
+
+            if (isCancelled)
+            {
+                _readingState.BeginTentative(ExceptionResource.AlreadyReading);
+            }
+            else
+            {
+                _readingState.Begin(ExceptionResource.AlreadyReading);
+            }
+        }
+
+        // IWritableBufferAwaiter members
+
+        bool IWritableBufferAwaiter.IsCompleted => _writerAwaitable.IsCompleted;
+
+        FlushResult IWritableBufferAwaiter.GetResult()
+        {
+            var result = new FlushResult();
+            lock (_sync)
+            {
+                if (!_writerAwaitable.IsCompleted)
+                {
+                    PipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.GetResultNotCompleted);
+                }
+
+                // Change the state from to be cancelled -> observed
+                if (_writerAwaitable.ObserveCancelation())
+                {
+                    result.ResultFlags |= ResultFlags.Cancelled;
+                }
+                if (_readerCompletion.IsCompletedOrThrow())
+                {
+                    result.ResultFlags |= ResultFlags.Completed;
+                }
+            }
+
+            return result;
+        }
+
+        void IWritableBufferAwaiter.OnCompleted(Action continuation)
+        {
+            Action awaitable;
+            bool doubleCompletion;
+            lock (_sync)
+            {
+                awaitable = _writerAwaitable.OnCompleted(continuation, out doubleCompletion);
+            }
+            if (doubleCompletion)
+            {
+                Reader.Complete(PipelinesThrowHelper.GetInvalidOperationException(ExceptionResource.NoConcurrentOperation));
+            }
+            TrySchedule(_writerScheduler, awaitable);
+        }
+
+        private void ReaderCancellationRequested()
+        {
+            Action action;
+            lock (_sync)
+            {
+                action = _readerAwaitable.Cancel();
+            }
+            TrySchedule(_readerScheduler, action);
+        }
+
+        private void WriterCancellationRequested()
+        {
+            Action action;
+            lock (_sync)
+            {
+                action = _writerAwaitable.Cancel();
+            }
+            TrySchedule(_writerScheduler, action);
+        }
+
+        public IPipeReader Reader => this;
+        public IPipeWriter Writer => this;
+
+        public void Reset()
+        {
+            lock (_sync)
+            {
+                if (!_disposed)
+                {
+                    throw new InvalidOperationException("Both reader and writer need to be completed to be able to reset ");
+                }
+
+                _disposed = false;
+                ResetState();
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipeAwaitable.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipeAwaitable.cs
@@ -1,0 +1,156 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    internal struct PipeAwaitable
+    {
+        private static readonly Action _awaitableIsCompleted = () => { };
+        private static readonly Action _awaitableIsNotCompleted = () => { };
+
+        private CancelledState _cancelledState;
+        private Action _state;
+        private CancellationToken _cancellationToken;
+        private CancellationTokenRegistration _cancellationTokenRegistration;
+
+        public PipeAwaitable(bool completed)
+        {
+            _cancelledState = CancelledState.NotCancelled;
+            _state = completed ? _awaitableIsCompleted : _awaitableIsNotCompleted;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public CancellationTokenRegistration AttachToken(CancellationToken cancellationToken, Action<object> callback, object state)
+        {
+            CancellationTokenRegistration oldRegistration;
+            if (!cancellationToken.Equals(_cancellationToken))
+            {
+                oldRegistration = _cancellationTokenRegistration;
+                _cancellationToken = cancellationToken;
+                if (_cancellationToken.CanBeCanceled)
+                {
+                    _cancellationToken.ThrowIfCancellationRequested();
+                    _cancellationTokenRegistration = _cancellationToken.Register(callback, state);
+                }
+            }
+            return oldRegistration;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Action Complete()
+        {
+            var awaitableState = _state;
+            _state = _awaitableIsCompleted;
+
+            if (!ReferenceEquals(awaitableState, _awaitableIsCompleted) &&
+                !ReferenceEquals(awaitableState, _awaitableIsNotCompleted))
+            {
+                return awaitableState;
+            }
+            return null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Reset()
+        {
+            if (ReferenceEquals(_state, _awaitableIsCompleted) &&
+                _cancelledState < CancelledState.CancellationPreRequested)
+            {
+                _state = _awaitableIsNotCompleted;
+            }
+
+            // Change the state from observed -> not cancelled.
+            // We only want to reset the cancelled state if it was observed
+            if (_cancelledState == CancelledState.CancellationObserved)
+            {
+                _cancelledState = CancelledState.NotCancelled;
+            }
+        }
+
+        public bool IsCompleted => ReferenceEquals(_state, _awaitableIsCompleted);
+        internal bool HasContinuation => !ReferenceEquals(_state, _awaitableIsNotCompleted);
+
+        public Action OnCompleted(Action continuation, out bool doubleCompletion)
+        {
+            doubleCompletion = false;
+            var awaitableState = _state;
+            if (ReferenceEquals(awaitableState, _awaitableIsNotCompleted))
+            {
+                _state = continuation;
+            }
+
+            if (ReferenceEquals(awaitableState, _awaitableIsCompleted))
+            {
+                return continuation;
+            }
+
+            if (!ReferenceEquals(awaitableState, _awaitableIsNotCompleted))
+            {
+                doubleCompletion = true;
+                return continuation;
+            }
+
+            return null;
+        }
+
+        public Action Cancel()
+        {
+            var action = Complete();
+            _cancelledState = action == null ?
+                CancelledState.CancellationPreRequested :
+                CancelledState.CancellationRequested;
+            return action;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ObserveCancelation()
+        {
+            if (_cancelledState == CancelledState.NotCancelled)
+            {
+                return false;
+            }
+
+            bool isPrerequested = _cancelledState == CancelledState.CancellationPreRequested;
+
+            if (_cancelledState >= CancelledState.CancellationPreRequested)
+            {
+                _cancelledState = CancelledState.CancellationObserved;
+
+                // Do not reset awaitable if we were not awaiting in the first place
+                if (!isPrerequested)
+                {
+                    Reset();
+                }
+
+                _cancellationToken.ThrowIfCancellationRequested();
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public override string ToString()
+        {
+            return $"CancelledState: {_cancelledState}, {nameof(IsCompleted)}: {IsCompleted}";
+        }
+
+        private enum CancelledState
+        {
+            NotCancelled = 0,
+            CancellationObserved = 1,
+            CancellationPreRequested = 2,
+            CancellationRequested = 3,
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipeCompletion.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipeCompletion.cs
@@ -1,0 +1,141 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    internal struct PipeCompletion
+    {
+        private static readonly ArrayPool<PipeCompletionCallback> CompletionCallbackPool = ArrayPool<PipeCompletionCallback>.Shared;
+
+        private const int InitialCallbacksSize = 1;
+        private static readonly Exception _completedNoException = new Exception();
+
+#if COMPLETION_LOCATION_TRACKING
+        private string _completionLocation;
+#endif
+        private Exception _exception;
+
+        private PipeCompletionCallback[] _callbacks;
+        private int _callbackCount;
+
+        public string Location
+        {
+            get
+            {
+#if COMPLETION_LOCATION_TRACKING
+                return _completionLocation;
+#else
+                return null;
+#endif
+            }
+        }
+
+        public bool IsCompleted => _exception != null;
+
+        public PipeCompletionCallbacks TryComplete(Exception exception = null)
+        {
+#if COMPLETION_LOCATION_TRACKING
+            _completionLocation = Environment.StackTrace;
+#endif
+            if (_exception == null)
+            {
+                // Set the exception object to the exception passed in or a sentinel value
+                _exception = exception ?? _completedNoException;
+            }
+            return GetCallbacks();
+        }
+
+        public PipeCompletionCallbacks AddCallback(Action<Exception, object> callback, object state)
+        {
+            if (_callbacks == null)
+            {
+                _callbacks = CompletionCallbackPool.Rent(InitialCallbacksSize);
+            }
+
+            var newIndex = _callbackCount;
+            _callbackCount++;
+
+            if (newIndex == _callbacks.Length)
+            {
+                var newArray = new PipeCompletionCallback[_callbacks.Length * 2];
+                Array.Copy(_callbacks, newArray, _callbacks.Length);
+                CompletionCallbackPool.Return(_callbacks);
+                _callbacks = newArray;
+            }
+            _callbacks[newIndex].Callback = callback;
+            _callbacks[newIndex].State = state;
+
+            if (IsCompleted)
+            {
+                return GetCallbacks();
+            }
+
+            return null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsCompletedOrThrow()
+        {
+            if (_exception == null)
+            {
+                return false;
+            }
+
+            if (_exception != _completedNoException)
+            {
+                ThrowFailed();
+            }
+
+            return true;
+        }
+
+        private PipeCompletionCallbacks GetCallbacks()
+        {
+            Debug.Assert(IsCompleted);
+            if (_callbackCount == 0)
+            {
+                return null;
+            }
+
+            var callbacks = new PipeCompletionCallbacks(CompletionCallbackPool,
+                _callbackCount,
+                _exception == _completedNoException ? null : _exception,
+                _callbacks);
+
+            _callbacks = null;
+            _callbackCount = 0;
+            return callbacks;
+        }
+
+        public void Reset()
+        {
+            Debug.Assert(IsCompleted);
+            Debug.Assert(_callbacks == null);
+            _exception = null;
+#if COMPLETION_LOCATION_TRACKING
+            _completionLocation = null;
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowFailed()
+        {
+            throw _exception;
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(IsCompleted)}: {IsCompleted}";
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipeCompletionCallback.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipeCompletionCallback.cs
@@ -1,0 +1,17 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    internal struct PipeCompletionCallback
+    {
+        public Action<Exception, object> Callback;
+        public object State;
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipeCompletionCallbacks.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipeCompletionCallbacks.cs
@@ -1,0 +1,69 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    internal class PipeCompletionCallbacks
+    {
+        private readonly ArrayPool<PipeCompletionCallback> _pool;
+        private readonly int _count;
+        private readonly Exception _exception;
+        private readonly PipeCompletionCallback[] _callbacks;
+
+        public PipeCompletionCallbacks(ArrayPool<PipeCompletionCallback> pool, int count, Exception exception, PipeCompletionCallback[] callbacks)
+        {
+            _pool = pool;
+            _count = count;
+            _exception = exception;
+            _callbacks = callbacks;
+        }
+
+        public void Execute()
+        {
+            if (_callbacks == null || _count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                List<Exception> exceptions = null;
+
+                for (int i = 0; i < _count; i++)
+                {
+                    var callback = _callbacks[i];
+                    try
+                    {
+                        callback.Callback(_exception, callback.State);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (exceptions == null)
+                        {
+                            exceptions = new List<Exception>();
+                        }
+                        exceptions.Add(ex);
+                    }
+                }
+
+                if (exceptions != null)
+                {
+                    throw new AggregateException(exceptions);
+                }
+            }
+            finally
+            {
+                _pool.Return(_callbacks);
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipeFactory.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipeFactory.cs
@@ -1,0 +1,42 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Factory used to creaet instances of various pipelines.
+    /// </summary>
+    public class PipeFactory : IDisposable
+    {
+        private readonly BufferPool _pool;
+
+        public PipeFactory() : this(new MemoryPool())
+        {
+        }
+
+        public PipeFactory(BufferPool pool)
+        {
+            _pool = pool;
+        }
+
+        public IPipe Create()
+        {
+            return new Pipe(_pool);
+        }
+
+        public IPipe Create(PipeOptions options)
+        {
+            return new Pipe(_pool, options);
+        }
+
+        public void Dispose() => _pool.Dispose();
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipeOperationState.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipeOperationState.cs
@@ -1,0 +1,94 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    internal struct PipeOperationState
+    {
+        private State _state;
+#if OPERATION_LOCATION_TRACKING
+        private string _operationStartLocation;
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Begin(ExceptionResource exception)
+        {
+            // Inactive and Tenative are allowed
+            if (_state == State.Active)
+            {
+                PipelinesThrowHelper.ThrowInvalidOperationException(exception, Location);
+            }
+
+            _state = State.Active;
+
+#if OPERATION_LOCATION_TRACKING
+            _operationStartLocation = Environment.StackTrace;
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void BeginTentative(ExceptionResource exception)
+        {
+            // Inactive and Tenative are allowed
+            if (_state == State.Active)
+            {
+                PipelinesThrowHelper.ThrowInvalidOperationException(exception, Location);
+            }
+
+            _state = State.Tentative;
+
+#if OPERATION_LOCATION_TRACKING
+            _operationStartLocation = Environment.StackTrace;
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void End(ExceptionResource exception)
+        {
+            if (_state == State.Inactive)
+            {
+                PipelinesThrowHelper.ThrowInvalidOperationException(exception, Location);
+            }
+
+            _state = State.Inactive;
+#if OPERATION_LOCATION_TRACKING
+            _operationStartLocation = null;
+#endif
+        }
+
+        public bool IsActive => _state == State.Active;
+
+        public string Location
+        {
+            get
+            {
+#if OPERATION_LOCATION_TRACKING
+                return _operationStartLocation;
+#else
+                return null;
+#endif
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"State: {_state}";
+        }
+    }
+
+    internal enum State: byte
+    {
+        Inactive = 1,
+        Active = 2,
+        Tentative = 3
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipeOptions.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipeOptions.cs
@@ -1,0 +1,23 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public class PipeOptions
+    {
+        public long MaximumSizeHigh { get; set; }
+
+        public long MaximumSizeLow { get; set; }
+
+        public IScheduler WriterScheduler { get; set; }
+
+        public IScheduler ReaderScheduler { get; set; }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipelineReaderExtensions.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipelineReaderExtensions.cs
@@ -1,0 +1,20 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public static class PipelineReaderExtensions
+    {
+        public static void Advance(this IPipeReader input, ReadCursor cursor)
+        {
+            input.Advance(cursor, cursor);
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipelineWriterExtensions.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipelineWriterExtensions.cs
@@ -1,0 +1,47 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public static class PipelineWriterExtensions
+    {
+        private readonly static Task _completedTask = Task.FromResult(0);
+
+        public static Task WriteAsync(this IPipeWriter output, byte[] source)
+        {
+            return WriteAsync(output, new ArraySegment<byte>(source));
+        }
+
+        public static Task WriteAsync(this IPipeWriter output, ArraySegment<byte> source)
+        {
+            var writeBuffer = output.Alloc();
+            writeBuffer.Write(source);
+            return FlushAsync(writeBuffer);
+        }
+
+        private static Task FlushAsync(WritableBuffer writeBuffer)
+        {
+            var awaitable = writeBuffer.FlushAsync();
+            if (awaitable.IsCompleted)
+            {
+                awaitable.GetResult();
+                return _completedTask;
+            }
+
+            return FlushAsyncAwaited(awaitable);
+        }
+
+        private static async Task FlushAsyncAwaited(WritableBufferAwaitable awaitable)
+        {
+            await awaitable;
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PipelinesThrowHelper.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PipelinesThrowHelper.cs
@@ -1,0 +1,208 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    internal class PipelinesThrowHelper
+    {
+        public static void ThrowArgumentOutOfRangeException(int sourceLength, int offset)
+        {
+            throw GetArgumentOutOfRangeException(sourceLength, offset);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(int sourceLength, int offset)
+        {
+            if ((uint)offset > (uint)sourceLength)
+            {
+                // Offset is negative or less than array length
+                return new ArgumentOutOfRangeException(GetArgumentName(ExceptionArgument.offset));
+            }
+
+            // The third parameter (not passed) length must be out of range
+            return new ArgumentOutOfRangeException(GetArgumentName(ExceptionArgument.length));
+        }
+
+        public static void ThrowArgumentOutOfRangeException(ExceptionArgument argument)
+        {
+            throw GetArgumentOutOfRangeException(argument);
+        }
+
+        public static void ThrowInvalidOperationException(ExceptionResource resource, string location = null)
+        {
+            throw GetInvalidOperationException(resource, location);
+        }
+
+        public static void ThrowArgumentNullException(ExceptionArgument argument)
+        {
+            throw GetArgumentNullException(argument);
+        }
+
+        public static void ThrowNotSupportedException()
+        {
+            throw GetNotSupportedException();
+        }
+
+        public static void ThrowArgumentOutOfRangeException_BufferRequestTooLarge(int maxSize)
+        {
+            throw GetArgumentOutOfRangeException_BufferRequestTooLarge(maxSize);
+        }
+
+        public static void ThrowObjectDisposedException(string objectName)
+        {
+            throw GetObjectDisposedException(objectName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument)
+        {
+            return new ArgumentOutOfRangeException(GetArgumentName(argument));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static InvalidOperationException GetInvalidOperationException(ExceptionResource resource, string location = null)
+        {
+            return new InvalidOperationException(GetResourceString(resource, location));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static NotSupportedException GetNotSupportedException()
+        {
+            return new NotSupportedException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentNullException GetArgumentNullException(ExceptionArgument argument)
+        {
+            return new ArgumentNullException(GetArgumentName(argument));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException_BufferRequestTooLarge(int maxSize)
+        {
+            return new ArgumentOutOfRangeException(GetArgumentName(ExceptionArgument.size),
+                $"Cannot allocate more than {maxSize} bytes in a single buffer");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ObjectDisposedException GetObjectDisposedException(string objectName)
+        {
+            return new ObjectDisposedException(objectName);
+        }
+
+        private static string GetArgumentName(ExceptionArgument argument)
+        {
+            Debug.Assert(Enum.IsDefined(typeof(ExceptionArgument), argument),
+                "The enum value is not defined, please check the ExceptionArgument Enum.");
+
+            return argument.ToString();
+        }
+
+        private static string GetResourceString(ExceptionResource argument, string location = null)
+        {
+            Debug.Assert(Enum.IsDefined(typeof(ExceptionResource), argument),
+                "The enum value is not defined, please check the ExceptionResource Enum.");
+
+            // Should be look up with environment resources
+            string resourceString = null;
+            switch (argument)
+            {
+                case ExceptionResource.AlreadyWriting:
+                    resourceString = "Already writing.";
+                    break;
+                case ExceptionResource.NotWritingNoAlloc:
+                    resourceString = "No writing operation. Make sure Alloc() was called.";
+                    break;
+                case ExceptionResource.NoWriteToComplete:
+                    resourceString = "No writing operation to complete.";
+                    break;
+                case ExceptionResource.AlreadyReading:
+                    resourceString = "Already reading.";
+                    break;
+                case ExceptionResource.NoReadToComplete:
+                    resourceString = "No reading operation to complete.";
+                    break;
+                case ExceptionResource.NoConcurrentOperation:
+                    resourceString = "Concurrent reads or writes are not supported.";
+                    break;
+                case ExceptionResource.GetResultNotCompleted:
+                    resourceString = "Can't GetResult unless completed";
+                    break;
+                case ExceptionResource.NoWritingAllowed:
+                    resourceString = "Writing is not allowed after writer was completed";
+                    break;
+                case ExceptionResource.NoReadingAllowed:
+                    resourceString = "Reading is not allowed after reader was completed";
+                    break;
+                case ExceptionResource.CompleteWriterActiveWriter:
+                    resourceString = "Can't complete writer while writing.";
+                    break;
+                case ExceptionResource.CompleteReaderActiveReader:
+                    resourceString = "Can't complete reader while reading.";
+                    break;
+                case ExceptionResource.AdvancingPastBufferSize:
+                    resourceString = "Can't advance past buffer size";
+                    break;
+                case ExceptionResource.AdvancingWithNoBuffer:
+                    resourceString = "Can't advance without buffer allocated";
+                    break;
+                case ExceptionResource.BackpressureDeadlock:
+                    resourceString = "Advancing examined to the end would cause pipe to deadlock because FlushAsync is waiting";
+                    break;
+                case ExceptionResource.AdvanceToInvalidCursor:
+                    resourceString = "Pipe is already advanced past provided cursor";
+                    break;
+            }
+
+            resourceString = resourceString ?? $"Error ResourceKey not defined {argument}.";
+
+            if (location != null)
+            {
+                resourceString += Environment.NewLine;
+                resourceString += "From: " + location.Replace("at ", ">> ");
+            }
+
+            return resourceString;
+        }
+    }
+
+    internal enum ExceptionArgument
+    {
+        minimumSize,
+        bytesWritten,
+        destination,
+        offset,
+        length,
+        data,
+        size
+    }
+
+    internal enum ExceptionResource
+    {
+        AlreadyWriting,
+        NotWritingNoAlloc,
+        NoWriteToComplete,
+        AlreadyReading,
+        NoReadToComplete,
+        NoConcurrentOperation,
+        GetResultNotCompleted,
+        NoWritingAllowed,
+        NoReadingAllowed,
+        CompleteWriterActiveWriter,
+        CompleteReaderActiveReader,
+        AdvancingPastBufferSize,
+        AdvancingWithNoBuffer,
+        BackpressureDeadlock,
+        AdvanceToInvalidCursor
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/PreservedBuffer.cs
+++ b/shared/corefxlab/System.IO.Pipelines/PreservedBuffer.cs
@@ -1,0 +1,55 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Represents a buffer that can read a sequential series of bytes.
+    /// </summary>
+    public struct PreservedBuffer : IDisposable
+    {
+        private ReadableBuffer _buffer;
+
+        internal PreservedBuffer(ref ReadableBuffer buffer)
+        {
+            _buffer = buffer;
+        }
+
+        /// <summary>
+        /// Returns the preserved <see cref="ReadableBuffer"/>.
+        /// </summary>
+        public ReadableBuffer Buffer => _buffer;
+
+        /// <summary>
+        /// Dispose the preserved buffer.
+        /// </summary>
+        public void Dispose()
+        {
+            var returnStart = _buffer.Start.Segment;
+            var returnEnd = _buffer.End.Segment;
+
+            while (true)
+            {
+                var returnSegment = returnStart;
+                returnStart = returnStart?.Next;
+                returnSegment?.Dispose();
+
+                if (returnSegment == returnEnd)
+                {
+                    break;
+                }
+            }
+
+            _buffer.ClearCursors();
+        }
+
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/ReadCursor.cs
+++ b/shared/corefxlab/System.IO.Pipelines/ReadCursor.cs
@@ -1,0 +1,345 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public struct ReadCursor : IEquatable<ReadCursor>
+    {
+        internal BufferSegment Segment;
+        internal int Index;
+
+        internal ReadCursor(BufferSegment segment)
+        {
+            Segment = segment;
+            Index = segment?.Start ?? 0;
+        }
+
+        internal ReadCursor(BufferSegment segment, int index)
+        {
+            Segment = segment;
+            Index = index;
+        }
+
+        internal bool IsDefault => Segment == null;
+
+        internal bool IsEnd
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                var segment = Segment;
+
+                if (segment == null)
+                {
+                    return true;
+                }
+                else if (Index < segment.End)
+                {
+                    return false;
+                }
+                else if (segment.Next == null)
+                {
+                    return true;
+                }
+                else
+                {
+                    return IsEndMultiSegment();
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool IsEndMultiSegment()
+        {
+            var segment = Segment.Next;
+            while (segment != null)
+            {
+                if (segment.Start < segment.End)
+                {
+                    return false; // subsequent block has data - IsEnd is false
+                }
+                segment = segment.Next;
+            }
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal int GetLength(ReadCursor end)
+        {
+            if (IsDefault)
+            {
+                return 0;
+            }
+            return GetLength(Segment, Index, end.Segment, end.Index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int GetLength(
+            BufferSegment start,
+            int startIndex,
+            BufferSegment endSegment,
+            int endIndex)
+        {
+            if (start == endSegment)
+            {
+                return endIndex - startIndex;
+            }
+
+            return GetLengthMultiSegment(start, startIndex, endSegment, endIndex);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int GetLengthMultiSegment(BufferSegment start,
+            int startIndex,
+            BufferSegment endSegment,
+            int endIndex)
+        {
+            var segment = start;
+            var index = startIndex;
+            var length = 0;
+            checked
+            {
+                while (true)
+                {
+                    if (segment == endSegment)
+                    {
+                        return length + endIndex - index;
+                    }
+                    else if (segment.Next == null)
+                    {
+                        return length;
+                    }
+                    else
+                    {
+                        length += segment.End - index;
+                        segment = segment.Next;
+                        index = segment.Start;
+                    }
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal ReadCursor Seek(int bytes, ReadCursor end, bool checkEndReachable = true)
+        {
+            if (IsEnd)
+            {
+                return this;
+            }
+
+            ReadCursor cursor;
+            if (Segment == end.Segment && end.Index - Index >= bytes)
+            {
+                cursor = new ReadCursor(Segment, Index + bytes);
+            }
+            else
+            {
+                cursor = SeekMultiSegment(bytes, end, checkEndReachable);
+            }
+
+            return cursor;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private ReadCursor SeekMultiSegment(int bytes, ReadCursor end, bool checkEndReachable)
+        {
+            ReadCursor result = default(ReadCursor);
+            bool foundResult = false;
+
+            foreach (var segmentPart in new SegmentEnumerator(this, end))
+            {
+                // We need to loop up until the end to make sure start and end are connected
+                // if end is not trusted
+                if (!foundResult)
+                {
+                    if (segmentPart.Length >= bytes)
+                    {
+                        result = new ReadCursor(segmentPart.Segment, segmentPart.Start + bytes);
+                        foundResult = true;
+                        if (!checkEndReachable)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        bytes -= segmentPart.Length;
+                    }
+                }
+
+            }
+            if (!foundResult)
+            {
+                ThrowOutOfBoundsException();
+            }
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void BoundsCheck(ReadCursor newCursor)
+        {
+            if (!this.GreaterOrEqual(newCursor))
+            {
+                ThrowOutOfBoundsException();
+            }
+        }
+
+        private static void ThrowOutOfBoundsException()
+        {
+            throw new InvalidOperationException("Cursor is out of bounds");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool TryGetBuffer(ReadCursor end, out Buffer<byte> data)
+        {
+            if (IsDefault)
+            {
+                data = Buffer<byte>.Empty;
+                return false;
+            }
+
+            var segment = Segment;
+            var index = Index;
+
+            if (end.Segment == segment)
+            {
+                var following = end.Index - index;
+
+                if (following > 0)
+                {
+                    data = segment.Buffer.Slice(index, following);
+                    return true;
+                }
+
+                data = Buffer<byte>.Empty;
+                return false;
+            }
+            else
+            {
+                return TryGetBufferMultiBlock(end, out data);
+            }
+        }
+
+        private bool TryGetBufferMultiBlock(ReadCursor end, out Buffer<byte> data)
+        {
+            var segment = Segment;
+            var index = Index;
+
+            // Determine if we might attempt to copy data from segment.Next before
+            // calculating "following" so we don't risk skipping data that could
+            // be added after segment.End when we decide to copy from segment.Next.
+            // segment.End will always be advanced before segment.Next is set.
+
+            int following = 0;
+
+            while (true)
+            {
+                var wasLastSegment = segment.Next == null || end.Segment == segment;
+
+                if (end.Segment == segment)
+                {
+                    following = end.Index - index;
+                }
+                else
+                {
+                    following = segment.End - index;
+                }
+
+                if (following > 0)
+                {
+                    break;
+                }
+
+                if (wasLastSegment)
+                {
+                    data = Buffer<byte>.Empty;
+                    return false;
+                }
+                else
+                {
+                    segment = segment.Next;
+                    index = segment.Start;
+                }
+            }
+
+            data = segment.Buffer.Slice(index, following);
+            return true;
+        }
+
+        public override string ToString()
+        {
+            if (IsEnd)
+            {
+                return "<end>";
+            }
+
+            var sb = new StringBuilder();
+            Span<byte> span = Segment.Buffer.Span.Slice(Index, Segment.End - Index);
+            SpanExtensions.AppendAsLiteral(span, sb);
+            return sb.ToString();
+        }
+
+        public static bool operator ==(ReadCursor c1, ReadCursor c2)
+        {
+            return c1.Equals(c2);
+        }
+
+        public static bool operator !=(ReadCursor c1, ReadCursor c2)
+        {
+            return !c1.Equals(c2);
+        }
+
+        public bool Equals(ReadCursor other)
+        {
+            return other.Segment == Segment && other.Index == Index;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals((ReadCursor)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            var h1 = Segment?.GetHashCode() ?? 0;
+            var h2 = Index.GetHashCode();
+
+            var shift5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
+            return ((int)shift5 + h1) ^ h2;
+        }
+
+        internal bool GreaterOrEqual(ReadCursor other)
+        {
+            if (other.Segment == Segment)
+            {
+                return other.Index <= Index;
+            }
+            return IsReachable(other);
+        }
+
+        internal bool IsReachable(ReadCursor other)
+        {
+            var current = other.Segment;
+            while (current != null)
+            {
+                if (current == Segment)
+                {
+                    return true;
+                }
+                current = current.Next;
+            }
+            return false;
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/ReadCursorOperations.cs
+++ b/shared/corefxlab/System.IO.Pipelines/ReadCursorOperations.cs
@@ -1,0 +1,82 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public static class ReadCursorOperations
+    {
+        public static int Seek(ReadCursor begin, ReadCursor end, out ReadCursor result, byte byte0)
+        {
+            var enumerator = new SegmentEnumerator(begin, end);
+            while (enumerator.MoveNext())
+            {
+                var segmentPart = enumerator.Current;
+                var segment = segmentPart.Segment;
+                var span = segment.Buffer.Span.Slice(segmentPart.Start, segmentPart.Length);
+
+                int index = span.IndexOf(byte0);
+                if (index != -1)
+                {
+                    result = new ReadCursor(segment, segmentPart.Start + index);
+                    return span[index];
+                }
+            }
+
+            result = end;
+            return -1;
+        }
+
+        public static int Seek(ReadCursor begin, ReadCursor end, out ReadCursor result, byte byte0, byte byte1)
+        {
+            var enumerator = new SegmentEnumerator(begin, end);
+            while (enumerator.MoveNext())
+            {
+                var segmentPart = enumerator.Current;
+                var segment = segmentPart.Segment;
+                var span = segment.Buffer.Span.Slice(segmentPart.Start, segmentPart.Length);
+
+                int index = span.IndexOfAny(byte0, byte1);
+
+                if (index != -1)
+                {
+                    result = new ReadCursor(segment, segmentPart.Start + index);
+                    return span[index];
+                }
+            }
+
+            result = end;
+            return -1;
+        }
+
+        public static int Seek(ReadCursor begin, ReadCursor end, out ReadCursor result, byte byte0, byte byte1, byte byte2)
+        {
+            var enumerator = new SegmentEnumerator(begin, end);
+            while (enumerator.MoveNext())
+            {
+                var segmentPart = enumerator.Current;
+                var segment = segmentPart.Segment;
+                var span = segment.Buffer.Span.Slice(segmentPart.Start, segmentPart.Length);
+
+                int index = span.IndexOfAny(byte0, byte1, byte2);
+
+                if (index != -1)
+                {
+                    result = new ReadCursor(segment, segmentPart.Start + index);
+                    return span[index];
+                }
+            }
+
+            result = end;
+            return -1;
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/ReadResult.cs
+++ b/shared/corefxlab/System.IO.Pipelines/ReadResult.cs
@@ -1,0 +1,50 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// The result of a <see cref="IPipeReader.ReadAsync"/> call.
+    /// </summary>
+    public struct ReadResult
+    {
+        internal ReadableBuffer ResultBuffer;
+        internal ResultFlags ResultFlags;
+
+        public ReadResult(ReadableBuffer buffer, bool isCancelled, bool isCompleted)
+        {
+            ResultBuffer = buffer;
+            ResultFlags = ResultFlags.None;
+
+            if (isCompleted)
+            {
+                ResultFlags |= ResultFlags.Completed;
+            }
+            if (isCancelled)
+            {
+                ResultFlags |= ResultFlags.Cancelled;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="ReadableBuffer"/> that was read
+        /// </summary>
+        public ReadableBuffer Buffer => ResultBuffer;
+
+        /// <summary>
+        /// True if the currrent read was cancelled
+        /// </summary>
+        public bool IsCancelled => (ResultFlags & ResultFlags.Cancelled) != 0;
+
+        /// <summary>
+        /// True if the <see cref="IPipeReader"/> is complete
+        /// </summary>
+        public bool IsCompleted => (ResultFlags & ResultFlags.Completed) != 0;
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/ReadableBuffer.cs
+++ b/shared/corefxlab/System.IO.Pipelines/ReadableBuffer.cs
@@ -1,0 +1,340 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Collections.Sequences;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Represents a buffer that can read a sequential series of bytes.
+    /// </summary>
+    public struct ReadableBuffer : ISequence<ReadOnlyBuffer<byte>>
+    {
+        internal ReadCursor BufferStart;
+        internal ReadCursor BufferEnd;
+        internal int BufferLength;
+
+        /// <summary>
+        /// Length of the <see cref="ReadableBuffer"/> in bytes.
+        /// </summary>
+        public int Length => BufferLength;
+
+        /// <summary>
+        /// Determines if the <see cref="ReadableBuffer"/> is empty.
+        /// </summary>
+        public bool IsEmpty => BufferLength == 0;
+
+        /// <summary>
+        /// Determins if the <see cref="ReadableBuffer"/> is a single <see cref="Buffer{Byte}"/>.
+        /// </summary>
+        public bool IsSingleSpan => BufferStart.Segment == BufferEnd.Segment;
+
+        public Buffer<byte> First
+        {
+            get
+            {
+                BufferStart.TryGetBuffer(BufferEnd, out Buffer<byte> first);
+                return first;
+            }
+        }
+
+        /// <summary>
+        /// A cursor to the start of the <see cref="ReadableBuffer"/>.
+        /// </summary>
+        public ReadCursor Start => BufferStart;
+
+        /// <summary>
+        /// A cursor to the end of the <see cref="ReadableBuffer"/>
+        /// </summary>
+        public ReadCursor End => BufferEnd;
+
+        internal ReadableBuffer(ReadCursor start, ReadCursor end)
+        {
+            BufferStart = start;
+            BufferEnd = end;
+            BufferLength = start.GetLength(end);
+        }
+
+        private ReadableBuffer(ref ReadableBuffer buffer)
+        {
+            var begin = buffer.BufferStart;
+            var end = buffer.BufferEnd;
+
+            BufferSegment segmentTail;
+            var segmentHead = BufferSegment.Clone(begin, end, out segmentTail);
+
+            begin = new ReadCursor(segmentHead);
+            end = new ReadCursor(segmentTail, segmentTail.End);
+
+            BufferStart = begin;
+            BufferEnd = end;
+
+            BufferLength = buffer.BufferLength;
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given <see cref="ReadableBuffer"/>, beginning at 'start', and is at most length bytes
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="length">The length of the slice</param>
+        public ReadableBuffer Slice(int start, int length)
+        {
+            var begin = BufferStart.Seek(start, BufferEnd, false);
+            var end = begin.Seek(length, BufferEnd, false);
+            return Slice(begin, end);
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given <see cref="ReadableBuffer"/>, beginning at 'start', ending at 'end' (inclusive).
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="end">The end (inclusive) of the slice</param>
+        public ReadableBuffer Slice(int start, ReadCursor end)
+        {
+            BufferEnd.BoundsCheck(end);
+            var begin = BufferStart.Seek(start, end);
+            return Slice(begin, end);
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given <see cref="ReadableBuffer"/>, beginning at 'start', ending at 'end' (inclusive).
+        /// </summary>
+        /// <param name="start">The starting (inclusive) <see cref="ReadCursor"/> at which to begin this slice.</param>
+        /// <param name="end">The ending (inclusive) <see cref="ReadCursor"/> of the slice</param>
+        public ReadableBuffer Slice(ReadCursor start, ReadCursor end)
+        {
+            BufferEnd.BoundsCheck(end);
+            end.BoundsCheck(start);
+
+            return new ReadableBuffer(start, end);
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given <see cref="ReadableBuffer"/>, beginning at 'start', and is at most length bytes
+        /// </summary>
+        /// <param name="start">The starting (inclusive) <see cref="ReadCursor"/> at which to begin this slice.</param>
+        /// <param name="length">The length of the slice</param>
+        public ReadableBuffer Slice(ReadCursor start, int length)
+        {
+            BufferEnd.BoundsCheck(start);
+
+            var end = start.Seek(length, BufferEnd, false);
+
+            return Slice(start, end);
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given <see cref="ReadableBuffer"/>, beginning at 'start', ending at the existing <see cref="ReadableBuffer"/>'s end.
+        /// </summary>
+        /// <param name="start">The starting (inclusive) <see cref="ReadCursor"/> at which to begin this slice.</param>
+        public ReadableBuffer Slice(ReadCursor start)
+        {
+            BufferEnd.BoundsCheck(start);
+
+            return new ReadableBuffer(start, BufferEnd);
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given <see cref="ReadableBuffer"/>, beginning at 'start', ending at the existing <see cref="ReadableBuffer"/>'s end.
+        /// </summary>
+        /// <param name="start">The start index at which to begin this slice.</param>
+        public ReadableBuffer Slice(int start)
+        {
+            if (start == 0) return this;
+
+            var begin = BufferStart.Seek(start, BufferEnd, false);
+            return new ReadableBuffer(begin, BufferEnd);
+        }
+
+        /// <summary>
+        /// This transfers ownership of the buffer from the <see cref="IPipeReader"/> to the caller of this method. Preserved buffers must be disposed to avoid
+        /// memory leaks.
+        /// </summary>
+        public PreservedBuffer Preserve()
+        {
+            var buffer = new ReadableBuffer(ref this);
+            return new PreservedBuffer(ref buffer);
+        }
+
+        /// <summary>
+        /// Copy the <see cref="ReadableBuffer"/> to the specified <see cref="Span{Byte}"/>.
+        /// </summary>
+        /// <param name="destination">The destination <see cref="Span{Byte}"/>.</param>
+        public void CopyTo(Span<byte> destination)
+        {
+            if (Length > destination.Length)
+            {
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.destination);
+            }
+
+            foreach (var buffer in this)
+            {
+                buffer.Span.CopyTo(destination);
+                destination = destination.Slice(buffer.Length);
+            }
+        }
+
+        /// <summary>
+        /// Converts the <see cref="ReadableBuffer"/> to a <see cref="T:byte[]"/>
+        /// </summary>
+        public byte[] ToArray()
+        {
+            var buffer = new byte[Length];
+            CopyTo(buffer);
+            return buffer;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            foreach (var buffer in this)
+            {
+                SpanExtensions.AppendAsLiteral(buffer.Span, sb);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns an enumerator over the <see cref="ReadableBuffer"/>
+        /// </summary>
+        public BufferEnumerator GetEnumerator()
+        {
+            return new BufferEnumerator(BufferStart, BufferEnd);
+        }
+
+        internal void ClearCursors()
+        {
+            BufferStart = default(ReadCursor);
+            BufferEnd = default(ReadCursor);
+        }
+
+        /// <summary>
+        /// Create a <see cref="ReadableBuffer"/> over an array.
+        /// </summary>
+        public static ReadableBuffer Create(byte[] data)
+        {
+            if (data == null)
+            {
+                PipelinesThrowHelper.ThrowArgumentNullException(ExceptionArgument.data);
+            }
+
+            OwnedBuffer<byte> buffer = data;
+            return CreateInternal(buffer, 0, data.Length);
+        }
+
+        /// <summary>
+        /// Create a <see cref="ReadableBuffer"/> over an array.
+        /// </summary>
+        public static ReadableBuffer Create(byte[] data, int offset, int length)
+        {
+            if (data == null)
+            {
+                PipelinesThrowHelper.ThrowArgumentNullException(ExceptionArgument.data);
+            }
+
+            OwnedBuffer<byte> buffer = data;
+            return Create(buffer, offset, length);
+        }
+
+        /// <summary>
+        /// Create a <see cref="ReadableBuffer"/> over an OwnedBuffer.
+        /// </summary>
+        public static ReadableBuffer Create(OwnedBuffer<byte> data, int offset, int length)
+        {
+            if (data == null)
+            {
+                PipelinesThrowHelper.ThrowArgumentNullException(ExceptionArgument.data);
+            }
+
+            if (offset < 0)
+            {
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset);
+            }
+
+            if (length < 0 || length > data.Length - offset)
+            {
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+            }
+
+            return CreateInternal(data, offset, length);
+        }
+
+        private static ReadableBuffer CreateInternal(OwnedBuffer<byte> data, int offset, int length)
+        {
+            var segment = new BufferSegment(data);
+            segment.Start = offset;
+            segment.End = offset + length;
+            return new ReadableBuffer(new ReadCursor(segment, offset), new ReadCursor(segment, offset + length));
+        }
+
+        bool ISequence<ReadOnlyBuffer<byte>>.TryGet(ref Position position, out ReadOnlyBuffer<byte> item, bool advance)
+        {
+            if (position == Position.First)
+            {
+                // First is already sliced
+                item = First;
+                if (advance)
+                {
+                    if (BufferStart.IsEnd)
+                    {
+                        position = Position.AfterLast;
+                    }
+                    else
+                    {
+                        position.ObjectPosition = BufferStart.Segment.Next;
+                        if (position.ObjectPosition == null)
+                        {
+                            position = Position.AfterLast;
+                        }
+                    }
+                }
+                return true;
+            }
+            else if (position == Position.AfterLast)
+            {
+                item = default(ReadOnlyBuffer<byte>);
+                return false;
+            }
+
+            var currentSegment = (BufferSegment)position.ObjectPosition;
+            if (advance)
+            {
+                position.ObjectPosition = currentSegment.Next;
+                if (position.ObjectPosition == null)
+                {
+                    position = Position.AfterLast;
+                }
+            }
+            if (currentSegment == BufferEnd.Segment)
+            {
+                item = currentSegment.Buffer.Slice(currentSegment.Start, BufferEnd.Index - currentSegment.Start);
+            }
+            else
+            {
+                item = currentSegment.Buffer.Slice(currentSegment.Start, currentSegment.End - currentSegment.Start);
+            }
+            return true;
+        }
+
+        public ReadCursor Move(ReadCursor cursor, int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+            return cursor.Seek(count, BufferEnd, false);
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/ReadableBufferAwaitable.cs
+++ b/shared/corefxlab/System.IO.Pipelines/ReadableBufferAwaitable.cs
@@ -1,0 +1,37 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// An awaitable object that represents an asynchronous read operation
+    /// </summary>
+    public struct ReadableBufferAwaitable : ICriticalNotifyCompletion
+    {
+        private readonly IReadableBufferAwaiter _awaiter;
+
+        public ReadableBufferAwaitable(IReadableBufferAwaiter awaiter)
+        {
+            _awaiter = awaiter;
+        }
+
+        public bool IsCompleted => _awaiter.IsCompleted;
+
+        public ReadResult GetResult() => _awaiter.GetResult();
+
+        public ReadableBufferAwaitable GetAwaiter() => this;
+
+        public void UnsafeOnCompleted(Action continuation) => _awaiter.OnCompleted(continuation);
+
+        public void OnCompleted(Action continuation) => _awaiter.OnCompleted(continuation);
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/ReadableBufferReader.cs
+++ b/shared/corefxlab/System.IO.Pipelines/ReadableBufferReader.cs
@@ -1,0 +1,136 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public struct ReadableBufferReader
+    {
+        private Span<byte> _currentSpan;
+        private int _index;
+        private SegmentEnumerator _enumerator;
+        private int _consumedBytes;
+        private bool _end;
+
+        public ReadableBufferReader(ReadableBuffer buffer) : this(buffer.Start, buffer.End)
+        {
+        }
+
+        public ReadableBufferReader(ReadCursor start, ReadCursor end) : this()
+        {
+            _end = false;
+            _index = 0;
+            _consumedBytes = 0;
+            _enumerator = new SegmentEnumerator(start, end);
+            _currentSpan = default(Span<byte>);
+            MoveNext();
+        }
+
+        public bool End => _end;
+
+        public int Index => _index;
+
+        public ReadCursor Cursor
+        {
+            get
+            {
+                var part = _enumerator.Current;
+
+                if (_end)
+                {
+                    return new ReadCursor(part.Segment, part.Start + _currentSpan.Length);
+                }
+
+                return new ReadCursor(part.Segment, part.Start + _index);
+            }
+        }
+
+        public Span<byte> Span => _currentSpan;
+
+        public int ConsumedBytes => _consumedBytes;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Peek()
+        {
+            if (_end)
+            {
+                return -1;
+            }
+            return _currentSpan[_index];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Take()
+        {
+            if (_end)
+            {
+                return -1;
+            }
+
+            var value = _currentSpan[_index];
+
+            _index++;
+            _consumedBytes++;
+
+            if (_index >= _currentSpan.Length)
+            {
+                MoveNext();
+            }
+
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void MoveNext()
+        {
+            while (_enumerator.MoveNext())
+            {
+                var part = _enumerator.Current;
+                var length = part.Length;
+                if (length != 0)
+                {
+                    _currentSpan = part.Segment.Buffer.Span.Slice(part.Start, length);
+                    _index = 0;
+                    return;
+                }
+            }
+
+            _end = true;
+        }
+
+        public void Skip(int length)
+        {
+            if (length < 0)
+            {
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+            }
+
+            _consumedBytes += length;
+
+            while (!_end && length > 0)
+            {
+                if ((_index + length) < _currentSpan.Length)
+                {
+                    _index += length;
+                    length = 0;
+                    break;
+                }
+
+                length -= (_currentSpan.Length - _index);
+                MoveNext();
+            }
+
+            if (length > 0)
+            {
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/ResultFlags.cs
+++ b/shared/corefxlab/System.IO.Pipelines/ResultFlags.cs
@@ -1,0 +1,16 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    [Flags]
+    internal enum ResultFlags : byte
+    {
+        None = 0,
+        Cancelled = 1,
+        Completed = 2
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/SegmentEnumerator.cs
+++ b/shared/corefxlab/System.IO.Pipelines/SegmentEnumerator.cs
@@ -1,0 +1,112 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    internal struct SegmentEnumerator
+    {
+        private BufferSegment _segment;
+        private SegmentPart _current;
+        private int _startIndex;
+        private readonly int _endIndex;
+        private readonly BufferSegment _endSegment;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public SegmentEnumerator(ReadCursor start, ReadCursor end)
+        {
+            _startIndex = start.Index;
+            _segment = start.Segment;
+            _endSegment = end.Segment;
+            _endIndex = end.Index;
+            _current = default(SegmentPart);
+        }
+
+        /// <summary>
+        /// The current <see cref="Buffer{Byte}"/>
+        /// </summary>
+        public SegmentPart Current => _current;
+
+        /// <summary>
+        /// Moves to the next <see cref="Buffer{Byte}"/> in the <see cref="ReadableBuffer"/>
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            var segment = _segment;
+
+            if (segment == null)
+            {
+                return false;
+            }
+
+            var start = _startIndex;
+            var end = segment.End;
+
+            if (segment == _endSegment)
+            {
+                end = _endIndex;
+                _segment = null;
+            }
+            else
+            {
+                _segment = segment.Next;
+                if (_segment == null)
+                {
+                    if (_endSegment != null)
+                    {
+                        ThrowEndNotSeen();
+                    }
+                }
+                else
+                {
+                    _startIndex = _segment.Start;
+                }
+            }
+
+            _current = new SegmentPart()
+            {
+                Segment = segment,
+                Start = start,
+                End = end,
+            };
+
+            return true;
+        }
+
+        private void ThrowEndNotSeen()
+        {
+            throw new InvalidOperationException("Segments ended by end was never seen");
+        }
+
+        public SegmentEnumerator GetEnumerator()
+        {
+            return this;
+        }
+
+        public void Reset()
+        {
+            PipelinesThrowHelper.ThrowNotSupportedException();
+        }
+
+        internal struct SegmentPart
+        {
+            public BufferSegment Segment;
+            public int Start;
+            public int End;
+
+            public int Length => End - Start;
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/SpanExtensions.cs
+++ b/shared/corefxlab/System.IO.Pipelines/SpanExtensions.cs
@@ -1,0 +1,78 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    internal class SpanExtensions
+    {
+        internal static void AppendAsLiteral(Span<byte> span, StringBuilder sb)
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                AppendCharLiteral((char) span[i], sb);
+            }
+        }
+
+        internal static void AppendCharLiteral(char c, StringBuilder sb)
+        {
+            switch (c)
+            {
+                case '\'':
+                    sb.Append(@"\'");
+                    break;
+                case '\"':
+                    sb.Append("\\\"");
+                    break;
+                case '\\':
+                    sb.Append(@"\\");
+                    break;
+                case '\0':
+                    sb.Append(@"\0");
+                    break;
+                case '\a':
+                    sb.Append(@"\a");
+                    break;
+                case '\b':
+                    sb.Append(@"\b");
+                    break;
+                case '\f':
+                    sb.Append(@"\f");
+                    break;
+                case '\n':
+                    sb.Append(@"\n");
+                    break;
+                case '\r':
+                    sb.Append(@"\r");
+                    break;
+                case '\t':
+                    sb.Append(@"\t");
+                    break;
+                case '\v':
+                    sb.Append(@"\v");
+                    break;
+                default:
+                    // ASCII printable character
+                    if (!char.IsControl(c))
+                    {
+                        sb.Append(c);
+                        // As UTF16 escaped character
+                    }
+                    else
+                    {
+                        sb.Append(@"\u");
+                        sb.Append(((int) c).ToString("x4"));
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/TaskRunScheduler.cs
+++ b/shared/corefxlab/System.IO.Pipelines/TaskRunScheduler.cs
@@ -1,0 +1,24 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public class TaskRunScheduler : IScheduler
+    {
+        public static TaskRunScheduler Default = new TaskRunScheduler();
+
+        public void Schedule(Action<object> action, object state)
+        {
+            Task.Factory.StartNew(action, state);
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/Testing/BufferUtilities.cs
+++ b/shared/corefxlab/System.IO.Pipelines/Testing/BufferUtilities.cs
@@ -1,0 +1,82 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines.Testing
+{
+    public class BufferUtilities
+    {
+        public static ReadableBuffer CreateBuffer(params byte[][] inputs)
+        {
+            if (inputs == null || inputs.Length == 0)
+            {
+                throw new InvalidOperationException();
+            }
+
+            var i = 0;
+
+            BufferSegment last = null;
+            BufferSegment first = null;
+
+            do
+            {
+                var s = inputs[i];
+                var length = s.Length;
+                var memoryOffset = length;
+                var dataOffset = length * 2;
+                var chars = new byte[length * 8];
+
+                for (int j = 0; j < length; j++)
+                {
+                    chars[dataOffset + j] = s[j];
+                }
+
+                // Create a segment that has offset relative to the OwnedBuffer and OwnedBuffer itself has offset relative to array
+                var ownedBuffer = new UnownedBuffer(new ArraySegment<byte>(chars, memoryOffset, length * 3));
+                var current = new BufferSegment(ownedBuffer, length, length * 2);
+                if (first == null)
+                {
+                    first = current;
+                    last = current;
+                }
+                else
+                {
+                    last.Next = current;
+                    last = current;
+                }
+                i++;
+            } while (i < inputs.Length);
+
+            return new ReadableBuffer(new ReadCursor(first, first.Start), new ReadCursor(last, last.Start + last.ReadableBytes));
+        }
+
+        public static ReadableBuffer CreateBuffer(params string[] inputs)
+        {
+            var buffers = new byte[inputs.Length][];
+            for (int i = 0; i < inputs.Length; i++)
+            {
+                buffers[i] = Encoding.UTF8.GetBytes(inputs[i]);
+            }
+            return CreateBuffer(buffers);
+        }
+
+        public static ReadableBuffer CreateBuffer(params int[] inputs)
+        {
+            var buffers = new byte[inputs.Length][];
+            for (int i = 0; i < inputs.Length; i++)
+            {
+                buffers[i] = new byte[inputs[i]];
+            }
+            return CreateBuffer(buffers);
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/UnownedBuffer.cs
+++ b/shared/corefxlab/System.IO.Pipelines/UnownedBuffer.cs
@@ -1,0 +1,71 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Represents a buffer that is owned by an external component.
+    /// </summary>
+    public class UnownedBuffer : OwnedBuffer<byte>
+    {
+        public UnownedBuffer(ArraySegment<byte> buffer)
+        {
+            _buffer = buffer;
+        }
+
+        public override int Length => _buffer.Count;
+
+        public override Span<byte> Span
+        {
+            get
+            {
+                if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(UnownedBuffer));
+                return new Span<byte>(_buffer.Array, _buffer.Offset, _buffer.Count);
+            }
+        }
+
+        public OwnedBuffer<byte> MakeCopy(int offset, int length, out int newStart, out int newEnd)
+        {
+            // Copy to a new Owned Buffer.
+            var buffer = new byte[length];
+            global::System.Buffer.BlockCopy(_buffer.Array, _buffer.Offset + offset, buffer, 0, length);
+            newStart = 0;
+            newEnd = length;
+            return buffer;
+        }
+
+// In kestrel both MemoryPoolBlock and OwnedBuffer end up in the same assembly so
+// this method access modifiers need to be `protected internal`
+#if KESTREL_BY_SOURCE
+        internal
+#endif
+        protected override bool TryGetArrayInternal(out ArraySegment<byte> buffer)
+        {
+            if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(UnownedBuffer));
+            buffer = _buffer;
+            return true;
+        }
+
+// In kestrel both MemoryPoolBlock and OwnedBuffer end up in the same assembly so
+// this method access modifiers need to be `protected internal`
+#if KESTREL_BY_SOURCE
+        internal
+#endif
+        protected override unsafe bool TryGetPointerInternal(out void* pointer)
+        {
+            pointer = null;
+            return false;
+        }
+
+        private ArraySegment<byte> _buffer;
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/WritableBuffer.cs
+++ b/shared/corefxlab/System.IO.Pipelines/WritableBuffer.cs
@@ -1,0 +1,118 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Server.Kestrel.Internal.System.Buffers;
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Represents a buffer that can write a sequential series of bytes.
+    /// </summary>
+    public struct WritableBuffer : IOutput
+    {
+        private Pipe _pipe;
+
+        internal WritableBuffer(Pipe pipe)
+        {
+            _pipe = pipe;
+        }
+
+        /// <summary>
+        /// Available memory.
+        /// </summary>
+        public Buffer<byte> Buffer => _pipe.Buffer;
+
+        /// <summary>
+        /// Returns the number of bytes currently written and uncommitted.
+        /// </summary>
+        public int BytesWritten => AsReadableBuffer().Length;
+
+        Span<byte> IOutput.Buffer => Buffer.Span;
+
+        void IOutput.Enlarge(int desiredBufferLength) => Ensure(NewSize(desiredBufferLength));
+
+        private int NewSize(int desiredBufferLength)
+        {
+            var currentSize = Buffer.Length;
+            if(desiredBufferLength == 0) {
+                if (currentSize <= 0) return 256;
+                else return currentSize * 2;
+            }
+            return desiredBufferLength < currentSize ? currentSize : desiredBufferLength;
+        }
+
+        /// <summary>
+        /// Obtain a readable buffer over the data written but uncommitted to this buffer.
+        /// </summary>
+        public ReadableBuffer AsReadableBuffer()
+        {
+            return _pipe.AsReadableBuffer();
+        }
+
+        /// <summary>
+        /// Ensures the specified number of bytes are available.
+        /// Will assign more memory to the <see cref="WritableBuffer"/> if requested amount not currently available.
+        /// </summary>
+        /// <param name="count">number of bytes</param>
+        /// <remarks>
+        /// Used when writing to <see cref="Buffer"/> directly. 
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// More requested than underlying <see cref="IBufferPool"/> can allocate in a contiguous block.
+        /// </exception>
+        public void Ensure(int count = 1)
+        {
+            _pipe.Ensure(count);
+        }
+
+        /// <summary>
+        /// Appends the <see cref="ReadableBuffer"/> to the <see cref="WritableBuffer"/> in-place without copies.
+        /// </summary>
+        /// <param name="buffer">The <see cref="ReadableBuffer"/> to append</param>
+        public void Append(ReadableBuffer buffer)
+        {
+            _pipe.Append(buffer);
+        }
+
+        /// <summary>
+        /// Moves forward the underlying <see cref="IPipeWriter"/>'s write cursor but does not commit the data.
+        /// </summary>
+        /// <param name="bytesWritten">number of bytes to be marked as written.</param>
+        /// <remarks>Forwards the start of available <see cref="Buffer"/> by <paramref name="bytesWritten"/>.</remarks>
+        /// <exception cref="ArgumentException"><paramref name="bytesWritten"/> is larger than the current data available data.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="bytesWritten"/> is negative.</exception>
+        public void Advance(int bytesWritten)
+        {
+            _pipe.AdvanceWriter(bytesWritten);
+        }
+
+        /// <summary>
+        /// Commits all outstanding written data to the underlying <see cref="IPipeWriter"/> so they can be read
+        /// and seals the <see cref="WritableBuffer"/> so no more data can be committed.
+        /// </summary>
+        /// <remarks>
+        /// While an on-going conncurent read may pick up the data, <see cref="FlushAsync"/> should be called to signal the reader.
+        /// </remarks>
+        public void Commit()
+        {
+            _pipe.Commit();
+        }
+
+        /// <summary>
+        /// Signals the <see cref="IPipeReader"/> data is available.
+        /// Will <see cref="Commit"/> if necessary.
+        /// </summary>
+        /// <returns>A task that completes when the data is fully flushed.</returns>
+        public WritableBufferAwaitable FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _pipe.FlushAsync(cancellationToken);
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/WritableBufferAwaitable.cs
+++ b/shared/corefxlab/System.IO.Pipelines/WritableBufferAwaitable.cs
@@ -1,0 +1,33 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public struct WritableBufferAwaitable : ICriticalNotifyCompletion
+    {
+        private readonly IWritableBufferAwaiter _awaiter;
+
+        public WritableBufferAwaitable(IWritableBufferAwaiter awaiter)
+        {
+            _awaiter = awaiter;
+        }
+
+        public bool IsCompleted => _awaiter.IsCompleted;
+
+        public FlushResult GetResult() => _awaiter.GetResult();
+
+        public WritableBufferAwaitable GetAwaiter() => this;
+
+        public void UnsafeOnCompleted(Action continuation) => _awaiter.OnCompleted(continuation);
+
+        public void OnCompleted(Action continuation) => _awaiter.OnCompleted(continuation);
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/WritableBufferExtensions.cs
+++ b/shared/corefxlab/System.IO.Pipelines/WritableBufferExtensions.cs
@@ -1,0 +1,138 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    /// <summary>
+    /// Common extension methods against writable buffers
+    /// </summary>
+    public static class WritableBufferExtensions
+    {
+        /// <summary>
+        /// Writes the source <see cref="Span{Byte}"/> to the <see cref="WritableBuffer"/>.
+        /// </summary>
+        /// <param name="buffer">The <see cref="WritableBuffer"/></param>
+        /// <param name="source">The <see cref="Span{Byte}"/> to write</param>
+        public static void Write(this WritableBuffer buffer, ReadOnlySpan<byte> source)
+        {
+            if (buffer.Buffer.IsEmpty)
+            {
+                buffer.Ensure();
+            }
+
+            // Fast path, try copying to the available memory directly
+            if (source.Length <= buffer.Buffer.Length)
+            {
+                source.CopyTo(buffer.Buffer.Span);
+                buffer.Advance(source.Length);
+                return;
+            }
+
+            var remaining = source.Length;
+            var offset = 0;
+
+            while (remaining > 0)
+            {
+                var writable = Math.Min(remaining, buffer.Buffer.Length);
+
+                buffer.Ensure(writable);
+
+                if (writable == 0)
+                {
+                    continue;
+                }
+
+                source.Slice(offset, writable).CopyTo(buffer.Buffer.Span);
+
+                remaining -= writable;
+                offset += writable;
+
+                buffer.Advance(writable);
+            }
+        }
+
+        public static void Write(this WritableBuffer buffer, byte[] source)
+        {
+            Write(buffer, source, 0, source.Length);
+        }
+
+        public static void Write(this WritableBuffer buffer, byte[] source, int offset, int length)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (length == 0)
+            {
+                return;
+            }
+
+            Span<byte> dest = default(Span<byte>);
+            var destLength = dest.Length;
+            if (destLength == 0)
+            {
+                buffer.Ensure();
+
+                // Get the new span and length
+                dest = buffer.Buffer.Span;
+                destLength = dest.Length;
+            }
+
+            var sourceLength = length;
+            if (sourceLength <= destLength)
+            {
+                ref byte pSource = ref source[offset];
+                ref byte pDest = ref dest.DangerousGetPinnableReference();
+                Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)sourceLength);
+                buffer.Advance(sourceLength);
+                return;
+            }
+
+            WriteMultiBuffer(buffer, source, offset, length);
+        }
+
+        private static void WriteMultiBuffer(WritableBuffer buffer, byte[] source, int offset, int length)
+        {
+            var remaining = length;
+
+            while (remaining > 0)
+            {
+                var writable = Math.Min(remaining, buffer.Buffer.Length);
+
+                buffer.Ensure(writable);
+
+                if (writable == 0)
+                {
+                    continue;
+                }
+
+                ref byte pSource = ref source[offset];
+                ref byte pDest = ref buffer.Buffer.Span.DangerousGetPinnableReference();
+
+                Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)writable);
+
+                remaining -= writable;
+                offset += writable;
+
+                buffer.Advance(writable);
+            }
+        }
+    }
+}

--- a/shared/corefxlab/System.IO.Pipelines/WritableBufferWriter.cs
+++ b/shared/corefxlab/System.IO.Pipelines/WritableBufferWriter.cs
@@ -1,0 +1,111 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.IO.Pipelines
+{
+    public struct WritableBufferWriter
+    {
+        private WritableBuffer _writableBuffer;
+        private Span<byte> _span;
+
+        public WritableBufferWriter(WritableBuffer writableBuffer)
+        {
+            _writableBuffer = writableBuffer;
+            _span = writableBuffer.Buffer.Span;
+        }
+
+        public Span<byte> Span => _span;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Advance(int count)
+        {
+            _span = _span.Slice(count);
+            _writableBuffer.Advance(count);
+        }
+
+        public void Write(byte[] source)
+        {
+            if (source.Length > 0 && _span.Length >= source.Length)
+            {
+                ref byte pSource = ref source[0];
+                ref byte pDest = ref _span.DangerousGetPinnableReference();
+
+                Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)source.Length);
+
+                Advance(source.Length);
+            }
+            else
+            {
+                WriteMultiBuffer(source, 0, source.Length);
+            }
+        }
+
+        public void Write(byte[] source, int offset, int length)
+        {
+            // If offset or length is negative the cast to uint will make them larger than int.MaxValue
+            // so each test both tests for negative values and greater than values. This pattern wil also
+            // elide the second bounds check that would occur at source[offset]; as is pre-checked
+            // https://github.com/dotnet/coreclr/pull/9773
+            if ((uint)offset > (uint)source.Length || (uint)length > (uint)(source.Length - offset))
+            {
+                // Only need to pass in array length and offset for ThrowHelper to determine which test failed
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException(source.Length, offset);
+            }
+
+            if (length > 0 && _span.Length >= length)
+            {
+                ref byte pSource = ref source[offset];
+                ref byte pDest = ref _span.DangerousGetPinnableReference();
+
+                Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)length);
+
+                Advance(length);
+            }
+            else
+            {
+                WriteMultiBuffer(source, offset, length);
+            }
+        }
+
+        private void WriteMultiBuffer(byte[] source, int offset, int length)
+        {
+            var remaining = length;
+
+            while (remaining > 0)
+            {
+                if (_span.Length == 0)
+                {
+                    Ensure();
+                }
+
+                var writable = Math.Min(remaining, _span.Length);
+
+                ref byte pSource = ref source[offset];
+                ref byte pDest = ref _span.DangerousGetPinnableReference();
+
+                Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)writable);
+
+                Advance(writable);
+
+                remaining -= writable;
+                offset += writable;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Ensure(int count = 1)
+        {
+            _writableBuffer.Ensure(count);
+            _span = _writableBuffer.Buffer.Span;
+        }
+    }
+}

--- a/shared/corefxlab/System.Memory/src/System/Pinnable.cs
+++ b/shared/corefxlab/System.Memory/src/System/Pinnable.cs
@@ -1,0 +1,30 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    //
+    // This class exists solely so that arbitrary objects can be Unsafe-casted to it to get a ref to the start of the user data.
+    //
+    [StructLayout(LayoutKind.Sequential)]
+    internal sealed class Pinnable<T>
+    {
+        public T Data;
+    }
+}
+
+#endif

--- a/shared/corefxlab/System.Memory/src/System/ReadOnlySpan.cs
+++ b/shared/corefxlab/System.Memory/src/System/ReadOnlySpan.cs
@@ -1,0 +1,373 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
+using EditorBrowsableAttribute = System.ComponentModel.EditorBrowsableAttribute;
+
+#pragma warning disable 0809  //warning CS0809: Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    /// <summary>
+    /// ReadOnlySpan represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
+    /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
+    /// </summary>
+    public struct ReadOnlySpan<T>
+    {
+        /// <summary>
+        /// Creates a new read-only span over the entirety of the target array.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlySpan(T[] array)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+
+            _length = array.Length;
+            _pinnable = Unsafe.As<Pinnable<T>>(array);
+            _byteOffset = SpanHelpers.PerTypeValues<T>.ArrayAdjustment;
+        }
+
+        /// <summary>
+        /// Creates a new read-only span over the portion of the target array beginning
+        /// at 'start' index and covering the remainder of the array.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the read-only span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> is not in the range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlySpan(T[] array, int start)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+
+            int arrayLength = array.Length;
+            if ((uint)start > (uint)arrayLength)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _length = arrayLength - start;
+            _pinnable = Unsafe.As<Pinnable<T>>(array);
+            _byteOffset = SpanHelpers.PerTypeValues<T>.ArrayAdjustment.Add<T>(start);
+        }
+
+        /// <summary>
+        /// Creates a new read-only span over the portion of the target array beginning
+        /// at 'start' index and ending at 'end' index (exclusive).
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the read-only span.</param>
+        /// <param name="length">The number of items in the read-only span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlySpan(T[] array, int start, int length)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _length = length;
+            _pinnable = Unsafe.As<Pinnable<T>>(array);
+            _byteOffset = SpanHelpers.PerTypeValues<T>.ArrayAdjustment.Add<T>(start);
+        }
+
+        /// <summary>
+        /// Creates a new read-only span over the target unmanaged buffer.  Clearly this
+        /// is quite dangerous, because we are creating arbitrarily typed T's
+        /// out of a void*-typed block of memory.  And the length is not checked.
+        /// But if this creation is correct, then all subsequent uses are correct.
+        /// </summary>
+        /// <param name="pointer">An unmanaged pointer to memory.</param>
+        /// <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="T"/> is reference type or contains pointers and hence cannot be stored in unmanaged memory.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="length"/> is negative.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe ReadOnlySpan(void* pointer, int length)
+        {
+            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+            if (length < 0)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _length = length;
+            _pinnable = null;
+            _byteOffset = new IntPtr(pointer);
+        }
+
+        /// <summary>
+        /// Create a new read-only span over a portion of a regular managed object. This can be useful
+        /// if part of a managed object represents a "fixed array." This is dangerous because neither the
+        /// <paramref name="length"/> is checked, nor <paramref name="obj"/> being null, nor the fact that
+        /// "rawPointer" actually lies within <paramref name="obj"/>.
+        /// </summary>
+        /// <param name="obj">The managed object that contains the data to span over.</param>
+        /// <param name="objectData">A reference to data within that object.</param>
+        /// <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<T> DangerousCreate(object obj, ref T objectData, int length)
+        {
+            Pinnable<T> pinnable = Unsafe.As<Pinnable<T>>(obj);
+            IntPtr byteOffset = Unsafe.ByteOffset<T>(ref pinnable.Data, ref objectData);
+            return new ReadOnlySpan<T>(pinnable, byteOffset, length);
+        }
+
+        // Constructor for internal use only.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal ReadOnlySpan(Pinnable<T> pinnable, IntPtr byteOffset, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            _length = length;
+            _pinnable = pinnable;
+            _byteOffset = byteOffset;
+        }
+
+        /// <summary>
+        /// The number of items in the read-only span.
+        /// </summary>
+        public int Length => _length;
+
+        /// <summary>
+        /// Returns true if Length is 0.
+        /// </summary>
+        public bool IsEmpty => _length == 0;
+
+        /// <summary>
+        /// Returns the specified element of the read-only span.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        /// <exception cref="System.IndexOutOfRangeException">
+        /// Thrown when index less than 0 or index greater than or equal to Length
+        /// </exception>
+        public T this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if ((uint)index >= ((uint)_length))
+                    ThrowHelper.ThrowIndexOutOfRangeException();
+
+                if (_pinnable == null)
+                    unsafe { return Unsafe.Add<T>(ref Unsafe.AsRef<T>(_byteOffset.ToPointer()), index); }
+                else
+                    return Unsafe.Add<T>(ref Unsafe.AddByteOffset<T>(ref _pinnable.Data, _byteOffset), index);
+            }
+        }
+
+        /// <summary>
+        /// Copies the contents of this read-only span into destination span. If the source
+        /// and destinations overlap, this method behaves as if the original values in
+        /// a temporary location before the destination is overwritten.
+        ///
+        /// <param name="destination">The span to copy items into.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when the destination Span is shorter than the source Span.
+        /// </exception>
+        /// </summary>
+        public void CopyTo(Span<T> destination)
+        {
+            if (!TryCopyTo(destination))
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+        }
+
+
+        /// <summary>
+        /// Copies the contents of this read-only span into destination span. If the source
+        /// and destinations overlap, this method behaves as if the original values in
+        /// a temporary location before the destination is overwritten.
+        ///
+        /// <returns>If the destination span is shorter than the source span, this method
+        /// return false and no data is written to the destination.</returns>
+        /// </summary>
+        /// <param name="destination">The span to copy items into.</param>
+        public bool TryCopyTo(Span<T> destination)
+        {
+            int length = _length;
+            int destLength = destination.Length;
+
+            if ((uint)length == 0)
+                return true;
+
+            if ((uint)length > (uint)destLength)
+                return false;
+
+            ref T src = ref DangerousGetPinnableReference();
+            ref T dst = ref destination.DangerousGetPinnableReference();
+            SpanHelpers.CopyTo<T>(ref dst, destLength, ref src, length);
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if left and right point at the same memory and have the same length.  Note that
+        /// this does *not* check to see if the *contents* are equal.
+        /// </summary>
+        public static bool operator ==(ReadOnlySpan<T> left, ReadOnlySpan<T> right)
+        {
+            return left._length == right._length && Unsafe.AreSame<T>(ref left.DangerousGetPinnableReference(), ref right.DangerousGetPinnableReference());
+        }
+
+        /// <summary>
+        /// Returns false if left and right point at the same memory and have the same length.  Note that
+        /// this does *not* check to see if the *contents* are equal.
+        /// </summary>
+        public static bool operator !=(ReadOnlySpan<T> left, ReadOnlySpan<T> right) => !(left == right);
+
+        /// <summary>
+        /// This method is not supported as spans cannot be boxed. To compare two spans, use operator==.
+        /// <exception cref="System.NotSupportedException">
+        /// Always thrown by this method.
+        /// </exception>
+        /// </summary>
+        [Obsolete("Equals() on Span will always throw an exception. Use == instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            throw new NotSupportedException(SR.CannotCallEqualsOnSpan);
+        }
+
+        /// <summary>
+        /// This method is not supported as spans cannot be boxed.
+        /// <exception cref="System.NotSupportedException">
+        /// Always thrown by this method.
+        /// </exception>
+        /// </summary>
+        [Obsolete("GetHashCode() on Span will always throw an exception.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            throw new NotSupportedException(SR.CannotCallGetHashCodeOnSpan);
+        }
+
+        /// <summary>
+        /// Defines an implicit conversion of an array to a <see cref="ReadOnlySpan{T}"/>
+        /// </summary>
+        public static implicit operator ReadOnlySpan<T>(T[] array) => new ReadOnlySpan<T>(array);
+
+        /// <summary>
+        /// Defines an implicit conversion of a <see cref="ArraySegment{T}"/> to a <see cref="ReadOnlySpan{T}"/>
+        /// </summary>
+        public static implicit operator ReadOnlySpan<T>(ArraySegment<T> arraySegment) => new ReadOnlySpan<T>(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+
+        /// <summary>
+        /// Forms a slice out of the given read-only span, beginning at 'start'.
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlySpan<T> Slice(int start)
+        {
+            if ((uint)start > (uint)_length)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            IntPtr newOffset = _byteOffset.Add<T>(start);
+            int length = _length - start;
+            return new ReadOnlySpan<T>(_pinnable, newOffset, length);
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given read-only span, beginning at 'start', of given length
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="length">The desired length for the slice (exclusive).</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlySpan<T> Slice(int start, int length)
+        {
+            if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            IntPtr newOffset = _byteOffset.Add<T>(start);
+            return new ReadOnlySpan<T>(_pinnable, newOffset, length);
+        }
+
+        /// <summary>
+        /// Copies the contents of this read-only span into a new array.  This heap
+        /// allocates, so should generally be avoided, however it is sometimes
+        /// necessary to bridge the gap with APIs written in terms of arrays.
+        /// </summary>
+        public T[] ToArray()
+        {
+            if (_length == 0)
+                return SpanHelpers.PerTypeValues<T>.EmptyArray;
+
+            T[] result = new T[_length];
+            CopyTo(result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a 0-length read-only span whose base is the null pointer.
+        /// </summary>
+        public static ReadOnlySpan<T> Empty => default(ReadOnlySpan<T>);
+
+        /// <summary>
+        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
+        /// would have been stored. Such a reference can be used for pinning but must never be dereferenced.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ref T DangerousGetPinnableReference()
+        {
+            if (_pinnable == null)
+                unsafe { return ref Unsafe.AsRef<T>(_byteOffset.ToPointer()); }
+            else
+                return ref Unsafe.AddByteOffset<T>(ref _pinnable.Data, _byteOffset);
+        }
+
+        // These expose the internal representation for Span-related apis use only.
+        internal Pinnable<T> Pinnable => _pinnable;
+        internal IntPtr ByteOffset => _byteOffset;
+
+        //
+        // If the Span was constructed from an object,
+        //
+        //   _pinnable   = that object (unsafe-casted to a Pinnable<T>)
+        //   _byteOffset = offset in bytes from "ref _pinnable.Data" to "ref span[0]"
+        //
+        // If the Span was constructed from a native pointer,
+        //
+        //   _pinnable   = null
+        //   _byteOffset = the pointer
+        //
+        private readonly Pinnable<T> _pinnable;
+        private readonly IntPtr _byteOffset;
+        private readonly int _length;
+    }
+}
+
+#endif

--- a/shared/corefxlab/System.Memory/src/System/Span.cs
+++ b/shared/corefxlab/System.Memory/src/System/Span.cs
@@ -1,0 +1,488 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
+using EditorBrowsableAttribute = System.ComponentModel.EditorBrowsableAttribute;
+
+#pragma warning disable 0809  //warning CS0809: Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    /// <summary>
+    /// Span represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
+    /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
+    /// </summary>
+    [DebuggerTypeProxy(typeof(SpanDebugView<>))]
+    [DebuggerDisplay("Length = {Length}")]
+    public struct Span<T>
+    {
+        /// <summary>
+        /// Creates a new span over the entirety of the target array.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span(T[] array)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                ThrowHelper.ThrowArrayTypeMismatchException_ArrayTypeMustBeExactMatch(typeof(T));
+
+            _length = array.Length;
+            _pinnable = Unsafe.As<Pinnable<T>>(array);
+            _byteOffset = SpanHelpers.PerTypeValues<T>.ArrayAdjustment;
+        }
+
+        /// <summary>
+        /// Creates a new span over the portion of the target array beginning
+        /// at 'start' index and covering the remainder of the array.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> is not in the range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span(T[] array, int start)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                ThrowHelper.ThrowArrayTypeMismatchException_ArrayTypeMustBeExactMatch(typeof(T));
+
+            int arrayLength = array.Length;
+            if ((uint)start > (uint)arrayLength)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _length = arrayLength - start;
+            _pinnable = Unsafe.As<Pinnable<T>>(array);
+            _byteOffset = SpanHelpers.PerTypeValues<T>.ArrayAdjustment.Add<T>(start);
+        }
+
+        /// <summary>
+        /// Creates a new span over the portion of the target array beginning
+        /// at 'start' index and ending at 'end' index (exclusive).
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the span.</param>
+        /// <param name="length">The number of items in the span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span(T[] array, int start, int length)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                ThrowHelper.ThrowArrayTypeMismatchException_ArrayTypeMustBeExactMatch(typeof(T));
+            if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _length = length;
+            _pinnable = Unsafe.As<Pinnable<T>>(array);
+            _byteOffset = SpanHelpers.PerTypeValues<T>.ArrayAdjustment.Add<T>(start);
+        }
+
+        /// <summary>
+        /// Creates a new span over the target unmanaged buffer.  Clearly this
+        /// is quite dangerous, because we are creating arbitrarily typed T's
+        /// out of a void*-typed block of memory.  And the length is not checked.
+        /// But if this creation is correct, then all subsequent uses are correct.
+        /// </summary>
+        /// <param name="pointer">An unmanaged pointer to memory.</param>
+        /// <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="T"/> is reference type or contains pointers and hence cannot be stored in unmanaged memory.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="length"/> is negative.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe Span(void* pointer, int length)
+        {
+            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+            if (length < 0)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _length = length;
+            _pinnable = null;
+            _byteOffset = new IntPtr(pointer);
+        }
+
+        /// <summary>
+        /// Create a new span over a portion of a regular managed object. This can be useful
+        /// if part of a managed object represents a "fixed array." This is dangerous because neither the
+        /// <paramref name="length"/> is checked, nor <paramref name="obj"/> being null, nor the fact that
+        /// "rawPointer" actually lies within <paramref name="obj"/>.
+        /// </summary>
+        /// <param name="obj">The managed object that contains the data to span over.</param>
+        /// <param name="objectData">A reference to data within that object.</param>
+        /// <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> DangerousCreate(object obj, ref T objectData, int length)
+        {
+            Pinnable<T> pinnable = Unsafe.As<Pinnable<T>>(obj);
+            IntPtr byteOffset = Unsafe.ByteOffset<T>(ref pinnable.Data, ref objectData);
+            return new Span<T>(pinnable, byteOffset, length);
+        }
+
+        // Constructor for internal use only.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal Span(Pinnable<T> pinnable, IntPtr byteOffset, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            _length = length;
+            _pinnable = pinnable;
+            _byteOffset = byteOffset;
+        }
+
+        /// <summary>
+        /// The number of items in the span.
+        /// </summary>
+        public int Length => _length;
+
+        /// <summary>
+        /// Returns true if Length is 0.
+        /// </summary>
+        public bool IsEmpty => _length == 0;
+
+        /// <summary>
+        /// Returns a reference to specified element of the Span.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        /// <exception cref="System.IndexOutOfRangeException">
+        /// Thrown when index less than 0 or index greater than or equal to Length
+        /// </exception>
+        public ref T this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if ((uint)index >= ((uint)_length))
+                    ThrowHelper.ThrowIndexOutOfRangeException();
+
+                if (_pinnable == null)
+                    unsafe { return ref Unsafe.Add<T>(ref Unsafe.AsRef<T>(_byteOffset.ToPointer()), index); }
+                else
+                    return ref Unsafe.Add<T>(ref Unsafe.AddByteOffset<T>(ref _pinnable.Data, _byteOffset), index);
+            }
+        }
+
+        /// <summary>
+        /// Clears the contents of this span.
+        /// </summary>
+        public unsafe void Clear()
+        {
+            int length = _length;
+
+            if (length == 0)
+                return;
+
+            var byteLength = (UIntPtr)((uint)length * Unsafe.SizeOf<T>());
+
+            if ((Unsafe.SizeOf<T>() & (sizeof(IntPtr) - 1)) != 0)
+            {
+                if (_pinnable == null)
+                {
+                    var ptr = (byte*)_byteOffset.ToPointer();
+
+                    SpanHelpers.ClearLessThanPointerSized(ptr, byteLength);
+                }
+                else
+                {
+                    ref byte b = ref Unsafe.As<T, byte>(ref Unsafe.AddByteOffset<T>(ref _pinnable.Data, _byteOffset));
+
+                    SpanHelpers.ClearLessThanPointerSized(ref b, byteLength);
+                }
+            }
+            else
+            {
+                if (SpanHelpers.IsReferenceOrContainsReferences<T>())
+                {
+                    UIntPtr pointerSizedLength = (UIntPtr)((length * Unsafe.SizeOf<T>()) / sizeof(IntPtr));
+
+                    ref IntPtr ip = ref Unsafe.As<T, IntPtr>(ref DangerousGetPinnableReference());
+
+                    SpanHelpers.ClearPointerSizedWithReferences(ref ip, pointerSizedLength);
+                }
+                else
+                {
+                    ref byte b = ref Unsafe.As<T, byte>(ref DangerousGetPinnableReference());
+
+                    SpanHelpers.ClearPointerSizedWithoutReferences(ref b, byteLength);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Fills the contents of this span with the given value.
+        /// </summary>
+        public unsafe void Fill(T value)
+        {
+            int length = _length;
+
+            if (length == 0)
+                return;
+
+            if (Unsafe.SizeOf<T>() == 1)
+            {
+                byte fill = Unsafe.As<T, byte>(ref value);
+                if (_pinnable == null)
+                {
+                    Unsafe.InitBlockUnaligned(_byteOffset.ToPointer(), fill, (uint)length);
+                }
+                else
+                {
+                    ref byte r = ref Unsafe.As<T, byte>(ref Unsafe.AddByteOffset<T>(ref _pinnable.Data, _byteOffset));
+                    Unsafe.InitBlockUnaligned(ref r, fill, (uint)length);
+                }
+            }
+            else
+            {
+                ref T r = ref DangerousGetPinnableReference();
+
+                // TODO: Create block fill for value types of power of two sizes e.g. 2,4,8,16
+
+                // Simple loop unrolling
+                int i = 0;
+                for (; i < (length & ~7); i += 8)
+                {
+                    Unsafe.Add<T>(ref r, i + 0) = value;
+                    Unsafe.Add<T>(ref r, i + 1) = value;
+                    Unsafe.Add<T>(ref r, i + 2) = value;
+                    Unsafe.Add<T>(ref r, i + 3) = value;
+                    Unsafe.Add<T>(ref r, i + 4) = value;
+                    Unsafe.Add<T>(ref r, i + 5) = value;
+                    Unsafe.Add<T>(ref r, i + 6) = value;
+                    Unsafe.Add<T>(ref r, i + 7) = value;
+                }
+                if (i < (length & ~3))
+                {
+                    Unsafe.Add<T>(ref r, i + 0) = value;
+                    Unsafe.Add<T>(ref r, i + 1) = value;
+                    Unsafe.Add<T>(ref r, i + 2) = value;
+                    Unsafe.Add<T>(ref r, i + 3) = value;
+                    i += 4;
+                }
+                for (; i < length; i++)
+                {
+                    Unsafe.Add<T>(ref r, i) = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copies the contents of this span into destination span. If the source
+        /// and destinations overlap, this method behaves as if the original values in
+        /// a temporary location before the destination is overwritten.
+        ///
+        /// <param name="destination">The span to copy items into.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when the destination Span is shorter than the source Span.
+        /// </exception>
+        /// </summary>
+        public void CopyTo(Span<T> destination)
+        {
+            if (!TryCopyTo(destination))
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+        }
+
+        /// <summary>
+        /// Copies the contents of this span into destination span. If the source
+        /// and destinations overlap, this method behaves as if the original values in
+        /// a temporary location before the destination is overwritten.
+        ///
+        /// <returns>If the destination span is shorter than the source span, this method
+        /// return false and no data is written to the destination.</returns>
+        /// </summary>
+        /// <param name="destination">The span to copy items into.</param>
+        public bool TryCopyTo(Span<T> destination)
+        {
+            int length = _length;
+            int destLength = destination._length;
+
+            if ((uint)length == 0)
+                return true;
+
+            if ((uint)length > (uint)destLength)
+                return false;
+
+            ref T src = ref DangerousGetPinnableReference();
+            ref T dst = ref destination.DangerousGetPinnableReference();
+            SpanHelpers.CopyTo<T>(ref dst, destLength, ref src, length);
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if left and right point at the same memory and have the same length.  Note that
+        /// this does *not* check to see if the *contents* are equal.
+        /// </summary>
+        public static bool operator ==(Span<T> left, Span<T> right)
+        {
+            return left._length == right._length && Unsafe.AreSame<T>(ref left.DangerousGetPinnableReference(), ref right.DangerousGetPinnableReference());
+        }
+
+        /// <summary>
+        /// Returns false if left and right point at the same memory and have the same length.  Note that
+        /// this does *not* check to see if the *contents* are equal.
+        /// </summary>
+        public static bool operator !=(Span<T> left, Span<T> right) => !(left == right);
+
+        /// <summary>
+        /// This method is not supported as spans cannot be boxed. To compare two spans, use operator==.
+        /// <exception cref="System.NotSupportedException">
+        /// Always thrown by this method.
+        /// </exception>
+        /// </summary>
+        [Obsolete("Equals() on Span will always throw an exception. Use == instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            throw new NotSupportedException(SR.CannotCallEqualsOnSpan);
+        }
+
+        /// <summary>
+        /// This method is not supported as spans cannot be boxed.
+        /// <exception cref="System.NotSupportedException">
+        /// Always thrown by this method.
+        /// </exception>
+        /// </summary>
+        [Obsolete("GetHashCode() on Span will always throw an exception.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            throw new NotSupportedException(SR.CannotCallGetHashCodeOnSpan);
+        }
+
+        /// <summary>
+        /// Defines an implicit conversion of an array to a <see cref="Span{T}"/>
+        /// </summary>
+        public static implicit operator Span<T>(T[] array) => new Span<T>(array);
+
+        /// <summary>
+        /// Defines an implicit conversion of a <see cref="ArraySegment{T}"/> to a <see cref="Span{T}"/>
+        /// </summary>
+        public static implicit operator Span<T>(ArraySegment<T> arraySegment) => new Span<T>(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+
+        /// <summary>
+        /// Defines an implicit conversion of a <see cref="Span{T}"/> to a <see cref="ReadOnlySpan{T}"/>
+        /// </summary>
+        public static implicit operator ReadOnlySpan<T>(Span<T> span) => new ReadOnlySpan<T>(span._pinnable, span._byteOffset, span._length);
+
+        /// <summary>
+        /// Forms a slice out of the given span, beginning at 'start'.
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<T> Slice(int start)
+        {
+            if ((uint)start > (uint)_length)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            IntPtr newOffset = _byteOffset.Add<T>(start);
+            int length = _length - start;
+            return new Span<T>(_pinnable, newOffset, length);
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given span, beginning at 'start', of given length
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="length">The desired length for the slice (exclusive).</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<T> Slice(int start, int length)
+        {
+            if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            IntPtr newOffset = _byteOffset.Add<T>(start);
+            return new Span<T>(_pinnable, newOffset, length);
+        }
+
+        /// <summary>
+        /// Copies the contents of this span into a new array.  This heap
+        /// allocates, so should generally be avoided, however it is sometimes
+        /// necessary to bridge the gap with APIs written in terms of arrays.
+        /// </summary>
+        public T[] ToArray()
+        {
+            if (_length == 0)
+                return SpanHelpers.PerTypeValues<T>.EmptyArray;
+
+            T[] result = new T[_length];
+            CopyTo(result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a 0-length span whose base is the null pointer.
+        /// </summary>
+        public static Span<T> Empty => default(Span<T>);
+
+        /// <summary>
+        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
+        /// would have been stored. Such a reference can be used for pinning but must never be dereferenced.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ref T DangerousGetPinnableReference()
+        {
+            if (_pinnable == null)
+                unsafe { return ref Unsafe.AsRef<T>(_byteOffset.ToPointer()); }
+            else
+                return ref Unsafe.AddByteOffset<T>(ref _pinnable.Data, _byteOffset);
+        }
+
+        // These expose the internal representation for Span-related apis use only.
+        internal Pinnable<T> Pinnable => _pinnable;
+        internal IntPtr ByteOffset => _byteOffset;
+
+        //
+        // If the Span was constructed from an object,
+        //
+        //   _pinnable   = that object (unsafe-casted to a Pinnable<T>)
+        //   _byteOffset = offset in bytes from "ref _pinnable.Data" to "ref span[0]"
+        //
+        // If the Span was constructed from a native pointer,
+        //
+        //   _pinnable   = null
+        //   _byteOffset = the pointer
+        //
+        private readonly Pinnable<T> _pinnable;
+        private readonly IntPtr _byteOffset;
+        private readonly int _length;
+    }
+}
+
+#endif

--- a/shared/corefxlab/System.Memory/src/System/SpanDebugView.cs
+++ b/shared/corefxlab/System.Memory/src/System/SpanDebugView.cs
@@ -1,0 +1,67 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    internal sealed class SpanDebugView<T>
+    {
+        private readonly T[] _pinnable;
+        private readonly IntPtr _byteOffset;
+        private readonly int _length;
+
+        public SpanDebugView(Span<T> collection)
+        {
+            _pinnable = (T[])(object)collection.Pinnable;
+            _byteOffset = collection.ByteOffset;
+            _length = collection.Length;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public unsafe T[] Items
+        {
+            get
+            {
+                int elementSize = typeof(T).GetTypeInfo().IsValueType ? Unsafe.SizeOf<T>() : IntPtr.Size;//Workaround to VIL bug where Unsafe.SizeOf<T> where T is a class, returns the size of its fields instead of IntPtr.Size
+                T[] result = new T[_length];
+
+                if (_pinnable == null)
+                {
+                    byte* source = (byte*)_byteOffset.ToPointer();
+
+                    for (int i = 0; i < result.Length; i++)
+                    {
+                        result[i] = Unsafe.Read<T>(source);
+                        source = source + elementSize;
+                    }
+                }
+                else
+                {
+                    long byteOffsetInt = _byteOffset.ToInt64();
+                    long arrayAdjustment = SpanHelpers.PerTypeValues<T>.ArrayAdjustment.ToInt64();
+                    int sourceIndex = (int)((byteOffsetInt - arrayAdjustment) / elementSize);
+
+                    Array.Copy(_pinnable, sourceIndex, result, 0, _length);
+                }
+
+                return result;
+            }
+        }
+    }
+}
+
+#endif

--- a/shared/corefxlab/System.Memory/src/System/SpanExtensions.Portable.cs
+++ b/shared/corefxlab/System.Memory/src/System/SpanExtensions.Portable.cs
@@ -1,0 +1,157 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    /// <summary>
+    /// Extension methods for Span&lt;T&gt;.
+    /// </summary>
+    public static partial class SpanExtensions
+    {
+        /// <summary>
+        /// Casts a Span of one primitive type <typeparamref name="T"/> to Span of bytes.
+        /// That type may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+        /// </summary>
+        /// <param name="source">The source slice, of type <typeparamref name="T"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="T"/> contains pointers.
+        /// </exception>
+        /// <exception cref="System.OverflowException">
+        /// Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<byte> AsBytes<T>(this Span<T> source)
+            where T : struct
+        {
+            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+
+            int newLength = checked(source.Length * Unsafe.SizeOf<T>());
+            return new Span<byte>(Unsafe.As<Pinnable<byte>>(source.Pinnable), source.ByteOffset, newLength);
+        }
+
+        /// <summary>
+        /// Casts a ReadOnlySpan of one primitive type <typeparamref name="T"/> to ReadOnlySpan of bytes.
+        /// That type may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+        /// </summary>
+        /// <param name="source">The source slice, of type <typeparamref name="T"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="T"/> contains pointers.
+        /// </exception>
+        /// <exception cref="System.OverflowException">
+        /// Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source)
+            where T : struct
+        {
+            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+
+            int newLength = checked(source.Length * Unsafe.SizeOf<T>());
+            return new ReadOnlySpan<byte>(Unsafe.As<Pinnable<byte>>(source.Pinnable), source.ByteOffset, newLength);
+        }
+
+        /// <summary>
+        /// Creates a new readonly span over the portion of the target string.
+        /// </summary>
+        /// <param name="text">The target string.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<char> AsSpan(this string text)
+        {
+            if (text == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
+
+            return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), StringAdjustment, text.Length);
+        }
+
+        /// <summary>
+        /// Casts a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+        /// These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+        /// </summary>
+        /// <remarks>
+        /// Supported only for platforms that support misaligned memory access.
+        /// </remarks>
+        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
+        /// </exception>
+        /// <exception cref="System.OverflowException">
+        /// Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<TTo> NonPortableCast<TFrom, TTo>(this Span<TFrom> source)
+            where TFrom : struct
+            where TTo : struct
+        {
+            if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+
+            if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            int newLength = checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()));
+            return new Span<TTo>(Unsafe.As<Pinnable<TTo>>(source.Pinnable), source.ByteOffset, newLength);
+        }
+
+        /// <summary>
+        /// Casts a ReadOnlySpan of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+        /// These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+        /// </summary>
+        /// <remarks>
+        /// Supported only for platforms that support misaligned memory access.
+        /// </remarks>
+        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
+        /// </exception>
+        /// <exception cref="System.OverflowException">
+        /// Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source)
+            where TFrom : struct
+            where TTo : struct
+        {
+            if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+
+            if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            int newLength = checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()));
+            return new ReadOnlySpan<TTo>(Unsafe.As<Pinnable<TTo>>(source.Pinnable), source.ByteOffset, newLength);
+        }
+
+
+        private static readonly IntPtr StringAdjustment = MeasureStringAdjustment();
+
+        private static IntPtr MeasureStringAdjustment()
+        {
+            string sampleString = "a";
+            unsafe
+            {
+                fixed (char* pSampleString = sampleString)
+                {
+                    return Unsafe.ByteOffset<char>(ref Unsafe.As<Pinnable<char>>(sampleString).Data, ref Unsafe.AsRef<char>(pSampleString));
+                }
+            }
+        }
+    }
+}
+#endif

--- a/shared/corefxlab/System.Memory/src/System/SpanExtensions.cs
+++ b/shared/corefxlab/System.Memory/src/System/SpanExtensions.cs
@@ -1,0 +1,310 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    /// <summary>
+    /// Extension methods for Span&lt;T&gt;.
+    /// </summary>
+    public static partial class SpanExtensions
+    {
+        /// <summary>
+        /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable&lt;T&gt;.Equals(T). 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf<T>(this Span<T> span, T value)
+            where T:struct, IEquatable<T>
+        {
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), value, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this Span<byte> span, byte value)
+        {
+            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified sequence and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable&lt;T&gt;.Equals(T). 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The sequence to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value)
+            where T : struct, IEquatable<T>
+        {
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified sequence and returns the index of its first occurrence. If not found, returns -1.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The sequence to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this Span<byte> span, ReadOnlySpan<byte> value)
+        {
+            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
+        }
+
+        /// <summary>
+        /// Determines whether two sequences are equal by comparing the elements using IEquatable&lt;T&gt;.Equals(T). 
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second)
+            where T:struct, IEquatable<T>
+        {
+            int length = first.Length;
+            return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
+        }
+
+        /// <summary>
+        /// Determines whether two sequences are equal by comparing the elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool SequenceEqual(this Span<byte> first, ReadOnlySpan<byte> second)
+        {
+            int length = first.Length;
+            return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
+        }
+
+        /// <summary>
+        /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable&lt;T&gt;.Equals(T). 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf<T>(this ReadOnlySpan<T> span, T value)
+            where T : struct, IEquatable<T>
+        {
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), value, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this ReadOnlySpan<byte> span, byte value)
+        {
+            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified sequence and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable&lt;T&gt;.Equals(T). 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The sequence to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)
+            where T : struct, IEquatable<T>
+        {
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified sequence and returns the index of its first occurrence. If not found, returns -1.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The sequence to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> value)
+        {
+            return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
+        }
+
+
+        /// <summary>
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOfAny(this Span<byte> span, byte value0, byte value1)
+        {
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), value0, value1, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
+        /// <param name="value2">One of the values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOfAny(this Span<byte> span, byte value0, byte value1, byte value2)
+        {
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="values">The set of values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOfAny(this Span<byte> span, ReadOnlySpan<byte> values)
+        {
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), span.Length, ref values.DangerousGetPinnableReference(), values.Length);
+        }
+
+        /// <summary>
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1)
+        {
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), value0, value1, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
+        /// <param name="value2">One of the values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOfAny(this ReadOnlySpan<byte> span, byte value0, byte value1, byte value2)
+        {
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), value0, value1, value2, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="values">The set of values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOfAny(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> values)
+        {
+            return SpanHelpers.IndexOfAny(ref span.DangerousGetPinnableReference(), span.Length, ref values.DangerousGetPinnableReference(), values.Length);
+        }
+
+        /// <summary>
+        /// Determines whether two sequences are equal by comparing the elements using IEquatable&lt;T&gt;.Equals(T). 
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool SequenceEqual<T>(this ReadOnlySpan<T> first, ReadOnlySpan<T> second)
+            where T : struct, IEquatable<T>
+        {
+            int length = first.Length;
+            return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
+        }
+
+        /// <summary>
+        /// Determines whether two sequences are equal by comparing the elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool SequenceEqual(this ReadOnlySpan<byte> first, ReadOnlySpan<byte> second)
+        {
+            int length = first.Length;
+            return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
+        }
+
+        /// <summary>
+        /// Determines whether the specified sequence appears at the start of the span.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool StartsWith(this Span<byte> span, ReadOnlySpan<byte> value)
+        {
+            int valueLength = value.Length;
+            return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);
+        }
+
+        /// <summary>
+        /// Determines whether the specified sequence appears at the start of the span.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool StartsWith<T>(this Span<T> span, ReadOnlySpan<T> value)
+            where T : struct, IEquatable<T>
+        {
+            int valueLength = value.Length;
+            return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);
+        }
+
+        /// <summary>
+        /// Determines whether the specified sequence appears at the start of the span.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool StartsWith(this ReadOnlySpan<byte> span, ReadOnlySpan<byte> value)
+        {
+            int valueLength = value.Length;
+            return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);
+        }
+
+        /// <summary>
+        /// Determines whether the specified sequence appears at the start of the span.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool StartsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)
+            where T : struct, IEquatable<T>
+        {
+            int valueLength = value.Length;
+            return valueLength <= span.Length && SpanHelpers.SequenceEqual(ref span.DangerousGetPinnableReference(), ref value.DangerousGetPinnableReference(), valueLength);
+        }
+
+        /// <summary>
+        /// Creates a new  span over the portion of the target array.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this T[] array)
+        {
+            return new Span<T>(array);
+        }
+
+        /// <summary>
+        /// Creates a new  span over the portion of the target array segment.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ArraySegment<T> arraySegment)
+        {
+            return new Span<T>(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+        }
+
+        /// <summary>
+        /// Copies the contents of the array into the span. If the source
+        /// and destinations overlap, this method behaves as if the original values in
+        /// a temporary location before the destination is overwritten.
+        /// 
+        ///<param name="array">The array to copy items from.</param>
+        /// <param name="destination">The span to copy items into.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when the destination Span is shorter than the source array.
+        /// </exception>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyTo<T>(this T[] array, Span<T> destination)
+        {
+            new ReadOnlySpan<T>(array).CopyTo(destination);
+        }
+    }
+}
+#endif

--- a/shared/corefxlab/System.Memory/src/System/SpanHelpers.Clear.cs
+++ b/shared/corefxlab/System.Memory/src/System/SpanHelpers.Clear.cs
@@ -1,0 +1,164 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    internal static partial class SpanHelpers
+    {
+        public unsafe static void ClearLessThanPointerSized(byte* ptr, UIntPtr byteLength)
+        {
+            if (sizeof(UIntPtr) == sizeof(uint))
+            {
+                Unsafe.InitBlockUnaligned(ptr, 0, (uint)byteLength);
+            }
+            else
+            {
+                // PERF: Optimize for common case of length <= uint.MaxValue
+                ulong bytesRemaining = (ulong)byteLength;
+                uint bytesToClear = (uint)(bytesRemaining & uint.MaxValue);
+                Unsafe.InitBlockUnaligned(ptr, 0, bytesToClear);
+                bytesRemaining -= bytesToClear;
+                ptr += bytesToClear;
+                // Clear any bytes > uint.MaxValue
+                while (bytesRemaining > 0)
+                {
+                    bytesToClear = (bytesRemaining >= uint.MaxValue) ? uint.MaxValue : (uint)bytesRemaining;
+                    Unsafe.InitBlockUnaligned(ptr, 0, bytesToClear);
+                    ptr += bytesToClear;
+                    bytesRemaining -= bytesToClear;
+                }
+            }
+        }
+
+        public static unsafe void ClearLessThanPointerSized(ref byte b, UIntPtr byteLength)
+        {
+            if (sizeof(UIntPtr) == sizeof(uint))
+            {
+                Unsafe.InitBlockUnaligned(ref b, 0, (uint)byteLength);
+            }
+            else
+            {
+                // PERF: Optimize for common case of length <= uint.MaxValue
+                ulong bytesRemaining = (ulong)byteLength;
+                uint bytesToClear = (uint)(bytesRemaining & uint.MaxValue);
+                Unsafe.InitBlockUnaligned(ref b, 0, bytesToClear);
+                bytesRemaining -= bytesToClear;
+                long byteOffset = bytesToClear;
+                // Clear any bytes > uint.MaxValue
+                while (bytesRemaining > 0)
+                {
+                    bytesToClear = (bytesRemaining >= uint.MaxValue) ? uint.MaxValue : (uint)bytesRemaining;
+                    ref byte bOffset = ref Unsafe.Add(ref b, (IntPtr)byteOffset);
+                    Unsafe.InitBlockUnaligned(ref bOffset, 0, bytesToClear);
+                    byteOffset += bytesToClear;
+                    bytesRemaining -= bytesToClear;
+                }
+            }
+        }
+
+        public unsafe static void ClearPointerSizedWithoutReferences(ref byte b, UIntPtr byteLength)
+        {
+            // TODO: Perhaps do switch casing to improve small size perf
+
+            var i = IntPtr.Zero;
+            while (i.LessThanEqual(byteLength - sizeof(Reg64)))
+            {
+                Unsafe.As<byte, Reg64>(ref Unsafe.Add<byte>(ref b, i)) = default(Reg64);
+                i += sizeof(Reg64);
+            }
+            if (i.LessThanEqual(byteLength - sizeof(Reg32)))
+            {
+                Unsafe.As<byte, Reg32>(ref Unsafe.Add<byte>(ref b, i)) = default(Reg32);
+                i += sizeof(Reg32);
+            }
+            if (i.LessThanEqual(byteLength - sizeof(Reg16)))
+            {
+                Unsafe.As<byte, Reg16>(ref Unsafe.Add<byte>(ref b, i)) = default(Reg16);
+                i += sizeof(Reg16);
+            }
+            if (i.LessThanEqual(byteLength - sizeof(long)))
+            {
+                Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, i)) = 0;
+                i += sizeof(long);
+            }
+            // JIT: Should elide this if 64-bit
+            if (sizeof(IntPtr) == sizeof(int))
+            {
+                if (i.LessThanEqual(byteLength - sizeof(int)))
+                {
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, i)) = 0;
+                    i += sizeof(int);
+                }
+            }
+        }
+
+        public unsafe static void ClearPointerSizedWithReferences(ref IntPtr ip, UIntPtr pointerSizeLength)
+        {
+            // TODO: Perhaps do switch casing to improve small size perf
+
+            var i = IntPtr.Zero;
+            var n = IntPtr.Zero;
+            while ((n = i + 8).LessThanEqual(pointerSizeLength))
+            {
+                Unsafe.Add<IntPtr>(ref ip, i + 0) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 1) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 2) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 3) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 4) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 5) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 6) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 7) = default(IntPtr);
+                i = n;
+            }
+            if ((n = i + 4).LessThanEqual(pointerSizeLength))
+            {
+                Unsafe.Add<IntPtr>(ref ip, i + 0) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 1) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 2) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 3) = default(IntPtr);
+                i = n;
+            }
+            if ((n = i + 2).LessThanEqual(pointerSizeLength))
+            {
+                Unsafe.Add<IntPtr>(ref ip, i + 0) = default(IntPtr);
+                Unsafe.Add<IntPtr>(ref ip, i + 1) = default(IntPtr);
+                i = n;
+            }
+            if ((i + 1).LessThanEqual(pointerSizeLength))
+            {
+                Unsafe.Add<IntPtr>(ref ip, i) = default(IntPtr);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe static bool LessThanEqual(this IntPtr index, UIntPtr length)
+        {
+            return (sizeof(UIntPtr) == sizeof(uint))
+                ? (int)index <= (int)length
+                : (long)index <= (long)length;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Size = 64)]
+        private struct Reg64 { }
+        [StructLayout(LayoutKind.Sequential, Size = 32)]
+        private struct Reg32 { }
+        [StructLayout(LayoutKind.Sequential, Size = 16)]
+        private struct Reg16 { }
+    }
+}
+
+#endif

--- a/shared/corefxlab/System.Memory/src/System/SpanHelpers.T.cs
+++ b/shared/corefxlab/System.Memory/src/System/SpanHelpers.T.cs
@@ -1,0 +1,198 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    internal static partial class SpanHelpers
+    {
+        public static int IndexOf<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength)
+            where T : struct, IEquatable<T>
+        {
+            Debug.Assert(searchSpaceLength >= 0);
+            Debug.Assert(valueLength >= 0);
+
+            if (valueLength == 0)
+                return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
+
+            T valueHead = value;
+            ref T valueTail = ref Unsafe.Add(ref value, 1);
+            int valueTailLength = valueLength - 1;
+
+            int index = 0;
+            for (;;)
+            {
+                Debug.Assert(0 <= index && index <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
+                int remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
+                if (remainingSearchSpaceLength <= 0)
+                    break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
+
+                // Do a quick search for the first element of "value".
+                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
+                if (relativeIndex == -1)
+                    break;
+                index += relativeIndex;
+
+                // Found the first element of "value". See if the tail matches.
+                if (SequenceEqual(ref Unsafe.Add(ref searchSpace, index + 1), ref valueTail, valueTailLength))
+                    return index;  // The tail matched. Return a successful find.
+
+                index++;
+            }
+            return -1;
+        }
+
+        public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length)
+            where T : struct, IEquatable<T>
+        {
+            Debug.Assert(length >= 0);
+
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            while (length >= 8)
+            {
+                length -= 8;
+
+                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
+                    goto Found;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
+                    goto Found1;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 2)))
+                    goto Found2;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
+                    goto Found3;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 4)))
+                    goto Found4;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 5)))
+                    goto Found5;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 6)))
+                    goto Found6;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 7)))
+                    goto Found7;
+
+                index += 8;
+            }
+
+            if (length >= 4)
+            {
+                length -= 4;
+
+                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
+                    goto Found;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
+                    goto Found1;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 2)))
+                    goto Found2;
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
+                    goto Found3;
+
+                index += 4;
+            }
+
+            while (length > 0)
+            {
+                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
+                    goto Found;
+
+                index += 1;
+                length--;
+            }
+            return -1;
+
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return (int)(byte*)index;
+        Found1:
+            return (int)(byte*)(index + 1);
+        Found2:
+            return (int)(byte*)(index + 2);
+        Found3:
+            return (int)(byte*)(index + 3);
+        Found4:
+            return (int)(byte*)(index + 4);
+        Found5:
+            return (int)(byte*)(index + 5);
+        Found6:
+            return (int)(byte*)(index + 6);
+        Found7:
+            return (int)(byte*)(index + 7);
+        }
+
+        public static bool SequenceEqual<T>(ref T first, ref T second, int length)
+            where T : struct, IEquatable<T>
+        {
+            Debug.Assert(length >= 0);
+
+            if (Unsafe.AreSame(ref first, ref second))
+                goto Equal;
+
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            while (length >= 8)
+            {
+                length -= 8;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 1).Equals(Unsafe.Add(ref second, index + 1)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 2).Equals(Unsafe.Add(ref second, index + 2)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 3).Equals(Unsafe.Add(ref second, index + 3)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 4).Equals(Unsafe.Add(ref second, index + 4)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 5).Equals(Unsafe.Add(ref second, index + 5)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 6).Equals(Unsafe.Add(ref second, index + 6)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 7).Equals(Unsafe.Add(ref second, index + 7)))
+                    goto NotEqual;
+
+                index += 8;
+            }
+
+            if (length >= 4)
+            {
+                length -= 4;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 1).Equals(Unsafe.Add(ref second, index + 1)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 2).Equals(Unsafe.Add(ref second, index + 2)))
+                    goto NotEqual;
+                if (!Unsafe.Add(ref first, index + 3).Equals(Unsafe.Add(ref second, index + 3)))
+                    goto NotEqual;
+
+                index += 4;
+            }
+
+            while (length > 0)
+            {
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    goto NotEqual;
+                index += 1;
+                length--;
+            }
+
+        Equal:
+            return true;
+
+        NotEqual: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return false;
+        }
+    }
+}
+
+#endif

--- a/shared/corefxlab/System.Memory/src/System/SpanHelpers.byte.cs
+++ b/shared/corefxlab/System.Memory/src/System/SpanHelpers.byte.cs
@@ -1,0 +1,632 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+#if !netstandard10
+using System.Numerics;
+#endif
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    internal static partial class SpanHelpers
+    {
+        public static int IndexOf(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)
+        {
+            Debug.Assert(searchSpaceLength >= 0);
+            Debug.Assert(valueLength >= 0);
+
+            if (valueLength == 0)
+                return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
+
+            byte valueHead = value;
+            ref byte valueTail = ref Unsafe.Add(ref value, 1);
+            int valueTailLength = valueLength - 1;
+
+            int index = 0;
+            for (;;)
+            {
+                Debug.Assert(0 <= index && index <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
+                int remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
+                if (remainingSearchSpaceLength <= 0)
+                    break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
+
+                // Do a quick search for the first element of "value".
+                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
+                if (relativeIndex == -1)
+                    break;
+                index += relativeIndex;
+
+                // Found the first element of "value". See if the tail matches.
+                if (SequenceEqual(ref Unsafe.Add(ref searchSpace, index + 1), ref valueTail, valueTailLength))
+                    return index;  // The tail matched. Return a successful find.
+
+                index++;
+            }
+            return -1;
+        }
+
+        public static int IndexOfAny(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)
+        {
+            Debug.Assert(searchSpaceLength >= 0);
+            Debug.Assert(valueLength >= 0);
+
+            if (valueLength == 0)
+                return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
+
+            int index = -1;
+            for (int i = 0; i < valueLength; i++)
+            {
+                var tempIndex = IndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
+                if (tempIndex != -1)
+                {
+                    index = (index == -1 || index > tempIndex) ? tempIndex : index;
+                }
+            }
+            return index;
+        }
+
+        public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)(uint)length;
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
+            {
+                unchecked
+                {
+                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                }
+            }
+        SequentialScan:
+#endif
+            while ((byte*)nLength >= (byte*)8)
+            {
+                nLength -= 8;
+
+                if (uValue == Unsafe.Add(ref searchSpace, index))
+                    goto Found;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                    goto Found1;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                    goto Found2;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                    goto Found3;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 4))
+                    goto Found4;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 5))
+                    goto Found5;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 6))
+                    goto Found6;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 7))
+                    goto Found7;
+
+                index += 8;
+            }
+
+            if ((byte*)nLength >= (byte*)4)
+            {
+                nLength -= 4;
+
+                if (uValue == Unsafe.Add(ref searchSpace, index))
+                    goto Found;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
+                    goto Found1;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
+                    goto Found2;
+                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
+                    goto Found3;
+
+                index += 4;
+            }
+
+            while ((byte*)nLength > (byte*)0)
+            {
+                nLength -= 1;
+
+                if (uValue == Unsafe.Add(ref searchSpace, index))
+                    goto Found;
+
+                index += 1;
+            }
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated)
+            {
+                if ((int)(byte*)index >= length)
+                {
+                    goto NotFound;
+                }
+                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
+                // Get comparison Vector
+                Vector<byte> vComparison = GetVector(value);
+                while ((byte*)nLength > (byte*)index)
+                {
+                    var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index)));
+                    if (Vector<byte>.Zero.Equals(vMatches))
+                    {
+                        index += Vector<byte>.Count;
+                        continue;
+                    }
+                    // Found match, reuse Vector vComparison to keep register pressure low
+                    vComparison = vMatches;
+                    // goto rather than inline return to keep function smaller https://github.com/dotnet/coreclr/issues/9692
+                    goto VectorFound;
+                }
+
+                if ((int)(byte*)index >= length)
+                {
+                    goto NotFound;
+                }
+                else
+                {
+                    unchecked
+                    {
+                        nLength = (IntPtr)(length - (int)(byte*)index);
+                    }
+                    goto SequentialScan;
+                }
+            VectorFound:
+                // Find offset of first match
+                return (int)(byte*)index + LocateFirstFoundByte(vComparison);
+            }
+        NotFound: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+#endif
+            return -1;
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return (int)(byte*)index;
+        Found1:
+            return (int)(byte*)(index + 1);
+        Found2:
+            return (int)(byte*)(index + 2);
+        Found3:
+            return (int)(byte*)(index + 3);
+        Found4:
+            return (int)(byte*)(index + 4);
+        Found5:
+            return (int)(byte*)(index + 5);
+        Found6:
+            return (int)(byte*)(index + 6);
+        Found7:
+            return (int)(byte*)(index + 7);
+        }
+
+        public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)(uint)length;
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
+            {
+                unchecked
+                {
+                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                }
+            }
+        SequentialScan:
+#endif
+            uint lookUp;
+            while ((byte*)nLength >= (byte*)8)
+            {
+                nLength -= 8;
+
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found;
+                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found1;
+                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found2;
+                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found3;
+                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found4;
+                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found5;
+                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found6;
+                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found7;
+
+                index += 8;
+            }
+
+            if ((byte*)nLength >= (byte*)4)
+            {
+                nLength -= 4;
+
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found;
+                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found1;
+                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found2;
+                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found3;
+
+                index += 4;
+            }
+
+            while ((byte*)nLength > (byte*)0)
+            {
+                nLength -= 1;
+
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp)
+                    goto Found;
+
+                index += 1;
+            }
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated)
+            {
+                if ((int)(byte*)index >= length)
+                {
+                    goto NotFound;
+                }
+                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
+                // Get comparison Vector
+                Vector<byte> values0 = GetVector(value0);
+                Vector<byte> values1 = GetVector(value1);
+
+                while ((byte*)nLength > (byte*)index)
+                {
+                    var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+                    var vMatches = Vector.BitwiseOr(
+                                    Vector.Equals(vData, values0),
+                                    Vector.Equals(vData, values1));
+                    if (Vector<byte>.Zero.Equals(vMatches))
+                    {
+                        index += Vector<byte>.Count;
+                        continue;
+                    }
+                    // Found match, reuse Vector vComparison to keep register pressure low
+                    values0 = vMatches;
+                    // goto rather than inline return to keep function smaller https://github.com/dotnet/coreclr/issues/9692
+                    goto VectorFound;
+                }
+
+                if ((int)(byte*)index >= length)
+                {
+                    goto NotFound;
+                }
+                else
+                {
+                    unchecked
+                    {
+                        nLength = (IntPtr)(length - (int)(byte*)index);
+                    }
+                    goto SequentialScan;
+                }
+            VectorFound:
+                // Find offset of first match
+                return (int)(byte*)index + LocateFirstFoundByte(values0);
+            }
+        NotFound: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+#endif
+            return -1;
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return (int)(byte*)index;
+        Found1:
+            return (int)(byte*)(index + 1);
+        Found2:
+            return (int)(byte*)(index + 2);
+        Found3:
+            return (int)(byte*)(index + 3);
+        Found4:
+            return (int)(byte*)(index + 4);
+        Found5:
+            return (int)(byte*)(index + 5);
+        Found6:
+            return (int)(byte*)(index + 6);
+        Found7:
+            return (int)(byte*)(index + 7);
+        }
+
+        public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            IntPtr index = (IntPtr)0; // Use UIntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)(uint)length;
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
+            {
+                unchecked
+                {
+                    int unaligned = (int)(byte*)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                    nLength = (IntPtr)(uint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                }
+            }
+        SequentialScan:
+#endif
+            uint lookUp;
+            while ((byte*)nLength >= (byte*)8)
+            {
+                nLength -= 8;
+
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found;
+                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found1;
+                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found2;
+                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found3;
+                lookUp = Unsafe.Add(ref searchSpace, index + 4);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found4;
+                lookUp = Unsafe.Add(ref searchSpace, index + 5);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found5;
+                lookUp = Unsafe.Add(ref searchSpace, index + 6);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found6;
+                lookUp = Unsafe.Add(ref searchSpace, index + 7);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found7;
+
+                index += 8;
+            }
+
+            if ((byte*)nLength >= (byte*)4)
+            {
+                nLength -= 4;
+
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found;
+                lookUp = Unsafe.Add(ref searchSpace, index + 1);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found1;
+                lookUp = Unsafe.Add(ref searchSpace, index + 2);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found2;
+                lookUp = Unsafe.Add(ref searchSpace, index + 3);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found3;
+
+                index += 4;
+            }
+
+            while ((byte*)nLength > (byte*)0)
+            {
+                nLength -= 1;
+
+                lookUp = Unsafe.Add(ref searchSpace, index);
+                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                    goto Found;
+
+                index += 1;
+            }
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated)
+            {
+                if ((int)(byte*)index >= length)
+                {
+                    goto NotFound;
+                }
+                nLength = (IntPtr)(uint)((length - (uint)index) & ~(Vector<byte>.Count - 1));
+                // Get comparison Vector
+                Vector<byte> values0 = GetVector(value0);
+                Vector<byte> values1 = GetVector(value1);
+                Vector<byte> values2 = GetVector(value2);
+                while ((byte*)nLength > (byte*)index)
+                {
+                    var vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+
+                    var vMatches = Vector.BitwiseOr(
+                                    Vector.BitwiseOr(
+                                        Vector.Equals(vData, values0),
+                                        Vector.Equals(vData, values1)),
+                                    Vector.Equals(vData, values2));
+
+                    if (Vector<byte>.Zero.Equals(vMatches))
+                    {
+                        index += Vector<byte>.Count;
+                        continue;
+                    }
+                    // Found match, reuse Vector vComparison to keep register pressure low
+                    values0 = vMatches;
+                    // goto rather than inline return to keep function smaller https://github.com/dotnet/coreclr/issues/9692
+                    goto VectorFound;
+                }
+
+                if ((int)(byte*)index >= length)
+                {
+                    goto NotFound;
+                }
+                else
+                {
+                    unchecked
+                    {
+                        nLength = (IntPtr)(length - (int)(byte*)index);
+                    }
+                    goto SequentialScan;
+                }
+            VectorFound:
+                // Find offset of first match
+                return (int)(byte*)index + LocateFirstFoundByte(values0);
+            }
+        NotFound: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+#endif
+            return -1;
+        Found: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return (int)(byte*)index;
+        Found1:
+            return (int)(byte*)(index + 1);
+        Found2:
+            return (int)(byte*)(index + 2);
+        Found3:
+            return (int)(byte*)(index + 3);
+        Found4:
+            return (int)(byte*)(index + 4);
+        Found5:
+            return (int)(byte*)(index + 5);
+        Found6:
+            return (int)(byte*)(index + 6);
+        Found7:
+            return (int)(byte*)(index + 7);
+        }
+
+        public static unsafe bool SequenceEqual(ref byte first, ref byte second, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            if (Unsafe.AreSame(ref first, ref second))
+                goto Equal;
+
+            IntPtr i = (IntPtr)0; // Use IntPtr and byte* for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr n = (IntPtr)length;
+
+#if !netstandard10
+            if (Vector.IsHardwareAccelerated && (byte*)n >= (byte*)Vector<byte>.Count)
+            {
+                n -= Vector<byte>.Count;
+                while ((byte*)n > (byte*)i)
+                {
+                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
+                    {
+                        goto NotEqual;
+                    }
+                    i += Vector<byte>.Count;
+                }
+                return Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, n)) ==
+                       Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, n));
+            }
+#endif
+
+            if ((byte*)n >= (byte*)sizeof(UIntPtr))
+            {
+                n -= sizeof(UIntPtr);
+                while ((byte*)n > (byte*)i)
+                {
+                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
+                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
+                    {
+                        goto NotEqual;
+                    }
+                    i += sizeof(UIntPtr);
+                }
+                return Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, n)) ==
+                       Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, n));
+            }
+
+            while ((byte*)n > (byte*)i)
+            {
+                if (Unsafe.AddByteOffset(ref first, i) != Unsafe.AddByteOffset(ref second, i))
+                    goto NotEqual;
+                i += 1;
+            }
+
+        Equal:
+            return true;
+
+        NotEqual: // Workaround for https://github.com/dotnet/coreclr/issues/9692
+            return false;
+        }
+
+#if !netstandard10
+        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LocateFirstFoundByte(Vector<byte> match)
+        {
+            var vector64 = Vector.AsVectorUInt64(match);
+            ulong candidate = 0;
+            int i = 0;
+            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
+            for (; i < Vector<ulong>.Count; i++)
+            {
+                candidate = vector64[i];
+                if (candidate != 0)
+                {
+                    break;
+                }
+            }
+
+            // Single LEA instruction with jitted const (using function result)
+            return i * 8 + LocateFirstFoundByte(candidate);
+        }
+#endif
+
+#if !netstandard10
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LocateFirstFoundByte(ulong match)
+        {
+            unchecked
+            {
+                // Flag least significant power of two bit
+                var powerOfTwoFlag = match ^ (match - 1);
+                // Shift all powers of two into the high byte and extract
+                return (int)((powerOfTwoFlag * xorPowerOfTwoToHighByte) >> 57);
+            }
+        }
+#endif
+
+#if !netstandard10
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector<byte> GetVector(byte vectorByte)
+        {
+#if !netcoreapp
+            // Vector<byte> .ctor doesn't become an intrinsic due to detection issue
+            // However this does cause it to become an intrinsic (with additional multiply and reg->reg copy)
+            // https://github.com/dotnet/coreclr/issues/7459#issuecomment-253965670
+            return Vector.AsVectorByte(new Vector<uint>(vectorByte * 0x01010101u));
+#else
+            return new Vector<byte>(vectorByte);
+#endif
+        }
+#endif
+
+#if !netstandard10
+        private const ulong xorPowerOfTwoToHighByte = (0x07ul       |
+                                                       0x06ul <<  8 |
+                                                       0x05ul << 16 |
+                                                       0x04ul << 24 |
+                                                       0x03ul << 32 |
+                                                       0x02ul << 40 |
+                                                       0x01ul << 48) + 1;
+#endif
+    }
+}
+
+#endif

--- a/shared/corefxlab/System.Memory/src/System/SpanHelpers.cs
+++ b/shared/corefxlab/System.Memory/src/System/SpanHelpers.cs
@@ -1,0 +1,189 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    internal static partial class SpanHelpers
+    {
+        /// <summary>
+        /// Implements the copy functionality used by Span and ReadOnlySpan.
+        ///
+        /// NOTE: Fast span implements TryCopyTo in corelib and therefore this implementation
+        ///       is only used by portable span. The code must live in code that only compiles
+        ///       for portable span which means either each individual span implementation
+        ///       of this shared code file. Other shared SpanHelper.X.cs files are compiled
+        ///       for both portable and fast span implementations.
+        /// </summary>
+        public static unsafe void CopyTo<T>(ref T dst, int dstLength, ref T src, int srcLength)
+        {
+            Debug.Assert(dstLength != 0);
+
+            IntPtr srcByteCount = Unsafe.ByteOffset(ref src, ref Unsafe.Add(ref src, srcLength));
+            IntPtr dstByteCount = Unsafe.ByteOffset(ref dst, ref Unsafe.Add(ref dst, dstLength));
+
+            IntPtr diff = Unsafe.ByteOffset(ref src, ref dst);
+
+            bool isOverlapped = (sizeof(IntPtr) == sizeof(int))
+                ? (uint)diff < (uint)srcByteCount || (uint)diff > (uint)-(int)dstByteCount
+                : (ulong)diff < (ulong)srcByteCount || (ulong)diff > (ulong)-(long)dstByteCount;
+
+            if (!isOverlapped && !SpanHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                ref byte dstBytes = ref Unsafe.As<T, byte>(ref dst);
+                ref byte srcBytes = ref Unsafe.As<T, byte>(ref src);
+                ulong byteCount = (ulong)srcByteCount;
+                ulong index = 0;
+
+                while (index < byteCount)
+                {
+                    uint blockSize = (byteCount - index) > uint.MaxValue ? uint.MaxValue : (uint)(byteCount - index);
+                    Unsafe.CopyBlock(
+                        ref Unsafe.Add(ref dstBytes, (IntPtr)index),
+                        ref Unsafe.Add(ref srcBytes, (IntPtr)index),
+                        blockSize);
+                    index += blockSize;
+                }
+            }
+            else
+            {
+                bool srcGreaterThanDst = (sizeof(IntPtr) == sizeof(int))
+                    ? (uint)diff > (uint)-(int)dstByteCount
+                    : (ulong)diff > (ulong)-(long)dstByteCount;
+
+                int direction = srcGreaterThanDst ? 1 : -1;
+                int runCount = srcGreaterThanDst ? 0 : srcLength - 1;
+
+                int loopCount = 0;
+                for (; loopCount < (srcLength & ~7); loopCount += 8)
+                {
+                    Unsafe.Add<T>(ref dst, runCount + direction * 0) = Unsafe.Add<T>(ref src, runCount + direction * 0);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 1) = Unsafe.Add<T>(ref src, runCount + direction * 1);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 2) = Unsafe.Add<T>(ref src, runCount + direction * 2);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 3) = Unsafe.Add<T>(ref src, runCount + direction * 3);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 4) = Unsafe.Add<T>(ref src, runCount + direction * 4);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 5) = Unsafe.Add<T>(ref src, runCount + direction * 5);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 6) = Unsafe.Add<T>(ref src, runCount + direction * 6);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 7) = Unsafe.Add<T>(ref src, runCount + direction * 7);
+                    runCount += direction * 8;
+                }
+                if (loopCount < (srcLength & ~3))
+                {
+                    Unsafe.Add<T>(ref dst, runCount + direction * 0) = Unsafe.Add<T>(ref src, runCount + direction * 0);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 1) = Unsafe.Add<T>(ref src, runCount + direction * 1);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 2) = Unsafe.Add<T>(ref src, runCount + direction * 2);
+                    Unsafe.Add<T>(ref dst, runCount + direction * 3) = Unsafe.Add<T>(ref src, runCount + direction * 3);
+                    runCount += direction * 4;
+                    loopCount += 4;
+                }
+                for (; loopCount < srcLength; ++loopCount)
+                {
+                    Unsafe.Add<T>(ref dst, runCount) = Unsafe.Add<T>(ref src, runCount);
+                    runCount += direction;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes "start + index * sizeof(T)", using the unsigned IntPtr-sized multiplication for 32 and 64 bits.
+        ///
+        /// Assumptions:
+        ///     Start and index are non-negative, and already pre-validated to be within the valid range of their containing Span.
+        ///
+        ///     If the byte length (Span.Length * sizeof(T)) does an unsigned overflow (i.e. the buffer wraps or is too big to fit within the address space),
+        ///     the behavior is undefined.
+        ///
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IntPtr Add<T>(this IntPtr start, int index)
+        {
+            Debug.Assert(start.ToInt64() >= 0);
+            Debug.Assert(index >= 0);
+
+            unsafe
+            {
+                if (sizeof(IntPtr) == sizeof(int))
+                {
+                    // 32-bit path.
+                    uint byteLength = (uint)index * (uint)Unsafe.SizeOf<T>();
+                    return (IntPtr)(((byte*)start) + byteLength);
+                }
+                else
+                {
+                    // 64-bit path.
+                    ulong byteLength = (ulong)index * (ulong)Unsafe.SizeOf<T>();
+                    return (IntPtr)(((byte*)start) + byteLength);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determine if a type is eligible for storage in unmanaged memory.
+        /// Portable equivalent of RuntimeHelpers.IsReferenceOrContainsReferences&lt;T&gt;()
+        /// </summary>
+        public static bool IsReferenceOrContainsReferences<T>() => PerTypeValues<T>.IsReferenceOrContainsReferences;
+
+        private static bool IsReferenceOrContainsReferencesCore(Type type)
+        {
+            if (type.GetTypeInfo().IsPrimitive) // This is hopefully the common case. All types that return true for this are value types w/out embedded references.
+                return false;
+
+            if (!type.GetTypeInfo().IsValueType)
+                return true;
+
+            // If type is a Nullable<> of something, unwrap it first.
+            Type underlyingNullable = Nullable.GetUnderlyingType(type);
+            if (underlyingNullable != null)
+                type = underlyingNullable;
+
+            if (type.GetTypeInfo().IsEnum)
+                return false;
+
+            foreach (FieldInfo field in type.GetTypeInfo().DeclaredFields)
+            {
+                if (field.IsStatic)
+                    continue;
+                if (IsReferenceOrContainsReferencesCore(field.FieldType))
+                    return true;
+            }
+            return false;
+        }
+
+        public static class PerTypeValues<T>
+        {
+            //
+            // Latch to ensure that excruciatingly expensive validation check for constructing a Span around a raw pointer is done
+            // only once per type.
+            //
+            public static readonly bool IsReferenceOrContainsReferences = IsReferenceOrContainsReferencesCore(typeof(T));
+
+            public static readonly T[] EmptyArray = new T[0];
+
+            public static readonly IntPtr ArrayAdjustment = MeasureArrayAdjustment();
+
+            // Array header sizes are a runtime implementation detail and aren't the same across all runtimes. (The CLR made a tweak after 4.5, and Mono has an extra Bounds pointer.)
+            private static IntPtr MeasureArrayAdjustment()
+            {
+                T[] sampleArray = new T[1];
+                return Unsafe.ByteOffset<T>(ref Unsafe.As<Pinnable<T>>(sampleArray).Data, ref sampleArray[0]);
+            }
+        }
+    }
+}
+
+#endif

--- a/shared/corefxlab/System.Memory/src/System/ThrowHelper.cs
+++ b/shared/corefxlab/System.Memory/src/System/ThrowHelper.cs
@@ -1,0 +1,71 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+#if SYSTEM_MEMORY
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System { }
+
+#else
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System
+{
+    //
+    // This pattern of easily inlinable "void Throw" routines that stack on top of NoInlining factory methods
+    // is a compromise between older JITs and newer JITs (RyuJIT in Core CLR 1.1.0+ and desktop CLR in 4.6.3+).
+    // This package is explicitly targeted at older JITs as newer runtimes expect to implement Span intrinsically for
+    // best performance.
+    //
+    // The aim of this pattern is three-fold
+    // 1. Extracting the throw makes the method preforming the throw in a conditional branch smaller and more inlinable
+    // 2. Extracting the throw from generic method to non-generic method reduces the repeated codegen size for value types
+    // 3a. Newer JITs will not inline the methods that only throw and also recognise them, move the call to cold section
+    //     and not add stack prep and unwind before calling https://github.com/dotnet/coreclr/pull/6103
+    // 3b. Older JITs will inline the throw itself and move to cold section; but not inline the non-inlinable exception
+    //     factory methods - still maintaining advantages 1 & 2
+    //
+
+    internal static class ThrowHelper
+    {
+        internal static void ThrowArgumentNullException(ExceptionArgument argument) { throw CreateArgumentNullException(argument); }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateArgumentNullException(ExceptionArgument argument) { return new ArgumentNullException(argument.ToString()); }
+
+        internal static void ThrowArrayTypeMismatchException_ArrayTypeMustBeExactMatch(Type type) { throw CreateArrayTypeMismatchException_ArrayTypeMustBeExactMatch(type); }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateArrayTypeMismatchException_ArrayTypeMustBeExactMatch(Type type) { return new ArrayTypeMismatchException(SR.Format(SR.ArrayTypeMustBeExactMatch, type)); }
+
+        internal static void ThrowArgumentException_InvalidTypeWithPointersNotSupported(Type type) { throw CreateArgumentException_InvalidTypeWithPointersNotSupported(type); }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateArgumentException_InvalidTypeWithPointersNotSupported(Type type) { return new ArgumentException(SR.Format(SR.Argument_InvalidTypeWithPointersNotSupported, type)); }
+
+        internal static void ThrowArgumentException_DestinationTooShort() { throw CreateArgumentException_DestinationTooShort(); }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateArgumentException_DestinationTooShort() { return new ArgumentException(SR.Argument_DestinationTooShort); }
+
+        internal static void ThrowIndexOutOfRangeException() { throw CreateIndexOutOfRangeException(); }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateIndexOutOfRangeException() { return new IndexOutOfRangeException(); }
+
+        internal static void ThrowArgumentOutOfRangeException(ExceptionArgument argument) { throw CreateArgumentOutOfRangeException(argument); }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateArgumentOutOfRangeException(ExceptionArgument argument) { return new ArgumentOutOfRangeException(argument.ToString()); }
+    }
+
+    internal enum ExceptionArgument
+    {
+        array,
+        length,
+        start,
+        text,
+        obj,
+    }
+}
+
+#endif

--- a/shared/corefxlab/System.Text.Encodings.Web.Utf8/UrlEncoder.cs
+++ b/shared/corefxlab/System.Text.Encodings.Web.Utf8/UrlEncoder.cs
@@ -1,0 +1,340 @@
+// This file was processed with Internalizer tool and should not be edited manually
+
+using System;
+using System.Buffers;
+using System.Runtime;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal.System.Text.Encodings.Web.Utf8
+{
+    public class UrlEncoder
+    {
+        /// <summary>
+        /// Unescape a URL path
+        /// </summary>
+        /// <param name="source">The byte span represents a UTF8 encoding url path.</param>
+        /// <param name="destination">The byte span where unescaped url path is copied to.</param>
+        /// <returns>The length of the byte sequence of the unescaped url path.</returns>
+        public static int Decode(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            if (destination.Length < source.Length)
+            {
+                throw new ArgumentException(
+                    "Lenghth of the destination byte span is less then the source.",
+                    nameof(destination));
+            }
+
+            // This requires the destination span to be larger or equal to source span
+            source.CopyTo(destination);
+            return DecodeInPlace(destination);
+        }
+
+        /// <summary>
+        /// Unescape a URL path in place.
+        /// </summary>
+        /// <param name="buffer">The byte span represents a UTF8 encoding url path.</param>
+        /// <returns>The number of the bytes representing the result.</returns>
+        /// <remarks>
+        /// The unescape is done in place, which means after decoding the result is the subset of 
+        /// the input span.
+        /// </remarks>
+        public static int DecodeInPlace(Span<byte> buffer)
+        {
+            // the slot to read the input
+            var sourceIndex = 0;
+
+            // the slot to write the unescaped byte
+            var destinationIndex = 0;
+
+            while (true)
+            {
+                if (sourceIndex == buffer.Length)
+                {
+                    break;
+                }
+
+                if (buffer[sourceIndex] == '%')
+                {
+                    var decodeIndex = sourceIndex;
+
+                    // If decoding process succeeds, the writer iterator will be moved
+                    // to the next write-ready location. On the other hand if the scanned
+                    // percent-encodings cannot be interpreted as sequence of UTF-8 octets,
+                    // these bytes should be copied to output as is. 
+                    // The decodeReader iterator is always moved to the first byte not yet 
+                    // be scanned after the process. A failed decoding means the chars
+                    // between the reader and decodeReader can be copied to output untouched. 
+                    if (!DecodeCore(ref decodeIndex, ref destinationIndex, buffer))
+                    {
+                        Copy(sourceIndex, decodeIndex, ref destinationIndex, buffer);
+                    }
+
+                    sourceIndex = decodeIndex;
+                }
+                else
+                {
+                    buffer[destinationIndex++] = buffer[sourceIndex++];
+                }
+            }
+
+            return destinationIndex;
+        }
+
+        /// <summary>
+        /// Unescape the percent-encodings
+        /// </summary>
+        /// <param name="sourceIndex">The iterator point to the first % char</param>
+        /// <param name="destinationIndex">The place to write to</param>
+        /// <param name="end">The end of the buffer</param>
+        /// <param name="buffer">The byte array</param>
+        private static bool DecodeCore(ref int sourceIndex, ref int destinationIndex, Span<byte> buffer)
+        {
+            // preserves the original head. if the percent-encodings cannot be interpreted as sequence of UTF-8 octets,
+            // bytes from this till the last scanned one will be copied to the memory pointed by writer.
+            var byte1 = UnescapePercentEncoding(ref sourceIndex, buffer);
+            if (byte1 == -1)
+            {
+                return false;
+            }
+
+            if (byte1 == 0)
+            {
+                throw new InvalidOperationException("The path contains null characters.");
+            }
+
+            if (byte1 <= 0x7F)
+            {
+                // first byte < U+007f, it is a single byte ASCII
+                buffer[destinationIndex++] = (byte)byte1;
+                return true;
+            }
+
+            int byte2 = 0, byte3 = 0, byte4 = 0;
+
+            // anticipate more bytes
+            var currentDecodeBits = 0;
+            var byteCount = 1;
+            var expectValueMin = 0;
+            if ((byte1 & 0xE0) == 0xC0)
+            {
+                // 110x xxxx, expect one more byte
+                currentDecodeBits = byte1 & 0x1F;
+                byteCount = 2;
+                expectValueMin = 0x80;
+            }
+            else if ((byte1 & 0xF0) == 0xE0)
+            {
+                // 1110 xxxx, expect two more bytes
+                currentDecodeBits = byte1 & 0x0F;
+                byteCount = 3;
+                expectValueMin = 0x800;
+            }
+            else if ((byte1 & 0xF8) == 0xF0)
+            {
+                // 1111 0xxx, expect three more bytes
+                currentDecodeBits = byte1 & 0x07;
+                byteCount = 4;
+                expectValueMin = 0x10000;
+            }
+            else
+            {
+                // invalid first byte
+                return false;
+            }
+
+            var remainingBytes = byteCount - 1;
+            while (remainingBytes > 0)
+            {
+                // read following three chars
+                if (sourceIndex == buffer.Length)
+                {
+                    return false;
+                }
+
+                var nextSourceIndex = sourceIndex;
+                var nextByte = UnescapePercentEncoding(ref nextSourceIndex, buffer);
+                if (nextByte == -1)
+                {
+                    return false;
+                }
+
+                if ((nextByte & 0xC0) != 0x80)
+                {
+                    // the follow up byte is not in form of 10xx xxxx
+                    return false;
+                }
+
+                currentDecodeBits = (currentDecodeBits << 6) | (nextByte & 0x3F);
+                remainingBytes--;
+
+                if (remainingBytes == 1 && currentDecodeBits >= 0x360 && currentDecodeBits <= 0x37F)
+                {
+                    // this is going to end up in the range of 0xD800-0xDFFF UTF-16 surrogates that
+                    // are not allowed in UTF-8;
+                    return false;
+                }
+
+                if (remainingBytes == 2 && currentDecodeBits >= 0x110)
+                {
+                    // this is going to be out of the upper Unicode bound 0x10FFFF.
+                    return false;
+                }
+
+                sourceIndex = nextSourceIndex;
+                if (byteCount - remainingBytes == 2)
+                {
+                    byte2 = nextByte;
+                }
+                else if (byteCount - remainingBytes == 3)
+                {
+                    byte3 = nextByte;
+                }
+                else if (byteCount - remainingBytes == 4)
+                {
+                    byte4 = nextByte;
+                }
+            }
+
+            if (currentDecodeBits < expectValueMin)
+            {
+                // overlong encoding (e.g. using 2 bytes to encode something that only needed 1).
+                return false;
+            }
+
+            // all bytes are verified, write to the output
+            // TODO: measure later to determine if the performance of following logic can be improved
+            //       the idea is to combine the bytes into short/int and write to span directly to avoid
+            //       range check cost
+            if (byteCount > 0)
+            {
+                buffer[destinationIndex++] = (byte)byte1;
+            }
+            if (byteCount > 1)
+            {
+                buffer[destinationIndex++] = (byte)byte2;
+            }
+            if (byteCount > 2)
+            {
+                buffer[destinationIndex++] = (byte)byte3;
+            }
+            if (byteCount > 3)
+            {
+                buffer[destinationIndex++] = (byte)byte4;
+            }
+
+            return true;
+        }
+
+        private static void Copy(int begin, int end, ref int writer, Span<byte> buffer)
+        {
+            while (begin != end)
+            {
+                buffer[writer++] = buffer[begin++];
+            }
+        }
+
+        /// <summary>
+        /// Read the percent-encoding and try unescape it.
+        /// 
+        /// The operation first peek at the character the <paramref name="scan"/> 
+        /// iterator points at. If it is % the <paramref name="scan"/> is then 
+        /// moved on to scan the following to characters. If the two following 
+        /// characters are hexadecimal literals they will be unescaped and the 
+        /// value will be returned.
+        /// 
+        /// If the first character is not % the <paramref name="scan"/> iterator 
+        /// will be removed beyond the location of % and -1 will be returned.
+        /// 
+        /// If the following two characters can't be successfully unescaped the 
+        /// <paramref name="scan"/> iterator will be move behind the % and -1 
+        /// will be returned.
+        /// </summary>
+        /// <param name="scan">The value to read</param>
+        /// <param name="buffer">The byte array</param>
+        /// <returns>The unescaped byte if success. Otherwise return -1.</returns>
+        private static int UnescapePercentEncoding(ref int scan, Span<byte> buffer)
+        {
+            if (buffer[scan++] != '%')
+            {
+                return -1;
+            }
+
+            var probe = scan;
+
+            var value1 = ReadHex(ref probe, buffer);
+            if (value1 == -1)
+            {
+                return -1;
+            }
+
+            var value2 = ReadHex(ref probe, buffer);
+            if (value2 == -1)
+            {
+                return -1;
+            }
+
+            if (SkipUnescape(value1, value2))
+            {
+                return -1;
+            }
+
+            scan = probe;
+            return (value1 << 4) + value2;
+        }
+
+
+        /// <summary>
+        /// Read the next char and convert it into hexadecimal value.
+        /// 
+        /// The <paramref name="scan"/> index will be moved to the next
+        /// byte no matter no matter whether the operation successes.
+        /// </summary>
+        /// <param name="scan">The index of the byte in the buffer to read</param>
+        /// <param name="buffer">The byte span from which the hex to be read</param>
+        /// <returns>The hexadecimal value if successes, otherwise -1.</returns>
+        private static int ReadHex(ref int scan, Span<byte> buffer)
+        {
+            if (scan == buffer.Length)
+            {
+                return -1;
+            }
+
+            var value = buffer[scan++];
+            var isHead = ((value >= '0') && (value <= '9')) ||
+                         ((value >= 'A') && (value <= 'F')) ||
+                         ((value >= 'a') && (value <= 'f'));
+
+            if (!isHead)
+            {
+                return -1;
+            }
+
+            if (value <= '9')
+            {
+                return value - '0';
+            }
+            else if (value <= 'F')
+            {
+                return (value - 'A') + 10;
+            }
+            else // a - f
+            {
+                return (value - 'a') + 10;
+            }
+        }
+
+        private static bool SkipUnescape(int value1, int value2)
+        {
+            // skip %2F - '/'
+            if (value1 == 2 && value2 == 15)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj
+++ b/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.csproj
@@ -15,7 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Internal.CoreFxLab.Sources" Version="$(MicrosoftAspNetCoreInternalCoreFxLabSourcesPackageVersion)" PrivateAssets="All" />
+    <Compile Include="..\..\shared\corefxlab\**\*.cs" Link="corefxlab\%(RecursiveDir)%(FileName)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="$(MicrosoftAspNetCoreHttpFeaturesPackageVersion)" />
     <PackageReference Include="System.Numerics.Vectors" Version="$(SystemNumericsVectorsPackageVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersPackageVersion)" />


### PR DESCRIPTION
Resolves https://github.com/aspnet/KestrelHttpServer/issues/2105

This is an exact copy of the source code from Microsoft.AspNetCore.Internal.CoreFxLab.Sources/2.0.0-rtm-21470.

We don't want to rely on the existence of the Microsoft.AspNetCore.Internal.CoreFxLab.Sources package to be able to build Kestrel 2.0.x patches in the future. This package was produced by automation that itself is not reproducible. If we lost this package somehow, we would have a really hard time producing a new patch of Kestrel.

