### PR TITLE
Fix for #2129

### DIFF
--- a/src/Kestrel.Core/Internal/Http/ReasonPhrases.cs
+++ b/src/Kestrel.Core/Internal/Http/ReasonPhrases.cs
@@ -222,9 +222,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     default:
                         var predefinedReasonPhrase = WebUtilities.ReasonPhrases.GetReasonPhrase(statusCode);
+                        // https://tools.ietf.org/html/rfc7230#section-3.1.2 requires trailing whitespace regardless of reason phrase
+                        var formattedStatusCode = statusCode.ToString(CultureInfo.InvariantCulture) + " ";
                         return string.IsNullOrEmpty(predefinedReasonPhrase)
-                            ? Encoding.ASCII.GetBytes(statusCode.ToString(CultureInfo.InvariantCulture))
-                            : Encoding.ASCII.GetBytes(statusCode.ToString(CultureInfo.InvariantCulture) + " " + predefinedReasonPhrase);
+                            ? Encoding.ASCII.GetBytes(formattedStatusCode)
+                            : Encoding.ASCII.GetBytes(formattedStatusCode + predefinedReasonPhrase);
 
                 }
             }

--- a/test/Kestrel.Core.Tests/ReasonPhrasesTests.cs
+++ b/test/Kestrel.Core.Tests/ReasonPhrasesTests.cs
@@ -3,26 +3,20 @@
 
 using Xunit;
 using Microsoft.AspNetCore.Http;
+using System.Text;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 {
     public class ReasonPhraseTests
     {
         [Theory]
-        [InlineData(999, "Unknown")]
-        [InlineData(999, null)]
-        public void UnknownStatusCodes(int statusCode, string reasonPhrase)
+        [InlineData(999, "Unknown", "999 Unknown")]
+        [InlineData(999, null, "999 ")]
+        public void UnknownStatusCodes(int statusCode, string reasonPhrase, string expectedResult)
         {
             var bytes = Internal.Http.ReasonPhrases.ToStatusBytes(statusCode, reasonPhrase);
             Assert.NotNull(bytes);
-            if (string.IsNullOrEmpty(reasonPhrase))
-            {
-                Assert.Equal(0x20, bytes[bytes.Length - 1]);
-            }
-            else
-            {
-                Assert.NotEqual(0x20, bytes[bytes.Length - 1]);
-            }
+            Assert.Equal(expectedResult, Encoding.ASCII.GetString(bytes));
         }
 
         [Theory]

--- a/test/Kestrel.Core.Tests/ReasonPhrasesTests.cs
+++ b/test/Kestrel.Core.Tests/ReasonPhrasesTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
+{
+    public class ReasonPhraseTests
+    {
+        [Theory]
+        [InlineData(999, "Unknown")]
+        [InlineData(999, null)]
+        public void UnknownStatusCodes(int statusCode, string reasonPhrase)
+        {
+            var bytes = Internal.Http.ReasonPhrases.ToStatusBytes(statusCode, reasonPhrase);
+            Assert.NotNull(bytes);
+            if (string.IsNullOrEmpty(reasonPhrase))
+            {
+                Assert.Equal(0x20, bytes[bytes.Length - 1]);
+            }
+            else
+            {
+                Assert.NotEqual(0x20, bytes[bytes.Length - 1]);
+            }
+        }
+
+        [Theory]
+        [InlineData(StatusCodes.Status200OK, "OK")]
+        [InlineData(StatusCodes.Status200OK, null)]
+        public void KnownStatusCodes(int statusCode, string reasonPhrase)
+        {
+            var bytes = Internal.Http.ReasonPhrases.ToStatusBytes(statusCode, reasonPhrase);
+            Assert.NotNull(bytes);
+            Assert.NotEqual(0x20, bytes[bytes.Length - 1]);
+        }
+    }
+}

--- a/test/Kestrel.Core.Tests/ReasonPhrasesTests.cs
+++ b/test/Kestrel.Core.Tests/ReasonPhrasesTests.cs
@@ -12,21 +12,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Theory]
         [InlineData(999, "Unknown", "999 Unknown")]
         [InlineData(999, null, "999 ")]
-        public void UnknownStatusCodes(int statusCode, string reasonPhrase, string expectedResult)
+		[InlineData(StatusCodes.Status200OK, "OK", "200 OK")]
+        [InlineData(StatusCodes.Status200OK, null, "200 OK")]
+        public void Formatting(int statusCode, string reasonPhrase, string expectedResult)
         {
             var bytes = Internal.Http.ReasonPhrases.ToStatusBytes(statusCode, reasonPhrase);
             Assert.NotNull(bytes);
             Assert.Equal(expectedResult, Encoding.ASCII.GetString(bytes));
-        }
-
-        [Theory]
-        [InlineData(StatusCodes.Status200OK, "OK")]
-        [InlineData(StatusCodes.Status200OK, null)]
-        public void KnownStatusCodes(int statusCode, string reasonPhrase)
-        {
-            var bytes = Internal.Http.ReasonPhrases.ToStatusBytes(statusCode, reasonPhrase);
-            Assert.NotNull(bytes);
-            Assert.NotEqual(0x20, bytes[bytes.Length - 1]);
         }
     }
 }

--- a/test/Kestrel.Core.Tests/ReasonPhrasesTests.cs
+++ b/test/Kestrel.Core.Tests/ReasonPhrasesTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Theory]
         [InlineData(999, "Unknown", "999 Unknown")]
         [InlineData(999, null, "999 ")]
-		[InlineData(StatusCodes.Status200OK, "OK", "200 OK")]
+        [InlineData(StatusCodes.Status200OK, "OK", "200 OK")]
         [InlineData(StatusCodes.Status200OK, null, "200 OK")]
         public void Formatting(int statusCode, string reasonPhrase, string expectedResult)
         {


### PR DESCRIPTION
This pull request fixes #2129.
- Add the whitespace even if the reason phrase is empty
- Add a comment to explain it
- Add tests (in new class, couldn't find any test class for it)