### PR TITLE
Add ListenLocalhost and ListenAnyIP

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -76,6 +76,13 @@ namespace SampleApp
                         listenOptions.UseConnectionLogging();
                     });
 
+                    options.ListenLocalhost(basePort + 2, listenOptions =>
+                    {
+                        listenOptions.UseHttps("testCert.pfx", "testPassword");
+                    });
+
+                    options.ListenAnyIP(basePort + 3);
+
                     options.UseSystemd();
 
                     // The following section should be used to demo sockets

--- a/src/Kestrel.Core/AnyIPListenOptions.cs
+++ b/src/Kestrel.Core/AnyIPListenOptions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core
+{
+    internal class AnyIPListenOptions : ListenOptions
+    {
+        internal AnyIPListenOptions(int port)
+            : base(new IPEndPoint(IPAddress.IPv6Any, port))
+        {
+        }
+
+        internal override async Task BindAsync(AddressBindContext context)
+        {
+            // when address is 'http://hostname:port', 'http://*:port', or 'http://+:port'
+            try
+            {
+                await base.BindAsync(context).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is IOException))
+            {
+                context.Logger.LogDebug(CoreStrings.FormatFallbackToIPv4Any(IPEndPoint.Port));
+
+                // for machines that do not support IPv6
+                IPEndPoint = new IPEndPoint(IPAddress.Any, IPEndPoint.Port);
+                await base.BindAsync(context).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Kestrel.Core/Internal/AddressBindContext.cs
+++ b/src/Kestrel.Core/Internal/AddressBindContext.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
+{
+    internal class AddressBindContext
+    {
+        public ICollection<string> Addresses { get; set; }
+        public List<ListenOptions> ListenOptions { get; set; }
+        public KestrelServerOptions ServerOptions { get; set; }
+        public ILogger Logger { get; set; }
+        public IDefaultHttpsProvider DefaultHttpsProvider { get; set; }
+
+        public Func<ListenOptions, Task> CreateBinding { get; set; }
+    }
+}

--- a/src/Kestrel.Core/KestrelServerOptions.cs
+++ b/src/Kestrel.Core/KestrelServerOptions.cs
@@ -105,6 +105,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             ListenOptions.Add(listenOptions);
         }
 
+        public void ListenLocalhost(int port) => ListenLocalhost(port, options => { });
+
+        public void ListenLocalhost(int port, Action<ListenOptions> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var listenOptions = new LocalhostListenOptions(port)
+            {
+                KestrelServerOptions = this,
+            };
+            configure(listenOptions);
+            ListenOptions.Add(listenOptions);
+        }
+
+        public void ListenAnyIP(int port) => ListenAnyIP(port, options => { });
+
+        public void ListenAnyIP(int port, Action<ListenOptions> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var listenOptions = new AnyIPListenOptions(port)
+            {
+                KestrelServerOptions = this,
+            };
+            configure(listenOptions);
+            ListenOptions.Add(listenOptions);
+        }
+
         /// <summary>
         /// Bind to given Unix domain socket path.
         /// </summary>

--- a/src/Kestrel.Core/ListenOptions.cs
+++ b/src/Kestrel.Core/ListenOptions.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Protocols;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core
@@ -140,7 +141,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// <summary>
         /// Gets the name of this endpoint to display on command-line when the web server starts.
         /// </summary>
-        internal string GetDisplayName()
+        internal virtual string GetDisplayName()
         {
             var scheme = ConnectionAdapters.Any(f => f.IsHttps)
                 ? "https"
@@ -181,6 +182,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
 
             return app;
+        }
+
+        internal virtual async Task BindAsync(AddressBindContext context)
+        {
+            await AddressBinder.BindEndpointAsync(this, context).ConfigureAwait(false);
+            context.Addresses.Add(GetDisplayName());
         }
     }
 }

--- a/src/Kestrel.Core/LocalhostListenOptions.cs
+++ b/src/Kestrel.Core/LocalhostListenOptions.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core
+{
+    internal class LocalhostListenOptions : ListenOptions
+    {
+        internal LocalhostListenOptions(int port)
+            : base(new IPEndPoint(IPAddress.Loopback, port))
+        {
+            if (port == 0)
+            {
+                throw new InvalidOperationException(CoreStrings.DynamicPortOnLocalhostNotSupported);
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of this endpoint to display on command-line when the web server starts.
+        /// </summary>
+        internal override string GetDisplayName()
+        {
+            var scheme = ConnectionAdapters.Any(f => f.IsHttps)
+                ? "https"
+                : "http";
+
+            return $"{scheme}://localhost:{IPEndPoint.Port}";
+        }
+
+        internal override async Task BindAsync(AddressBindContext context)
+        {
+            var exceptions = new List<Exception>();
+
+            try
+            {
+                var v4Options = Clone(IPAddress.Loopback);
+                await AddressBinder.BindEndpointAsync(v4Options, context).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is IOException))
+            {
+                context.Logger.LogWarning(0, CoreStrings.NetworkInterfaceBindingFailed, GetDisplayName(), "IPv4 loopback", ex.Message);
+                exceptions.Add(ex);
+            }
+
+            try
+            {
+                var v6Options = Clone(IPAddress.IPv6Loopback);
+                await AddressBinder.BindEndpointAsync(v6Options, context).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is IOException))
+            {
+                context.Logger.LogWarning(0, CoreStrings.NetworkInterfaceBindingFailed, GetDisplayName(), "IPv6 loopback", ex.Message);
+                exceptions.Add(ex);
+            }
+
+            if (exceptions.Count == 2)
+            {
+                throw new IOException(CoreStrings.FormatAddressBindingFailed(GetDisplayName()), new AggregateException(exceptions));
+            }
+
+            // If StartLocalhost doesn't throw, there is at least one listener.
+            // The port cannot change for "localhost".
+            context.Addresses.Add(GetDisplayName());
+        }
+
+        // used for cloning to two IPEndpoints
+        private ListenOptions Clone(IPAddress address)
+        {
+            var options = new ListenOptions(new IPEndPoint(address, IPEndPoint.Port))
+            {
+                HandleType = HandleType,
+                KestrelServerOptions = KestrelServerOptions,
+                NoDelay = NoDelay,
+                Protocols = Protocols,
+            };
+            options.ConnectionAdapters.AddRange(ConnectionAdapters);
+            return options;
+        }
+    }
+}

--- a/test/Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
+++ b/test/Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             _bufferPool = new MemoryPool();
             _mockLibuv = new MockLibuv();
 
-            var libuvTransport = new LibuvTransport(_mockLibuv, new TestLibuvTransportContext(), new ListenOptions(0));
+            var libuvTransport = new LibuvTransport(_mockLibuv, new TestLibuvTransportContext(), new ListenOptions((ulong)0));
             _libuvThread = new LibuvThread(libuvTransport, maxLoops: 1);
             _libuvThread.StartAsync().Wait();
         }


### PR DESCRIPTION
#2139 Still needs tests

This abstracts the address parser to work independently of the binder so it can be used for future config code. It also adds first class support for two scenarios formerly only available via UseUrls, ListenLocalhost and ListenAnyIP. Both of these provide dynamic fallback behavior that's not was not possible with a single ListenOptions before.