### PR TITLE
Null out send buffer less

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
             _socket = socket;
             _eventArgs.UserToken = _awaitable;
-            _eventArgs.Completed += (_, e) => SendCompleted(e, (SocketAwaitable)e.UserToken);
+            _eventArgs.Completed += (_, e) => ((SocketAwaitable)e.UserToken).Complete(e.BytesTransferred, e.SocketError);
         }
 
         public SocketAwaitable SendAsync(ReadableBuffer buffers)
@@ -31,11 +31,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 return SendAsync(buffers.First);
             }
 
+            if (_eventArgs.Buffer != null)
+            {
+                _eventArgs.SetBuffer(null, 0, 0);
+            }
+
             _eventArgs.BufferList = GetBufferList(buffers);
 
             if (!_socket.SendAsync(_eventArgs))
             {
-                SendCompleted(_eventArgs, _awaitable);
+                _awaitable.Complete(_eventArgs.BytesTransferred, _eventArgs.SocketError);
             }
 
             return _awaitable;
@@ -45,11 +50,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
             var segment = buffer.GetArray();
 
+            // The BufferList getter is much less expensive then the setter.
+            if (_eventArgs.BufferList != null)
+            {
+                _eventArgs.BufferList = null;
+            }
+
             _eventArgs.SetBuffer(segment.Array, segment.Offset, segment.Count);
 
             if (!_socket.SendAsync(_eventArgs))
             {
-                SendCompleted(_eventArgs, _awaitable);
+                _awaitable.Complete(_eventArgs.BytesTransferred, _eventArgs.SocketError);
             }
 
             return _awaitable;
@@ -64,9 +75,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             {
                 _bufferList = new List<ArraySegment<byte>>();
             }
-
-            // We should always clear the list after the send
-            Debug.Assert(_bufferList.Count == 0);
+            else
+            {
+                // Buffers are pooled, so it's OK to root them until the next multi-buffer write.
+                _bufferList.Clear();
+            }
 
             foreach (var b in buffer)
             {
@@ -74,25 +87,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             }
 
             return _bufferList;
-        }
-
-        private static void SendCompleted(SocketAsyncEventArgs e, SocketAwaitable awaitable)
-        {
-            // Clear buffer(s) to prevent the SetBuffer buffer and BufferList from both being
-            // set for the next write operation. This is unnecessary for reads since they never
-            // set BufferList.
-
-            if (e.BufferList != null)
-            {
-                e.BufferList.Clear();
-                e.BufferList = null;
-            }
-            else
-            {
-                e.SetBuffer(null, 0, 0);
-            }
-
-            awaitable.Complete(e.BytesTransferred, e.SocketError);
         }
     }
 }


### PR DESCRIPTION
Nulling out write buffers less greedily allows the Windows managed socket implementation to create less GCHandles. This improves the Socket transport performance on Windows by about 3%. Thanks to @stephentoub for the suggestion.

### Windows Results (Plaintext RPS):

  | SocketAsyncEventArgs 2.0 | SocketAsyncEventArgs 2.1 | SocketAsyncEventArgs 2.1 (null-less) | Libuv 2.0
-- | -- | -- | -- | --
AVG: | 187396 | 210402 | 216650 | 236338

### Linux Results (Plaintext RPS):

  | SocketAsyncEventArgs 2.0 | SocketAsyncEventArgs 2.1 | SocketAsyncEventArgs 2.1 (null-less) | Libuv 2.0
-- | -- | -- | -- | --
AVG: | 205213 | 204287 | 201845 | 235460


### Benchmark environment info:
PlatformLevelTechempower halter73/2.1-2.1 (ba483fc53bbaaef3b4cc59b621308ad5de5e85d2)
Kestrel halter73/null-less (f494adb344496f15a751f154de5ad738e3b02679)
.NET Core Runtime 2.1.0-preview1-25907-02 Windows
.NET Core Runtime 2.1.0-preview1-25909-03 Linux