### PR TITLE
Remove use of Dangerous* Span APIs and use MemoryMarshal instead

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -27,13 +27,13 @@
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
-    <SystemBuffersPackageVersion>4.5.0-preview1-26006-06</SystemBuffersPackageVersion>
+    <SystemBuffersPackageVersion>4.5.0-preview1-26016-05</SystemBuffersPackageVersion>
     <SystemIOPipelinesPackageVersion>0.1.0-e171206-2</SystemIOPipelinesPackageVersion>
     <SystemIOPipelinesTestingPackageVersion>0.1.0-e171206-2</SystemIOPipelinesTestingPackageVersion>
-    <SystemMemoryPackageVersion>4.5.0-preview1-26006-06</SystemMemoryPackageVersion>
-    <SystemNumericsVectorsPackageVersion>4.5.0-preview1-26006-06</SystemNumericsVectorsPackageVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.5.0-preview1-26006-06</SystemRuntimeCompilerServicesUnsafePackageVersion>
-    <SystemSecurityCryptographyCngPackageVersion>4.5.0-preview1-26006-06</SystemSecurityCryptographyCngPackageVersion>
+    <SystemMemoryPackageVersion>4.5.0-preview1-26016-05</SystemMemoryPackageVersion>
+    <SystemNumericsVectorsPackageVersion>4.5.0-preview1-26016-05</SystemNumericsVectorsPackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.5.0-preview1-26016-05</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemSecurityCryptographyCngPackageVersion>4.5.0-preview1-26016-05</SystemSecurityCryptographyCngPackageVersion>
     <SystemTextEncodingsWebUtf8PackageVersion>0.1.0-e171206-2</SystemTextEncodingsWebUtf8PackageVersion>
     <SystemThreadingTasksExtensionsPackageVersion>4.5.0-preview2-25707-02</SystemThreadingTasksExtensionsPackageVersion>
     <XunitAnalyzersPackageVersion>0.8.0</XunitAnalyzersPackageVersion>

--- a/src/Kestrel.Core/Internal/Http/Http1Connection.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1Connection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.IO.Pipelines;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Encodings.Web.Utf8;
 using Microsoft.AspNetCore.Http.Features;
@@ -341,7 +342,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             // .NET 451 doesn't have pointer overloads for Encoding.GetString so we
             // copy to an array
-            fixed (byte* pointer = &path.DangerousGetPinnableReference())
+            fixed (byte* pointer = &MemoryMarshal.GetReference(path))
             {
                 return Encoding.UTF8.GetString(pointer, path.Length);
             }

--- a/src/Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpParser.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
@@ -60,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             // Fix and parse the span
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+            fixed (byte* data = &MemoryMarshal.GetReference(span))
             {
                 ParseRequestLine(handler, data, span.Length);
             }
@@ -204,7 +205,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var span = reader.Span;
                     var remaining = span.Length - reader.Index;
 
-                    fixed (byte* pBuffer = &span.DangerousGetPinnableReference())
+                    fixed (byte* pBuffer = &MemoryMarshal.GetReference(span))
                     {
                         while (remaining > 0)
                         {
@@ -289,7 +290,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                                 var headerSpan = buffer.Slice(current, lineEnd).ToSpan();
                                 length = headerSpan.Length;
 
-                                fixed (byte* pHeader = &headerSpan.DangerousGetPinnableReference())
+                                fixed (byte* pHeader = &MemoryMarshal.GetReference(headerSpan))
                                 {
                                     TakeSingleHeader(pHeader, length, handler);
                                 }

--- a/src/Kestrel.Core/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpRequestHeaders.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -32,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public unsafe void Append(Span<byte> name, string value)
         {
-            fixed (byte* namePtr = &name.DangerousGetPinnableReference())
+            fixed (byte* namePtr = &MemoryMarshal.GetReference(name))
             {
                 Append(namePtr, name.Length, value);
             }

--- a/src/Kestrel.Core/Internal/Http/PathNormalizer.cs
+++ b/src/Kestrel.Core/Internal/Http/PathNormalizer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
@@ -14,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         // In-place implementation of the algorithm from https://tools.ietf.org/html/rfc3986#section-5.2.4
         public static unsafe int RemoveDotSegments(Span<byte> input)
         {
-            fixed (byte* start = &input.DangerousGetPinnableReference())
+            fixed (byte* start = &MemoryMarshal.GetReference(input))
             {
                 var end = start + input.Length;
                 return RemoveDotSegments(start, end);

--- a/src/Kestrel.Core/Internal/Http/PipelineExtensions.cs
+++ b/src/Kestrel.Core/Internal/Http/PipelineExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
@@ -49,7 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (sourceLength <= destLength)
             {
                 fixed (char* input = data)
-                fixed (byte* output = &dest.DangerousGetPinnableReference())
+                fixed (byte* output = &MemoryMarshal.GetReference(dest))
                 {
                     EncodeAsciiCharsToBytes(input, output, sourceLength);
                 }
@@ -72,7 +73,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             // Fast path, try copying to the available memory directly
             var simpleWrite = true;
-            fixed (byte* output = &span.DangerousGetPinnableReference())
+            fixed (byte* output = &MemoryMarshal.GetReference(span))
             {
                 var start = output;
                 if (number < 10 && bytesLeftInBlock >= 1)
@@ -152,7 +153,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         continue;
                     }
 
-                    fixed (byte* output = &buffer.Span.DangerousGetPinnableReference())
+                    fixed (byte* output = &MemoryMarshal.GetReference(buffer.Span))
                     {
                         EncodeAsciiCharsToBytes(inputSlice, output, writable);
                     }

--- a/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
@@ -91,7 +92,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             var asciiString = new string('\0', span.Length);
 
             fixed (char* output = asciiString)
-            fixed (byte* buffer = &span.DangerousGetPinnableReference())
+            fixed (byte* buffer = &MemoryMarshal.GetReference(span))
             {
                 // This version if AsciiUtilities returns null if there are any null (0 byte) characters
                 // in the string
@@ -136,7 +137,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool GetKnownMethod(this Span<byte> span, out HttpMethod method, out int length)
         {
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+            fixed (byte* data = &MemoryMarshal.GetReference(span))
             {
                 method = GetKnownMethod(data, span.Length, out length);
                 return method != HttpMethod.Custom;
@@ -190,7 +191,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool GetKnownVersion(this Span<byte> span, out HttpVersion knownVersion, out byte length)
         {
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+            fixed (byte* data = &MemoryMarshal.GetReference(span))
             {
                 knownVersion = GetKnownVersion(data, span.Length);
                 if (knownVersion != HttpVersion.Unknown)
@@ -249,7 +250,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool GetKnownHttpScheme(this Span<byte> span, out HttpScheme knownScheme)
         {
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+            fixed (byte* data = &MemoryMarshal.GetReference(span))
             {
                 return GetKnownHttpScheme(data, span.Length, out knownScheme);
             }


### PR DESCRIPTION
See https://github.com/dotnet/corefx/issues/25412#issuecomment-352176634

**Depends on a package update to aspnet/Universe to go through** - https://github.com/aspnet/Universe/pull/717

> /home/travis/build/aspnet/KestrelHttpServer/benchmarks/Kestrel.Performance/Kestrel.Performance.csproj : error NU1102: Unable to find package System.Security.Cryptography.Cng with version (>= 4.5.0-preview1-26016-05) [/home/travis/build/aspnet/KestrelHttpServer/KestrelHttpServer.sln]

- SignalR doesn't use DangerousGetPinnableReference or DangerousTryGetArray (these APIs will be removed/changed).
- Kestrel doesn't use DangerousTryGetArray
- I couldn't find any other aspnet repo that relied on these two APIs.

cc @pakrym, @davidfowl, @BrennanConroy, @KrzysztofCwalina, @natemcmaster, @jkotas, @joshfree