### PR TITLE
Suppress API check due to reflection load errors

### DIFF
--- a/src/Kestrel.Https/Kestrel.Https.csproj
+++ b/src/Kestrel.Https/Kestrel.Https.csproj
@@ -8,6 +8,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;kestrel</PackageTags>
     <NoWarn>CS1591;$(NoWarn)</NoWarn>
+    <!-- Temporarily disabled to workaround https://github.com/aspnet/BuildTools/issues/492 -->
+    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
API check fails for reasons we don't completely understand. Followup: https://github.com/aspnet/BuildTools/issues/492