### PR TITLE
Put Libuv.FunctionalTests into a separate test group

### DIFF
--- a/test/Kestrel.Transport.Libuv.FunctionalTests/Kestrel.Transport.Libuv.FunctionalTests.csproj
+++ b/test/Kestrel.Transport.Libuv.FunctionalTests/Kestrel.Transport.Libuv.FunctionalTests.csproj
@@ -7,6 +7,8 @@
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <DefineConstants Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(DefineConstants);MACOS</DefineConstants>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <!-- Put this project into its own test group to avoid running parallel with other test projects. Libuv does not play nice with other test assemblies. -->
+    <TestGroupName>Libuv.FunctionalTests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Preparation for https://github.com/aspnet/BuildTools/pull/417 - "Execute test assemblies in parallel".

LibUv.FunctionalTests fails when run in parallel with other test assemblies. Here are some examples of failures:

A handful of address binding tests fail with EACCESS.
```
Failed   RegisterAddresses_IPv4Port80_Success(addressInput: "http://localhost", testUrl: "http://127.0.0.1")
Error Message:
 System.IO.IOException : Failed to bind to address http://localhost:80.
---- System.AggregateException : One or more errors occurred.
-------- Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networking.UvException : Error -4092 EACCES permission denied
-------- Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networking.UvException : Error -4092 EACCES permission denied
Stack Trace:
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.<BindLocalhostAsync>d__6.MoveNext() in C:\dev\aspnet\KestrelHttpServer\src\Kestrel.Core\Internal\AddressBinder.cs:line 174
```

EINVAL
```
Failed   CanListenToOpenTcpSocketHandle
Error Message:
 System.Exception : Unexpected critical error.
---- Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networking.UvException : Error -4071 EINVAL invalid argument
Stack Trace:
   at Microsoft.AspNetCore.Testing.TestApplicationErrorLogger.Log[TState](LogLevel logLevel, EventId eventId, TState state, Exception exception, Func`3 formatter) in C:\dev\aspnet\KestrelHttpServer\test\shared\TestApplicationErrorLogger.cs:line 51
```

On .NET Core
```
The active test run was aborted. Reason: FailFast: ThreadId is incorrect
   at System.Diagnostics.Debug.Assert(Boolean condition, String message, String detailMessage)
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networking.UvMemory.Validate(Boolean closed) in C:\dev\aspnet\KestrelHttpServer\src\Kestrel.Transport.Libuv\Internal\Networking\UvMemory.cs:line 84
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networking.LibuvFunctions.loop_close(UvLoopHandle handle) in C:\dev\aspnet\KestrelHttpServer\src\Kestrel.Transport.Libuv\Internal\Networking\LibuvFunctions.cs:line 111
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networking.UvLoopHandle.ReleaseHandle() in C:\dev\aspnet\KestrelHttpServer\src\Kestrel.Transport.Libuv\Internal\Networking\UvLoopHandle.cs:line 48
```