### PR TITLE
Use new Memory<byte> APIs on SocketAsyncEventArgs

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -21,10 +21,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public SocketAwaitable ReceiveAsync(Memory<byte> buffer)
         {
+#if NETCOREAPP2_1
+            _eventArgs.SetBuffer(buffer);
+#else
             var segment = buffer.GetArray();
 
             _eventArgs.SetBuffer(segment.Array, segment.Offset, segment.Count);
-
+#endif
             if (!_socket.ReceiveAsync(_eventArgs))
             {
                 _awaitable.Complete(_eventArgs.BytesTransferred, _eventArgs.SocketError);

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
@@ -48,16 +48,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         private SocketAwaitable SendAsync(Memory<byte> buffer)
         {
-            var segment = buffer.GetArray();
-
             // The BufferList getter is much less expensive then the setter.
             if (_eventArgs.BufferList != null)
             {
                 _eventArgs.BufferList = null;
             }
 
-            _eventArgs.SetBuffer(segment.Array, segment.Offset, segment.Count);
+#if NETCOREAPP2_1
+            _eventArgs.SetBuffer(buffer);
+#else
+            var segment = buffer.GetArray();
 
+            _eventArgs.SetBuffer(segment.Array, segment.Offset, segment.Count);
+#endif
             if (!_socket.SendAsync(_eventArgs))
             {
                 _awaitable.Complete(_eventArgs.BytesTransferred, _eventArgs.SocketError);

--- a/src/Kestrel.Transport.Sockets/Kestrel.Transport.Sockets.csproj
+++ b/src/Kestrel.Transport.Sockets/Kestrel.Transport.Sockets.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets</AssemblyName>
     <RootNamespace>Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets</RootNamespace>
     <Description>Managed socket transport for the ASP.NET Core Kestrel cross-platform web server.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;kestrel</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Kestrel.Transport.Sockets/Kestrel.Transport.Sockets.csproj
+++ b/src/Kestrel.Transport.Sockets/Kestrel.Transport.Sockets.csproj
@@ -9,6 +9,7 @@
     <PackageTags>aspnetcore;kestrel</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1591;$(NoWarn)</NoWarn>
+    <EnableAPICheck>false</EnableAPICheck>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- This should improve the performance of handling buffers by (eventually)
removing GCHandle churn for Kestrel's already pinned buffers.
- Made the Sockets transport target both netcoreapp2.1 and netstandard2.0 to use new
APIs

Contributes to https://github.com/aspnet/KestrelHttpServer/issues/1686

/cc @stephentoub @geoffkizer 