### PR TITLE
Treat SocketError.InvalidArgument from Socket.ReceiveAsync as abort

### DIFF
--- a/src/Kestrel.Transport.Sockets/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/SocketConnection.cs
@@ -136,8 +136,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 _trace.ConnectionReset(ConnectionId);
             }
             catch (SocketException ex) when (ex.SocketErrorCode == SocketError.OperationAborted ||
-                                             ex.SocketErrorCode == SocketError.Interrupted)
+                                             ex.SocketErrorCode == SocketError.ConnectionAborted ||
+                                             ex.SocketErrorCode == SocketError.Interrupted ||
+                                             ex.SocketErrorCode == SocketError.InvalidArgument)
             {
+                // Calling Dispose after ReceiveAsync can cause an "InvalidArgument" error on *nix.
                 error = new ConnectionAbortedException();
                 _trace.ConnectionError(ConnectionId, error);
             }


### PR DESCRIPTION
Disposing after calling ReceiveAsync can result in a "SocketError.InvalidArgument" SocketException on macOS and Linux. This is making the RequestsCanBeAbortedMidRead test flaky.