### PR TITLE
Fixed race in sockets transport

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -57,6 +57,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public async Task StartAsync(IConnectionHandler connectionHandler)
         {
+            Exception error = null;
             try
             {
                 connectionHandler.OnConnection(this);
@@ -76,17 +77,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
                 // Now wait for both to complete
                 await receiveTask;
-                var error = await sendTask;
+                error = await sendTask;
 
                 // Dispose the socket(should noop if already called)
                 _socket.Dispose();
-
-                // Complete the output after disposing the socket
-                Output.Complete(error);
             }
             catch (Exception ex)
             {
                 _trace.LogError(0, ex, $"Unexpected exception in {nameof(SocketConnection)}.{nameof(StartAsync)}.");
+            }
+            finally
+            {
+                // Complete the output after disposing the socket
+                Output.Complete(error);
             }
         }
 

--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public async Task StartAsync(IConnectionHandler connectionHandler)
         {
-            Exception error = null;
+            Exception sendError = null;
             try
             {
                 connectionHandler.OnConnection(this);
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
                 // Now wait for both to complete
                 await receiveTask;
-                error = await sendTask;
+                sendError = await sendTask;
 
                 // Dispose the socket(should noop if already called)
                 _socket.Dispose();
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             finally
             {
                 // Complete the output after disposing the socket
-                Output.Complete(error);
+                Output.Complete(sendError);
             }
         }
 


### PR DESCRIPTION
Testing a theory.

@halter73 I can't seem to reproduce the error with sockets alone but my guess is that we're still shutting down to early. Based on the changes you made earlier (https://github.com/aspnet/KestrelHttpServer/commit/f4d27e67bbe770b0290f1a08c2e3401bae8686f0), we trigger OnConnectionClosed before the socket is disposed in the SocketTransport. This moves the call to Output.Complete to happen after and thus fixes the race.

I don't like returning the exception but it's the cleanest thing I can think of to not expose all of the exception handling to the caller. I'll see if we can make it a bit cleaner. 

