### PR TITLE
Fix for #2085 - "The Detaskening"

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Http1Connection.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1Connection.cs
@@ -413,67 +413,77 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         protected override MessageBody CreateMessageBody()
             => Http1MessageBody.For(_httpVersion, HttpRequestHeaders, this);
 
-        protected override async Task<bool> ParseRequestAsync()
+        protected override void InitializeParsing()
         {
             Reset();
             TimeoutControl.SetTimeout(_keepAliveTicks, TimeoutAction.StopProcessingNextRequest);
+        }
 
-            while (_requestProcessingStatus != RequestProcessingStatus.AppStarted)
+        protected override bool BeginRead(out ReadableBufferAwaitable awaitable)
+        {
+            awaitable = Input.ReadAsync();
+            return true;
+        }
+
+        protected override void FinishParsing()
+        {
+            EnsureHostHeaderExists();
+        }
+
+        protected override bool TryParseRequest(ReadResult result, out bool endConnection)
+        {
+            var examined = result.Buffer.End;
+            var consumed = result.Buffer.End;
+
+            try
             {
-                var result = await Input.ReadAsync();
-
-                var examined = result.Buffer.End;
-                var consumed = result.Buffer.End;
-
-                try
+                ParseRequest(result.Buffer, out consumed, out examined);
+            }
+            catch (InvalidOperationException)
+            {
+                if (_requestProcessingStatus == RequestProcessingStatus.ParsingHeaders)
                 {
-                    ParseRequest(result.Buffer, out consumed, out examined);
+                    throw BadHttpRequestException.GetException(RequestRejectionReason
+                        .MalformedRequestInvalidHeaders);
                 }
-                catch (InvalidOperationException)
-                {
-                    if (_requestProcessingStatus == RequestProcessingStatus.ParsingHeaders)
-                    {
-                        throw BadHttpRequestException.GetException(RequestRejectionReason
-                            .MalformedRequestInvalidHeaders);
-                    }
-                    throw;
-                }
-                finally
-                {
-                    Input.Advance(consumed, examined);
-                }
-
-                if (result.IsCompleted)
-                {
-                    switch (_requestProcessingStatus)
-                    {
-                        case RequestProcessingStatus.RequestPending:
-                            return false;
-                        case RequestProcessingStatus.ParsingRequestLine:
-                            throw BadHttpRequestException.GetException(
-                                RequestRejectionReason.InvalidRequestLine);
-                        case RequestProcessingStatus.ParsingHeaders:
-                            throw BadHttpRequestException.GetException(
-                                RequestRejectionReason.MalformedRequestInvalidHeaders);
-                    }
-                }
-                else if (!_keepAlive && _requestProcessingStatus == RequestProcessingStatus.RequestPending)
-                {
-                    // Stop the request processing loop if the server is shutting down or there was a keep-alive timeout
-                    // and there is no ongoing request.
-                    return false;
-                }
-                else if (RequestTimedOut)
-                {
-                    // In this case, there is an ongoing request but the start line/header parsing has timed out, so send
-                    // a 408 response.
-                    throw BadHttpRequestException.GetException(RequestRejectionReason.RequestTimeout);
-                }
+                throw;
+            }
+            finally
+            {
+                Input.Advance(consumed, examined);
             }
 
-            EnsureHostHeaderExists();
+            if (result.IsCompleted)
+            {
+                switch (_requestProcessingStatus)
+                {
+                    case RequestProcessingStatus.RequestPending:
+                        endConnection = true;
+                        return true;
+                    case RequestProcessingStatus.ParsingRequestLine:
+                        throw BadHttpRequestException.GetException(
+                            RequestRejectionReason.InvalidRequestLine);
+                    case RequestProcessingStatus.ParsingHeaders:
+                        throw BadHttpRequestException.GetException(
+                            RequestRejectionReason.MalformedRequestInvalidHeaders);
+                }
+            }
+            else if (!_keepAlive && _requestProcessingStatus == RequestProcessingStatus.RequestPending)
+            {
+                // Stop the request processing loop if the server is shutting down or there was a keep-alive timeout
+                // and there is no ongoing request.
+                endConnection = true;
+                return true;
+            }
+            else if (RequestTimedOut)
+            {
+                // In this case, there is an ongoing request but the start line/header parsing has timed out, so send
+                // a 408 response.
+                throw BadHttpRequestException.GetException(RequestRejectionReason.RequestTimeout);
+            }
 
-            return true;
+            endConnection = false;
+            return _requestProcessingStatus == RequestProcessingStatus.AppStarted;
         }
     }
 }

--- a/src/Kestrel.Core/Internal/Http/Http1Connection.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1Connection.cs
@@ -413,15 +413,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         protected override MessageBody CreateMessageBody()
             => Http1MessageBody.For(_httpVersion, HttpRequestHeaders, this);
 
+        protected override void BeginRequestProcessing()
+        {
+            // Reset the features and timeout.
+            Reset();
+            TimeoutControl.SetTimeout(_keepAliveTicks, TimeoutAction.StopProcessingNextRequest);
+        }
+
         protected override bool BeginRead(out ReadableBufferAwaitable awaitable)
         {
-            if (_requestProcessingStatus == RequestProcessingStatus.RequestPending)
-            {
-                // Reset the features and timeout.
-                Reset();
-                TimeoutControl.SetTimeout(_keepAliveTicks, TimeoutAction.StopProcessingNextRequest);
-            }
-
             awaitable = Input.ReadAsync();
             return true;
         }
@@ -479,7 +479,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             endConnection = false;
-            if(_requestProcessingStatus == RequestProcessingStatus.AppStarted)
+            if (_requestProcessingStatus == RequestProcessingStatus.AppStarted)
             {
                 EnsureHostHeaderExists();
                 return true;

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
@@ -311,6 +311,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _onStarting = null;
             _onCompleted = null;
 
+            _requestProcessingStatus = RequestProcessingStatus.RequestPending;
             _autoChunk = false;
             _applicationException = null;
             _requestRejectedException = null;
@@ -371,6 +372,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         protected virtual void OnRequestProcessingEnded()
+        {
+        }
+
+        protected virtual void BeginRequestProcessing()
         {
         }
 
@@ -441,8 +446,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 while (_keepAlive)
                 {
-                    // Reset state
-                    _requestProcessingStatus = RequestProcessingStatus.RequestPending;
+                    BeginRequestProcessing();
 
                     var result = default(ReadResult);
                     var endConnection = false;

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
@@ -311,7 +311,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _onStarting = null;
             _onCompleted = null;
 
-            _requestProcessingStatus = RequestProcessingStatus.RequestPending;
             _autoChunk = false;
             _applicationException = null;
             _requestRejectedException = null;
@@ -372,14 +371,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         protected virtual void OnRequestProcessingEnded()
-        {
-        }
-
-        protected virtual void InitializeParsing()
-        {
-        }
-
-        protected virtual void FinishParsing()
         {
         }
 
@@ -450,7 +441,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 while (_keepAlive)
                 {
-                    InitializeParsing();
+                    // Reset state
+                    _requestProcessingStatus = RequestProcessingStatus.RequestPending;
+
                     var result = default(ReadResult);
                     var endConnection = false;
                     do
@@ -465,8 +458,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return;
                     }
-
-                    FinishParsing();
 
                     var messageBody = CreateMessageBody();
 

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -46,8 +46,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         protected override MessageBody CreateMessageBody()
             => Http2MessageBody.For(HttpRequestHeaders, this);
 
-        protected override Task<bool> ParseRequestAsync()
+        protected override bool TryParseRequest(ReadResult result, out bool endConnection)
         {
+            // We don't need any of the parameters because we don't implement BeginRead to actually
+            // do the reading from a pipeline, nor do we use endConnection to report connection-level errors.
+
             Method = RequestHeaders[":method"];
             Scheme = RequestHeaders[":scheme"];
             _httpVersion = Http.HttpVersion.Http2;
@@ -61,7 +64,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
             RequestHeaders["Host"] = RequestHeaders[":authority"];
 
-            return Task.FromResult(true);
+            endConnection = false;
+            return true;
         }
 
         public async Task OnDataAsync(ArraySegment<byte> data, bool endStream)

--- a/test/Kestrel.Core.Tests/Kestrel.Core.Tests.csproj
+++ b/test/Kestrel.Core.Tests/Kestrel.Core.Tests.csproj
@@ -23,8 +23,4 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Kestrel.Core.Tests/Kestrel.Core.Tests.csproj
+++ b/test/Kestrel.Core.Tests/Kestrel.Core.Tests.csproj
@@ -23,4 +23,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
PR #2041 ended up introducing a 5% perf regression in the HTTP/1.1 path. After investigating, I tracked it down to the refactoring of parsing logic into a helper function. Prior to #2041, the HTTP/1.1 and HTTP/2 implementations of `Frame` (what is now `HttpProtocol`) had their own request processing loops and the parsing was done inline in this function (in fact, much of the logic was done in-line, or in functions that intentionally avoid creating an async state machine until necessary). In #2041, by refactoring the parsing logic into a helper function, an async state machine was created in every request (within the `Http1Connection.ParseRequestAsync` method).

So, unfortunately this means we can't have nice things and we have to unrefactor that logic. It also means that `Http1Connection` and `Http2Stream` (the two implementations of `HttpProtocol`) have to have mostly-similar `ProcessRequestsAsync` methods but we can't refactor them up to the base class (because it would create more state machines).

Open to suggestions on how to add the code sharing back in a performant way.

Perf Data:

| Hardware | Benchmark | `dev` | This change | Ratio |
|-|-|-|-|-|
| Physical | Plaintext | 1.246M | 1.307M | 1.246 / 1.307 = **0.953** |
| Cloud | Plaintext | 501,510.91 | 537,988.42 | **0.933** (but Cloud data is also a bit volatile) |

/fyi @cesarbs, in case you're curious what the fix ended up being ;).
