### PR TITLE
[WIP] Add ListenLocalhost and ListenPrefix

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -73,7 +73,19 @@ namespace SampleApp
                     options.Listen(IPAddress.Loopback, basePort + 1, listenOptions =>
                     {
                         listenOptions.UseHttps("testCert.pfx", "testPassword");
-                        listenOptions.UseConnectionLogging();
+                    });
+
+                    options.ListenLocalhost(basePort + 2);
+
+                    // Use the default certificate
+                    options.ListenLocalhost(basePort + 3, useHttps: true);
+
+                    // Use the default certificate
+                    options.ListenPrefix($"https://*:{basePort + 4}");
+
+                    options.ListenPrefix($"https://*:{basePort + 5}", listenOptions =>
+                    {
+                        listenOptions.UseHttps("testCert.pfx", "testPassword");
                     });
 
                     options.UseSystemd();

--- a/src/Kestrel.Core/KestrelServerOptions.cs
+++ b/src/Kestrel.Core/KestrelServerOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
@@ -103,6 +104,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             var listenOptions = new ListenOptions(endPoint) { KestrelServerOptions = this };
             configure(listenOptions);
             ListenOptions.Add(listenOptions);
+        }
+
+        public void ListenPrefix(string prefix) => ListenPrefix(prefix, configure => { });
+
+        public void ListenPrefix(string prefix, Action<ListenOptions> configure)
+        {
+            if (string.IsNullOrEmpty(prefix))
+            {
+                throw new ArgumentNullException(nameof(prefix));
+            }
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var listenOptions = new ListenOptions(ListenType.Prefix)
+            {
+                Prefix = prefix,
+                KestrelServerOptions = this,
+            };
+            configure(listenOptions);
+            ListenOptions.Add(listenOptions);
+        }
+
+        public void ListenLocalhost(int port) => ListenLocalhost(port, configure => { });
+
+        public void ListenLocalhost(int port, bool useHttps) => ListenLocalhost(port, useHttps, configure => { });
+
+        public void ListenLocalhost(int port, Action<ListenOptions> configure) => ListenLocalhost(port, false, options => { });
+
+        public void ListenLocalhost(int port, bool useHttps, Action<ListenOptions> configure)
+        {
+            var scheme = useHttps ? "https" : "http";
+            ListenPrefix($"{scheme}://localhost:{port}", configure);
         }
 
         /// <summary>

--- a/src/Kestrel.Transport.Abstractions/Internal/ListenType.cs
+++ b/src/Kestrel.Transport.Abstractions/Internal/ListenType.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
     /// </summary>
     public enum ListenType
     {
+        Prefix,
         IPEndPoint,
         SocketPath,
         FileHandle

--- a/test/Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
+++ b/test/Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             _bufferPool = new MemoryPool();
             _mockLibuv = new MockLibuv();
 
-            var libuvTransport = new LibuvTransport(_mockLibuv, new TestLibuvTransportContext(), new ListenOptions(0));
+            var libuvTransport = new LibuvTransport(_mockLibuv, new TestLibuvTransportContext(), new ListenOptions((ulong)0));
             _libuvThread = new LibuvThread(libuvTransport, maxLoops: 1);
             _libuvThread.StartAsync().Wait();
         }


### PR DESCRIPTION
#2139, #1290
[Widows update took over my machine before I could finish the tests. Starting this PR so we can review the overall approach.]

This adds `options.ListenLocalhost(int port);` and `options.ListenPrefix(string prefix);` and the associated config lambda overloads.

ListenLocalhost listens on both IPv4 & IPv6 loopback adapters, and can add https either with the default cert or a manual cert. This mirrors the functionality of .UseUrls("https://localhost:{port}") with the addition of ListenOptions.

ListenPrefix is a more generic version of ListenLocalhost that allows any syntax from UseUrls and adds the ability to configure the endpoint settings like protocol and certificate. This will be useful for the upcoming configuration work.