### PR TITLE
Avoid long path 

### DIFF
--- a/test/Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Kestrel.FunctionalTests/ResponseTests.cs
@@ -2495,10 +2495,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public void ConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate()
         {
-            using (StartLog(out var loggerFactory))
+            using (StartLog(out var loggerFactory, "ConnClosedWhenRespDoesNotSatisfyMin"))
             {
-                var logger = loggerFactory.CreateLogger($"{typeof(ResponseTests).FullName}.{nameof(ConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate)}");
-
+                var logger = loggerFactory.CreateLogger($"{ typeof(ResponseTests).FullName}.{ nameof(ConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate)}");
                 var chunkSize = 64 * 1024;
                 var chunks = 128;
                 var responseSize = chunks * chunkSize;


### PR DESCRIPTION
This test fails on the CI due to long path like [this](http://aspnetci/viewLog.html?buildId=399124&tab=buildResultsDiv&buildTypeId=Lite_KestrelStressTest). Let's shorten the name so that it doesn't.