### PR TITLE
Hide the Http2 opt-in option.

### DIFF
--- a/samples/Http2SampleApp/Program.cs
+++ b/samples/Http2SampleApp/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -13,6 +14,9 @@ namespace Http2SampleApp
     {
         public static void Main(string[] args)
         {
+            // AppContext.SetSwitch("Switch.Microsoft.AspNetCore.Server.Kestrel.Experiential.Http2", isEnabled: true);
+            AppContext.SetSwitch("Switch.Microsoft.AspNetCore.Server.Kestrel.Experiential.Http1AndHttp2", isEnabled: true);
+
             var hostBuilder = new WebHostBuilder()
                 .ConfigureLogging((_, factory) =>
                 {
@@ -29,7 +33,7 @@ namespace Http2SampleApp
 
                     options.Listen(IPAddress.Any, basePort, listenOptions =>
                     {
-                        listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                        // listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
                         listenOptions.UseHttps("testCert.pfx", "testPassword");
                         listenOptions.UseConnectionLogging();
                     });

--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -67,7 +67,7 @@ namespace SampleApp
 
                     options.ConfigureEndpointDefaults(opt =>
                     {
-                        opt.Protocols = HttpProtocols.Http1;
+                        // opt.Protocols = HttpProtocols.Http1;
                     });
 
                     options.ConfigureHttpsDefaults(httpsOptions =>
@@ -115,7 +115,7 @@ namespace SampleApp
                         .Configure(context.Configuration.GetSection("Kestrel"))
                         .Endpoint("NamedEndpoint", opt =>
                         {
-                            opt.ListenOptions.Protocols = HttpProtocols.Http1;
+                            // opt.ListenOptions.Protocols = HttpProtocols.Http1;
                         })
                         .Endpoint("NamedHttpsEndpoint", opt =>
                         {

--- a/src/Kestrel.Core/ListenOptions.cs
+++ b/src/Kestrel.Core/ListenOptions.cs
@@ -19,6 +19,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
     /// </summary>
     public class ListenOptions : IEndPointInformation, IConnectionBuilder
     {
+        private const string Http2ExperimentSwitch = "Switch.Microsoft.AspNetCore.Server.Kestrel.Experiential.Http2";
+        private const string Http1AndHttp2ExperimentSwitch = "Switch.Microsoft.AspNetCore.Server.Kestrel.Experiential.Http1AndHttp2";
+
         private FileHandleType _handleType;
         private readonly List<Func<ConnectionDelegate, ConnectionDelegate>> _components = new List<Func<ConnectionDelegate, ConnectionDelegate>>();
 
@@ -26,6 +29,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         {
             Type = ListenType.IPEndPoint;
             IPEndPoint = endPoint;
+
+            if (AppContext.TryGetSwitch(Http1AndHttp2ExperimentSwitch, out var isEnabled))
+            {
+                Protocols = HttpProtocols.Http1AndHttp2;
+            }
+            else if (AppContext.TryGetSwitch(Http2ExperimentSwitch, out isEnabled))
+            {
+                Protocols = HttpProtocols.Http2;
+            }
         }
 
         internal ListenOptions(string socketPath)
@@ -123,7 +135,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// The protocols enabled on this endpoint.
         /// </summary>
         /// <remarks>Defaults to HTTP/1.x only.</remarks>
-        public HttpProtocols Protocols { get; set; } = HttpProtocols.Http1;
+        internal HttpProtocols Protocols { get; set; } = HttpProtocols.Http1;
 
         /// <summary>
         /// Gets the <see cref="List{IConnectionAdapter}"/> that allows each connection <see cref="System.IO.Stream"/>


### PR DESCRIPTION
The Http/2 implementation is not yet ready for consumption. Hide the setting as to not confuse users. I've added a hidden switch advanced users can use for targeted testing.