### PR TITLE
Show cause of connection failure in test

### DIFF
--- a/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs
+++ b/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     }
                     catch (Exception ex)
                     {
-                        closedTcs.TrySetException(ex);
+                        openedTcs.TrySetException(ex);
                     }
                 });
 


### PR DESCRIPTION
I think the flakiness of the ConnectionCountingReturnsToZero test might be due to ephemeral port exhaustion or a file handle limit on macOS.

This has lead to timeout errors like the following on our CI server:

```
[Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.ConnectionLimitTests.ConnectionCountingReturnsToZero]
System.TimeoutException : The operation at /Users/asplab/TeamCity/work/33bdfc1cae7b2a38/.r/KestrelHttpServer/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs:182 timed out after reaching the limit of 120000ms.
    at Microsoft.AspNetCore.Testing.TaskExtensions.<TimeoutAfter>d__0`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.ConnectionLimitTests.<ConnectionCountingReturnsToZero>d__3.MoveNext() in /Users/asplab/TeamCity/work/33bdfc1cae7b2a38/.r/KestrelHttpServer/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs:line 182
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
```

With this PR, we should see that actual cause of the connection failure. If it's a port exhaustion issue, the test failure will look like the following after the change:

```
    ConnectionCountingReturnsToZero [FAIL]
      System.Net.Internals.SocketExceptionFactory+ExtendedSocketException : Can't assign requested address 127.0.0.1:53066
      Stack Trace:
           at System.Net.Sockets.Socket.DoConnect(EndPoint endPointSnapshot, SocketAddress socketAddress)
           at System.Net.Sockets.Socket.Connect(EndPoint remoteEP)
        /Users/shalter/source/aspnet/KestrelHttpServer/test/shared/TestConnection.cs(259,0): at Microsoft.AspNetCore.Testing.TestConnection.CreateConnectedLoopbackSocket(Int32 port, AddressFamily addressFamily)
        /Users/shalter/source/aspnet/KestrelHttpServer/test/shared/TestConnection.cs(33,0): at Microsoft.AspNetCore.Testing.TestConnection..ctor(Int32 port, AddressFamily addressFamily)
        /Users/shalter/source/aspnet/KestrelHttpServer/test/Kestrel.FunctionalTests/TestHelpers/TestServer.cs(100,0): at Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.TestServer.CreateConnection()
        /Users/shalter/source/aspnet/KestrelHttpServer/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs(171,0): at Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.ConnectionLimitTests.<>c__DisplayClass3_1.<<ConnectionCountingReturnsToZero>b__3>d.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at Microsoft.AspNetCore.Testing.TaskExtensions.<TimeoutAfter>d__0`1.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
           at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
        /Users/shalter/source/aspnet/KestrelHttpServer/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs(184,0): at Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.ConnectionLimitTests.<ConnectionCountingReturnsToZero>d__3.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
  Finished:    Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.FunctionalTests
=== TEST EXECUTION SUMMARY ===
   Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.FunctionalTests  Total: 1, Errors: 0, Failed: 1, Skipped: 0, Time: 17.547s
```