### PR TITLE
Use SocketAsyncEventArgs to improve perf

### DIFF
--- a/src/Kestrel.Transport.Libuv/Internal/LibuvAwaitable.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/LibuvAwaitable.cs
@@ -36,6 +36,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
         public UvWriteResult GetResult()
         {
+            Debug.Assert(_callback == _callbackCompleted);
+
             var exception = _exception;
             var status = _status;
 

--- a/src/Kestrel.Transport.Sockets/Internal/BufferExtensions.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/BufferExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
+{
+    public static class BufferExtensions
+    {
+        public static ArraySegment<byte> GetArray(this Buffer<byte> buffer)
+        {
+            ArraySegment<byte> result;
+            if (!buffer.TryGetArray(out result))
+            {
+                throw new InvalidOperationException("Buffer backed by array was expected");
+            }
+            return result;
+        }
+    }
+}

--- a/src/Kestrel.Transport.Sockets/Internal/SocketAwaitable.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketAwaitable.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -21,6 +22,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public int GetResult()
         {
+            Debug.Assert(_callback == _callbackCompleted);
+
             _callback = null;
 
             if (_error != SocketError.Success)

--- a/src/Kestrel.Transport.Sockets/Internal/SocketAwaitable.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketAwaitable.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
+{
+    public class SocketAwaitable : ICriticalNotifyCompletion
+    {
+        private static readonly Action _callbackCompleted = () => { };
+
+        private Action _callback;
+        private int _bytesTransfered;
+        private SocketError _error;
+
+        public SocketAwaitable GetAwaiter() => this;
+        public bool IsCompleted => _callback == _callbackCompleted;
+
+        public int GetResult()
+        {
+            _callback = null;
+
+            if (_error != SocketError.Success)
+            {
+                throw new SocketException((int)_error);
+            }
+
+            return _bytesTransfered;
+        }
+
+        public void OnCompleted(Action continuation)
+        {
+            if (_callback == _callbackCompleted ||
+                Interlocked.CompareExchange(ref _callback, continuation, null) == _callbackCompleted)
+            {
+                continuation();
+            }
+        }
+
+        public void UnsafeOnCompleted(Action continuation)
+        {
+            OnCompleted(continuation);
+        }
+
+        public void Complete(int bytesTransferred, SocketError socketError)
+        {
+            _error = socketError;
+            _bytesTransfered = bytesTransferred;
+            Interlocked.Exchange(ref _callback, _callbackCompleted)?.Invoke();
+        }
+    }
+}

--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
@@ -11,10 +10,9 @@ using System.Net.Sockets;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Protocols;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
-using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
     internal sealed class SocketConnection : TransportConnection
     {
@@ -22,8 +20,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
         private readonly Socket _socket;
         private readonly ISocketsTrace _trace;
+        private readonly SocketReceiver _receiver;
+        private readonly SocketSender _sender;
 
-        private IList<ArraySegment<byte>> _sendBufferList;
         private volatile bool _aborted;
 
         internal SocketConnection(Socket socket, PipeFactory pipeFactory, ISocketsTrace trace)
@@ -44,11 +43,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
             RemoteAddress = remoteEndPoint.Address;
             RemotePort = remoteEndPoint.Port;
+
+            _sender = new SocketSender(_socket);
+            _receiver = new SocketReceiver(_socket);
         }
 
         public override PipeFactory PipeFactory { get; }
         public override IScheduler InputWriterScheduler => InlineScheduler.Default;
-        public override IScheduler OutputReaderScheduler => TaskRunScheduler.Default;
+        public override IScheduler OutputReaderScheduler => InlineScheduler.Default;
 
         public async Task StartAsync(IConnectionHandler connectionHandler)
         {
@@ -95,7 +97,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
                     try
                     {
-                        var bytesReceived = await _socket.ReceiveAsync(GetArraySegment(buffer.Buffer), SocketFlags.None);
+                        var bytesReceived = await _receiver.ReceiveAsync(buffer.Buffer);
 
                         if (bytesReceived == 0)
                         {
@@ -176,25 +178,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             }
         }
 
-        private void SetupSendBuffers(ReadableBuffer buffer)
-        {
-            Debug.Assert(!buffer.IsEmpty);
-            Debug.Assert(!buffer.IsSingleSpan);
-
-            if (_sendBufferList == null)
-            {
-                _sendBufferList = new List<ArraySegment<byte>>();
-            }
-
-            // We should always clear the list after the send
-            Debug.Assert(_sendBufferList.Count == 0);
-
-            foreach (var b in buffer)
-            {
-                _sendBufferList.Add(GetArraySegment(b));
-            }
-        }
-
         private async Task DoSend()
         {
             Exception error = null;
@@ -216,23 +199,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                     {
                         if (!buffer.IsEmpty)
                         {
-                            if (buffer.IsSingleSpan)
-                            {
-                                await _socket.SendAsync(GetArraySegment(buffer.First), SocketFlags.None);
-                            }
-                            else
-                            {
-                                SetupSendBuffers(buffer);
-
-                                try
-                                {
-                                    await _socket.SendAsync(_sendBufferList, SocketFlags.None);
-                                }
-                                finally
-                                {
-                                    _sendBufferList.Clear();
-                                }
-                            }
+                            await _sender.SendAsync(buffer);
                         }
                         else if (result.IsCompleted)
                         {
@@ -273,16 +240,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 _socket.Shutdown(SocketShutdown.Both);
             }
         }
-
-        private static ArraySegment<byte> GetArraySegment(Buffer<byte> buffer)
-        {
-            if (!buffer.TryGetArray(out var segment))
-            {
-                throw new InvalidOperationException();
-            }
-
-            return segment;
-        }
-
     }
 }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -44,8 +44,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             RemoteAddress = remoteEndPoint.Address;
             RemotePort = remoteEndPoint.Port;
 
-            _sender = new SocketSender(_socket);
             _receiver = new SocketReceiver(_socket);
+            _sender = new SocketSender(_socket);
         }
 
         public override PipeFactory PipeFactory { get; }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public override PipeFactory PipeFactory { get; }
         public override IScheduler InputWriterScheduler => InlineScheduler.Default;
-        public override IScheduler OutputReaderScheduler => InlineScheduler.Default;
+        public override IScheduler OutputReaderScheduler => TaskRunScheduler.Default;
 
         public async Task StartAsync(IConnectionHandler connectionHandler)
         {

--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Sockets;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
+{
+    public class SocketReceiver
+    {
+        private readonly Socket _socket;
+        private readonly SocketAsyncEventArgs _eventArgs = new SocketAsyncEventArgs();
+        private readonly SocketAwaitable _awaitable = new SocketAwaitable();
+
+        public SocketReceiver(Socket socket)
+        {
+            _socket = socket;
+            _eventArgs.UserToken = this;
+            _eventArgs.Completed += (_, e) => ((SocketReceiver)e.UserToken).ReceiveCompleted(e);
+        }
+
+        public SocketAwaitable ReceiveAsync(Buffer<byte> buffer)
+        {
+            if (!buffer.TryGetArray(out var segment))
+            {
+                throw new InvalidOperationException();
+            }
+
+            _eventArgs.SetBuffer(segment.Array, segment.Offset, segment.Count);
+
+            if (!_socket.ReceiveAsync(_eventArgs))
+            {
+                ReceiveCompleted(_eventArgs);
+            }
+
+            return _awaitable;
+        }
+
+        private void ReceiveCompleted(SocketAsyncEventArgs e)
+        {
+            _awaitable.Complete(e.BytesTransferred, e.SocketError);
+        }
+    }
+}

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using System.Net.Sockets;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
+{
+    public class SocketSender
+    {
+        private readonly Socket _socket;
+        private readonly SocketAsyncEventArgs _eventArgs = new SocketAsyncEventArgs();
+        private readonly SocketAwaitable _awaitable = new SocketAwaitable();
+
+        private List<ArraySegment<byte>> _bufferList;
+
+        public SocketSender(Socket socket)
+        {
+            _socket = socket;
+            _eventArgs.UserToken = this;
+            _eventArgs.Completed += (_, e) => ((SocketSender)e.UserToken).SendCompleted(e);
+        }
+
+        public SocketAwaitable SendAsync(ReadableBuffer buffers)
+        {
+            if (buffers.IsSingleSpan)
+            {
+                return SendAsync(buffers.First);
+            }
+
+            _eventArgs.BufferList = GetBufferList(buffers);
+
+            if (!_socket.SendAsync(_eventArgs))
+            {
+                SendCompleted(_eventArgs);
+            }
+
+            return _awaitable;
+        }
+
+        private SocketAwaitable SendAsync(Buffer<byte> buffer)
+        {
+            var segment = GetArraySegment(buffer);
+
+            _eventArgs.SetBuffer(segment.Array, segment.Offset, segment.Count);
+
+            if (!_socket.SendAsync(_eventArgs))
+            {
+                SendCompleted(_eventArgs);
+            }
+
+            return _awaitable;
+        }
+
+        private void SendCompleted(SocketAsyncEventArgs e)
+        {
+            // Clear buffer(s) to prevent the SetBuffer buffer and BufferList from both being
+            // set for the next write operation. This is unnecessary for reads since they never
+            // set BufferList.
+
+            if (e.BufferList != null)
+            {
+                e.BufferList.Clear();
+                e.BufferList = null;
+            }
+            else
+            {
+                e.SetBuffer(null, 0, 0);
+            }
+
+            _awaitable.Complete(e.BytesTransferred, e.SocketError);
+        }
+
+        private List<ArraySegment<byte>> GetBufferList(ReadableBuffer buffer)
+        {
+            Debug.Assert(!buffer.IsEmpty);
+            Debug.Assert(!buffer.IsSingleSpan);
+
+            if (_bufferList == null)
+            {
+                _bufferList = new List<ArraySegment<byte>>();
+            }
+
+            // We should always clear the list after the send
+            Debug.Assert(_bufferList.Count == 0);
+
+            foreach (var b in buffer)
+            {
+                _bufferList.Add(GetArraySegment(b));
+            }
+
+            return _bufferList;
+        }
+
+        private static ArraySegment<byte> GetArraySegment(Buffer<byte> buffer)
+        {
+            if (!buffer.TryGetArray(out var segment))
+            {
+                throw new InvalidOperationException();
+            }
+
+            return segment;
+        }
+    }
+}


### PR DESCRIPTION
Using SocketAsyncEventArgs in the Kestrel managed socket transport instead of the TAP APIs helps narrow the performance gap between the libuv and socket transports on both Windows and Linux.

Here are some RPS numbers I got from running the plaintext benchmark with no pipelining against the [PlatformLevelTechempower app](https://github.com/halter73/PlatformLevelTechempower/commit/428d30d08fb7d0d09d47938966bfbc2fde28b6cf). I used this instead of the the official [Benchmarks app](https://github.com/aspnet/Benchmarks) because PlatformLevelTechempower is written directly against the transport abstraction.

### Benchmark results:

![image](https://user-images.githubusercontent.com/54385/32355641-155bb836-bfed-11e7-817a-9921b3c93c48.png)

### Benchmark environment info:
```
PlatformLevelTechempower halter73/2.1 commit: 428d30d08fb7d0d09d47938966bfbc2fde28b6cf
Kestrel dev commit: 6c82f78c657145404bcdbe403024b2d93ca7699a
Kestrel halter73/socket-event-args commit: 69d7c4c3affd2373ad33d11784c26977c693aee0
Windows server, Linux server and Linux client VMs: F4S
Windows OS: Windows Server 2016 Datacenter
Linux server and client OS: Ubuntu 16.04.2 LTS

Sample server commands:
dotnet ./bin/Release/netcoreapp2.0/PlatformLevelTechempower.dll --mode raw --port 5000 --transport sockets
dotnet ./bin/Release/netcoreapp2.0/PlatformLevelTechempower.dll --mode raw --port 5000

Sample client command:
wrk -t 32 -c 256 -d 30 http://host:5000/plaintext
```

### Copyable benchmark results:

  | Windows Sockets Dev | Windows SocketAsyncEventArgs | Windows Libuv |Linux Sockets Dev | Linux SocketAsyncEventArgs | Linux Libuv
-- | -- | -- | -- | -- |-- | --
Run 1 | 163209 | 186672 | 233858 | 188827 | 202882 | 231730
Run 2 | 163330 | 187990 | 236810 | 190314 | 205801 | 238674
Run 3 | 166695 | 187526 | 238348 | 189439 | 206955 | 235977
AVG: | 164411 | 187396 | 236338 | 189527 | 205213 | 235460

