### PR TITLE
EnableApiCheck for Kestrel.Https

### DIFF
--- a/src/Kestrel.Https/Kestrel.Https.csproj
+++ b/src/Kestrel.Https/Kestrel.Https.csproj
@@ -8,8 +8,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;kestrel</PackageTags>
     <NoWarn>CS1591;$(NoWarn)</NoWarn>
-    <!-- Temporarily disabled to workaround https://github.com/aspnet/BuildTools/issues/492 -->
-    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes aspnet/BuildTools#492. Reverts #2185.