### PR TITLE
DO NOT MERGE - open PR to track changes

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
             try
             {
-                connectionHandler.OnConnection(this);
+                connectionHandler?.OnConnection(this);
 
                 // Spawn send and receive logic
                 Task receiveTask = DoReceive();

--- a/src/Kestrel.Transport.Sockets/Internal/SocketsTrace.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketsTrace.cs
@@ -89,5 +89,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
             => _logger.Log(logLevel, eventId, state, exception, formatter);
+
+        public static ISocketsTrace Nil => NilTrace.Default;
+
+        private sealed class NilTrace : ISocketsTrace
+        {
+            public static readonly ISocketsTrace Default = new NilTrace();
+            private NilTrace() { }
+
+            IDisposable ILogger.BeginScope<TState>(TState state) => null;
+
+            void ISocketsTrace.ConnectionError(string connectionId, Exception ex) { }
+
+            void ISocketsTrace.ConnectionPause(string connectionId) { }
+
+            void ISocketsTrace.ConnectionReadFin(string connectionId) { }
+
+            void ISocketsTrace.ConnectionReset(string connectionId) { }
+
+            void ISocketsTrace.ConnectionResume(string connectionId) { }
+
+            void ISocketsTrace.ConnectionWriteFin(string connectionId) { }
+
+            bool ILogger.IsEnabled(LogLevel logLevel) => false;
+
+            void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) { }
+        }
     }
 }

--- a/src/Kestrel.Transport.Sockets/SocketTransportFactory.cs
+++ b/src/Kestrel.Transport.Sockets/SocketTransportFactory.cs
@@ -2,11 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net;
+using System.Buffers;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Hosting;
+using System.Threading.Tasks;
+using System.Net.Sockets;
+using System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
@@ -56,6 +61,53 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             }
 
             return new SocketTransport(endPointInformation, handler, _appLifetime, _trace);
+        }
+
+        public static Task<IPipeConnection> ConnectAsync(EndPoint endpoint, MemoryPool memoryPool)
+        {
+            var args = new SocketAsyncEventArgs();
+            args.RemoteEndPoint = endpoint;
+            args.Completed += (sender, p) => OnConnect(p);
+            var tcs = new TaskCompletionSource<IPipeConnection>(memoryPool);
+            args.UserToken = tcs;
+            if (!Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args))
+            {
+                OnConnect(args); // completed sync - usually means failure
+            }
+            return tcs.Task;
+        }
+
+        private static void OnConnect(SocketAsyncEventArgs e)
+        {
+            var tcs = (TaskCompletionSource<IPipeConnection>)e.UserToken;
+            try
+            {
+                if (e.SocketError == SocketError.Success)
+                {
+                    e.ConnectSocket.NoDelay = true;
+                    var connection = new SocketConnection(e.ConnectSocket, (MemoryPool)tcs.Task.AsyncState, SocketsTrace.Nil);
+
+                    //var options = new PipeOptions(connection.MemoryPool);
+
+                    //var receivePipe = new Pipe(options);
+                    //var sendPipe = new Pipe(options);
+
+                    //var pipe = new PipeConnection(receivePipe.Reader, sendPipe.Writer);
+                    var pair = PipeFactory.CreateConnectionPair(connection.MemoryPool);
+                    connection.Transport = pair.Transport;
+                    connection.Application = pair.Application;
+                    _ = connection.StartAsync(null);
+                    tcs.TrySetResult(connection.Transport);
+                }
+                else
+                {
+                    tcs.TrySetException(new SocketException((int)e.SocketError));
+                }
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+            }
         }
     }
 }

--- a/src/Protocols.Abstractions/PipeFactoryExtensions.cs
+++ b/src/Protocols.Abstractions/PipeFactoryExtensions.cs
@@ -6,7 +6,8 @@ namespace System.IO.Pipelines
     {
         public static (IPipeConnection Transport, IPipeConnection Application) CreateConnectionPair(MemoryPool memoryPool)
         {
-            return CreateConnectionPair(new PipeOptions(memoryPool), new PipeOptions(memoryPool));
+            var options = new PipeOptions(memoryPool);
+            return CreateConnectionPair(options, options);
         }
 
         public static (IPipeConnection Transport, IPipeConnection Application) CreateConnectionPair(PipeOptions inputOptions, PipeOptions outputOptions)


### PR DESCRIPTION
intent: make the kestrel transport usable from client scenarios