### PR TITLE
Use localhost dev cert in sample

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -102,7 +102,7 @@ namespace SampleApp
 
                     options.ListenAnyIP(basePort + 4, listenOptions =>
                     {
-                        listenOptions.UseHttps(StoreName.My, "aspnet.test", allowInvalid: true);
+                        listenOptions.UseHttps(StoreName.My, "localhost", allowInvalid: true);
                     });
 
                     options

--- a/samples/SampleApp/appsettings.Development.json
+++ b/samples/SampleApp/appsettings.Development.json
@@ -5,9 +5,9 @@
       "NamedHttpsEndpoint": {
         "Url": "https://localhost:6443",
         "Certificate": {
-          "Subject": "aspnet.test",
+          "Subject": "localhost",
           "Store": "My",
-          "AllowInvalid":  true
+          "AllowInvalid": true
         }
       }
     }


### PR DESCRIPTION
The localhost dev cert should be present for anybody using the new tooling. The aspnet.test cert is only installed by some functional tests.