### PR TITLE
Use MSBuild to set NuGet feeds instead of NuGet.config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,11 @@
-<Project>
+﻿<Project>
   <Import
     Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), AspNetCoreSettings.props))\AspNetCoreSettings.props"
     Condition=" '$(CI)' != 'true' AND '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), AspNetCoreSettings.props))' != '' " />
 
   <Import Project="version.props" />
   <Import Project="build\dependencies.props" />
+  <Import Project="build\sources.props" />
 
   <PropertyGroup>
     <Product>Microsoft ASP.NET Core</Product>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,9 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
-    <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <!-- Restore sources should be defined in build/sources.props. -->
   </packageSources>
 </configuration>

--- a/build/sources.props
+++ b/build/sources.props
@@ -1,0 +1,17 @@
+﻿<Project>
+  <Import Project="$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''"/>
+
+  <PropertyGroup Label="RestoreSources">
+    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND '$(AspNetUniverseBuildOffline)' != 'true' ">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json;
+      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
+    </RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
+      $(RestoreSources);
+      https://api.nuget.org/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Part of https://github.com/aspnet/Coherence-Signed/issues/682

Required for orchestrated build so we can conditionally exclude myget while restoring on CI.