### PR TITLE
Switching to the new toolset compiler - 2.6.0-beta2-62211-02

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="2.6.0-beta1-62126-01" PrivateAssets="All">
+    <PackageReference Include="Microsoft.NETCore.Compilers" Version="2.6.0-beta2-62211-02" PrivateAssets="All">
       <!--
         Suppresses the warning about having an explicit package version in this repo.
         We are okay with this for now as the experimental version of the compiler is unique to Kestrel (for now).


### PR DESCRIPTION
This brings support for the final syntax of "ref readonly" and some bug fixes.

Noticeable changes:
- use `in` at declaration of "in" parameters, not `ref readonly`
- `ref` comes before `partial` when declaring partial ref structs.
- unboxing conversions for ref-like types are statically rejected as impossible to succeed

The corresponding VSIX to match these compiler bits with IDE experience is -
https://dotnet.myget.org/F/roslyn/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7-2.6.0.6221102.vsix