### PR TITLE
Allow Content-Length 0 for Websocket-Connection

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Http1MessageBody.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1MessageBody.cs
@@ -228,6 +228,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 keepAlive = (connectionOptions & ConnectionOptions.KeepAlive) == ConnectionOptions.KeepAlive;
             }
 
+            if (upgrade)
+            {
+                if (headers.HeaderTransferEncoding.Count > 0 || (headers.ContentLength.HasValue && headers.ContentLength.Value != 0))
+                {
+                    context.ThrowRequestRejected(RequestRejectionReason.UpgradeRequestCannotHavePayload);
+                }
+
+                return new ForUpgrade(context);
+            }
+
             var transferEncoding = headers.HeaderTransferEncoding;
             if (transferEncoding.Count > 0)
             {
@@ -244,11 +254,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     context.ThrowRequestRejected(RequestRejectionReason.FinalTransferCodingNotChunked, transferEncoding.ToString());
                 }
 
-                if (upgrade)
-                {
-                    context.ThrowRequestRejected(RequestRejectionReason.UpgradeRequestCannotHavePayload);
-                }
-
                 return new ForChunkedEncoding(keepAlive, context);
             }
 
@@ -259,10 +264,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (contentLength == 0)
                 {
                     return keepAlive ? MessageBody.ZeroContentLengthKeepAlive : MessageBody.ZeroContentLengthClose;
-                }
-                else if (upgrade)
-                {
-                    context.ThrowRequestRejected(RequestRejectionReason.UpgradeRequestCannotHavePayload);
                 }
 
                 return new ForContentLength(keepAlive, contentLength, context);
@@ -278,11 +279,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var requestRejectionReason = httpVersion == HttpVersion.Http11 ? RequestRejectionReason.LengthRequired : RequestRejectionReason.LengthRequiredHttp10;
                     context.ThrowRequestRejected(requestRejectionReason, context.Method);
                 }
-            }
-
-            if (upgrade)
-            {
-                return new ForUpgrade(context);
             }
 
             return keepAlive ? MessageBody.ZeroContentLengthKeepAlive : MessageBody.ZeroContentLengthClose;


### PR DESCRIPTION
mojo is currently sending Content-Length 0 for websockets. This fails against ASP.NET Core/Kestrel.
I tried to patch mojo (see https://github.com/kraih/mojo/pull/1163), but I think this should patched server-side as well.