### PR TITLE
Use enum for method rather than string compares

### DIFF
--- a/src/Kestrel.Core/BadHttpRequestException.cs
+++ b/src/Kestrel.Core/BadHttpRequestException.cs
@@ -38,6 +38,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             throw GetException(reason);
         }
 
+        [StackTraceHidden]
+        public static void Throw(RequestRejectionReason reason, HttpMethod method)
+            => throw GetException(reason, method.ToString().ToUpperInvariant());
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal static BadHttpRequestException GetException(RequestRejectionReason reason)
         {

--- a/src/Kestrel.Core/Internal/Http/Http1Connection.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1Connection.cs
@@ -181,13 +181,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 OnAuthorityFormTarget(method, target);
             }
 
-            Method = method != HttpMethod.Custom
-                ? HttpUtilities.MethodToString(method) ?? string.Empty
-                : customMethod.GetAsciiStringNonNullCharacters();
+            Method = method;
+            if (method == HttpMethod.Custom)
+            {
+                _methodText = customMethod.GetAsciiStringNonNullCharacters();
+            }
+
             _httpVersion = version;
 
             Debug.Assert(RawTarget != null, "RawTarget was not set");
-            Debug.Assert(Method != null, "Method was not set");
+            Debug.Assert(((IHttpRequestFeature)this).Method != null, "Method was not set");
             Debug.Assert(Path != null, "Path was not set");
             Debug.Assert(QueryString != null, "QueryString was not set");
             Debug.Assert(HttpVersion != null, "HttpVersion was not set");

--- a/src/Kestrel.Core/Internal/Http/Http1MessageBody.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1MessageBody.cs
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 // If we got here, request contains no Content-Length or Transfer-Encoding header.
                 // Reject with 411 Length Required.
-                if (HttpMethods.IsPost(context.Method) || HttpMethods.IsPut(context.Method))
+                if (context.Method == HttpMethod.Post || context.Method == HttpMethod.Put)
                 {
                     var requestRejectionReason = httpVersion == HttpVersion.Http11 ? RequestRejectionReason.LengthRequired : RequestRejectionReason.LengthRequiredHttp10;
                     BadHttpRequestException.Throw(requestRejectionReason, context.Method);

--- a/src/Kestrel.Core/Internal/Http/HttpMethod.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpMethod.cs
@@ -16,5 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         Options,
 
         Custom,
+
+        None = byte.MaxValue,
     }
 }

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
@@ -89,8 +90,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         string IHttpRequestFeature.Method
         {
-            get => Method;
-            set => Method = value;
+            get
+            {
+                if (_methodText != null)
+                {
+                    return _methodText;
+                }
+
+                _methodText = HttpUtilities.MethodToString(Method) ?? string.Empty;
+                return _methodText;
+            }
+            set
+            {
+                Method = HttpUtilities.GetKnownMethod(value);
+                _methodText = value;
+            }
         }
 
         string IHttpRequestFeature.PathBase

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -102,7 +102,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                Method = HttpUtilities.GetKnownMethod(value);
                 _methodText = value;
             }
         }

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
@@ -53,7 +54,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // We don't need any of the parameters because we don't implement BeginRead to actually
             // do the reading from a pipeline, nor do we use endConnection to report connection-level errors.
 
-            Method = RequestHeaders[":method"];
+            var methodText = RequestHeaders[":method"];
+            Method = HttpUtilities.GetKnownMethod(methodText);
+            _methodText = methodText;
+
             Scheme = RequestHeaders[":scheme"];
             _httpVersion = Http.HttpVersion.Http2;
 

--- a/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         /// <returns><see cref="HttpMethod"/></returns>
         public static HttpMethod GetKnownMethod(string value)
         {
-            // Called by http/2 and if user code overrides and sets the Method on IHttpRequestFeature
+            // Called by http/2
             if (value == null)
             {
                 throw new ArgumentNullException(nameof(value));

--- a/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
@@ -175,6 +176,87 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
 
             return HttpMethod.Custom;
+        }
+
+        /// <summary>
+        /// Parses string <paramref name="value"/> for a known HTTP method.
+        /// </summary>
+        /// <remarks>
+        /// A "known HTTP method" can be an HTTP method name defined in the HTTP/1.1 RFC.
+        /// The Known Methods (CONNECT, DELETE, GET, HEAD, PATCH, POST, PUT, OPTIONS, TRACE)
+        /// </remarks>
+        /// <returns><see cref="HttpMethod"/></returns>
+        public static HttpMethod GetKnownMethod(string value)
+        {
+            // Called by http/2 and if user code overrides and sets the Method on IHttpRequestFeature
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var length = value.Length;
+            if (length == 0)
+            {
+                throw new ArgumentException(nameof(value));
+            }
+
+            // Start with custom and assign if known method is found
+            var method = HttpMethod.Custom;
+
+            var firstChar = value[0];
+            if (length == 3)
+            {
+                if (firstChar == 'G' && string.Equals(value, HttpMethods.Get, StringComparison.Ordinal))
+                {
+                    method = HttpMethod.Get;
+                }
+                else if (firstChar == 'P' && string.Equals(value, HttpMethods.Put, StringComparison.Ordinal))
+                {
+                    method = HttpMethod.Put;
+                }
+            }
+            else if (length == 4)
+            {
+                if (firstChar == 'H' && string.Equals(value, HttpMethods.Head, StringComparison.Ordinal))
+                {
+                    method = HttpMethod.Head;
+                }
+                else if(firstChar == 'P' && string.Equals(value, HttpMethods.Post, StringComparison.Ordinal))
+                {
+                    method = HttpMethod.Post;
+                }
+            }
+            else if (length == 5)
+            {
+                if (firstChar == 'T' && string.Equals(value, HttpMethods.Trace, StringComparison.Ordinal))
+                {
+                    method = HttpMethod.Trace;
+                }
+                else if(firstChar == 'P' && string.Equals(value, HttpMethods.Patch, StringComparison.Ordinal))
+                {
+                    method = HttpMethod.Patch;
+                }
+            }
+            else if (length == 6)
+            {
+                if (firstChar == 'D' && string.Equals(value, HttpMethods.Delete, StringComparison.Ordinal))
+                {
+                    method = HttpMethod.Delete;
+                }
+            }
+            else if (length == 7)
+            {
+                if (firstChar == 'C' && string.Equals(value, HttpMethods.Connect, StringComparison.Ordinal))
+                {
+                    method = HttpMethod.Connect;
+                }
+                else if (firstChar == 'O' && string.Equals(value, HttpMethods.Options, StringComparison.Ordinal))
+                {
+                    method = HttpMethod.Options;
+                }
+            }
+
+            return method;
         }
 
         /// <summary>

--- a/test/Kestrel.Core.Tests/Http1ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http1ConnectionTests.cs
@@ -344,7 +344,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _transport.Input.AdvanceTo(_consumed, _examined);
 
             Assert.True(returnValue);
-            Assert.Equal(expectedMethod, _http1Connection.Method);
+            Assert.Equal(expectedMethod, ((IHttpRequestFeature)_http1Connection).Method);
             Assert.Equal(expectedRawTarget, _http1Connection.RawTarget);
             Assert.Equal(expectedDecodedPath, _http1Connection.Path);
             Assert.Equal(expectedQueryString, _http1Connection.QueryString);
@@ -490,6 +490,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(405, exception.StatusCode);
             Assert.Equal(CoreStrings.BadRequest_MethodNotAllowed, exception.Message);
             Assert.Equal(HttpUtilities.MethodToString(allowedMethod), exception.AllowedHeader);
+        }
+
+        [Theory]
+        [InlineData("g", HttpMethod.Custom, "g")]
+        [InlineData("G", HttpMethod.Custom, "G")]
+        [InlineData("get", HttpMethod.Custom, "get")]
+        [InlineData("GET", HttpMethod.Get, "GET")]
+        [InlineData("put", HttpMethod.Custom, "put")]
+        [InlineData("PUT", HttpMethod.Put, "PUT")]
+        [InlineData("post", HttpMethod.Custom, "post")]
+        [InlineData("POST", HttpMethod.Post, "POST")]
+        [InlineData("head", HttpMethod.Custom, "head")]
+        [InlineData("HEAD", HttpMethod.Head, "HEAD")]
+        [InlineData("patch", HttpMethod.Custom, "patch")]
+        [InlineData("PATCH", HttpMethod.Patch, "PATCH")]
+        [InlineData("trace", HttpMethod.Custom, "trace")]
+        [InlineData("TRACE", HttpMethod.Trace, "TRACE")]
+        [InlineData("delete", HttpMethod.Custom, "delete")]
+        [InlineData("DELETE", HttpMethod.Delete, "DELETE")]
+        [InlineData("options", HttpMethod.Custom, "options")]
+        [InlineData("OPTIONS", HttpMethod.Options, "OPTIONS")]
+        [InlineData("connect", HttpMethod.Custom, "connect")]
+        [InlineData("CONNECT", HttpMethod.Connect, "CONNECT")]
+        [InlineData("unknown", HttpMethod.Custom, "unknown")]
+        [InlineData("UNKNOWN", HttpMethod.Custom, "UNKNOWN")]
+        public void RequestFeatureMethodSetsFrameEnum(string method, HttpMethod expectedEnum, string expectedString)
+        {
+            using (var input = new TestInput())
+            {
+                ((IHttpRequestFeature)input.Http1Connection).Method = method;
+
+                Assert.Equal(expectedEnum, input.Http1Connection.Method);
+                Assert.Equal(expectedString, ((IHttpRequestFeature)input.Http1Connection).Method);
+            }
         }
 
         [Fact]

--- a/test/Kestrel.Core.Tests/Http1ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http1ConnectionTests.cs
@@ -492,40 +492,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(HttpUtilities.MethodToString(allowedMethod), exception.AllowedHeader);
         }
 
-        [Theory]
-        [InlineData("g", HttpMethod.Custom, "g")]
-        [InlineData("G", HttpMethod.Custom, "G")]
-        [InlineData("get", HttpMethod.Custom, "get")]
-        [InlineData("GET", HttpMethod.Get, "GET")]
-        [InlineData("put", HttpMethod.Custom, "put")]
-        [InlineData("PUT", HttpMethod.Put, "PUT")]
-        [InlineData("post", HttpMethod.Custom, "post")]
-        [InlineData("POST", HttpMethod.Post, "POST")]
-        [InlineData("head", HttpMethod.Custom, "head")]
-        [InlineData("HEAD", HttpMethod.Head, "HEAD")]
-        [InlineData("patch", HttpMethod.Custom, "patch")]
-        [InlineData("PATCH", HttpMethod.Patch, "PATCH")]
-        [InlineData("trace", HttpMethod.Custom, "trace")]
-        [InlineData("TRACE", HttpMethod.Trace, "TRACE")]
-        [InlineData("delete", HttpMethod.Custom, "delete")]
-        [InlineData("DELETE", HttpMethod.Delete, "DELETE")]
-        [InlineData("options", HttpMethod.Custom, "options")]
-        [InlineData("OPTIONS", HttpMethod.Options, "OPTIONS")]
-        [InlineData("connect", HttpMethod.Custom, "connect")]
-        [InlineData("CONNECT", HttpMethod.Connect, "CONNECT")]
-        [InlineData("unknown", HttpMethod.Custom, "unknown")]
-        [InlineData("UNKNOWN", HttpMethod.Custom, "UNKNOWN")]
-        public void RequestFeatureMethodSetsFrameEnum(string method, HttpMethod expectedEnum, string expectedString)
-        {
-            using (var input = new TestInput())
-            {
-                ((IHttpRequestFeature)input.Http1Connection).Method = method;
-
-                Assert.Equal(expectedEnum, input.Http1Connection.Method);
-                Assert.Equal(expectedString, ((IHttpRequestFeature)input.Http1Connection).Method);
-            }
-        }
-
         [Fact]
         public void ProcessRequestsAsyncEnablesKeepAliveTimeout()
         {
@@ -566,7 +532,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             // Arrange
             _http1Connection.HttpVersion = "HTTP/1.1";
-            ((IHttpRequestFeature)_http1Connection).Method = "HEAD";
+            _http1Connection.Method = HttpMethod.Head;
 
             // Act/Assert
             await _http1Connection.WriteAsync(new ArraySegment<byte>(new byte[1]));
@@ -577,7 +543,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             // Arrange
             _http1Connection.HttpVersion = "HTTP/1.1";
-            ((IHttpRequestFeature)_http1Connection).Method = "HEAD";
+            _http1Connection.Method = HttpMethod.Head;
 
             // Act/Assert
             await _http1Connection.WriteAsync(new ArraySegment<byte>(new byte[1]), default(CancellationToken));
@@ -588,7 +554,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             // Arrange
             _http1Connection.HttpVersion = "HTTP/1.1";
-            ((IHttpRequestFeature)_http1Connection).Method = "HEAD";
+            _http1Connection.Method = HttpMethod.Head;
 
             // Act
             _http1Connection.ResponseHeaders.Add("Transfer-Encoding", "chunked");

--- a/test/Kestrel.Core.Tests/MessageBodyTests.cs
+++ b/test/Kestrel.Core.Tests/MessageBodyTests.cs
@@ -333,34 +333,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Theory]
-        [InlineData("POST")]
-        [InlineData("PUT")]
-        public void ForThrowsWhenMethodRequiresLengthButNoContentLengthOrTransferEncodingIsSet(string method)
+        [InlineData(HttpMethod.Post)]
+        [InlineData(HttpMethod.Put)]
+        public void ForThrowsWhenMethodRequiresLengthButNoContentLengthOrTransferEncodingIsSet(HttpMethod method)
         {
             using (var input = new TestInput())
             {
-                ((IHttpRequestFeature)input.Http1Connection).Method = method;
+                input.Http1Connection.Method = method;
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
                     Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(), input.Http1Connection));
 
                 Assert.Equal(StatusCodes.Status411LengthRequired, ex.StatusCode);
-                Assert.Equal(CoreStrings.FormatBadRequest_LengthRequired(method), ex.Message);
+                Assert.Equal(CoreStrings.FormatBadRequest_LengthRequired(((IHttpRequestFeature)input.Http1Connection).Method), ex.Message);
             }
         }
 
         [Theory]
-        [InlineData("POST")]
-        [InlineData("PUT")]
-        public void ForThrowsWhenMethodRequiresLengthButNoContentLengthSetHttp10(string method)
+        [InlineData(HttpMethod.Post)]
+        [InlineData(HttpMethod.Put)]
+        public void ForThrowsWhenMethodRequiresLengthButNoContentLengthSetHttp10(HttpMethod method)
         {
             using (var input = new TestInput())
             {
-                ((IHttpRequestFeature)input.Http1Connection).Method = method;
+                input.Http1Connection.Method = method;
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
                     Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders(), input.Http1Connection));
 
                 Assert.Equal(StatusCodes.Status400BadRequest, ex.StatusCode);
-                Assert.Equal(CoreStrings.FormatBadRequest_LengthRequiredHttp10(method), ex.Message);
+                Assert.Equal(CoreStrings.FormatBadRequest_LengthRequiredHttp10(((IHttpRequestFeature)input.Http1Connection).Method), ex.Message);
             }
         }
 

--- a/test/Kestrel.Core.Tests/MessageBodyTests.cs
+++ b/test/Kestrel.Core.Tests/MessageBodyTests.cs
@@ -339,7 +339,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                input.Http1Connection.Method = method;
+                ((IHttpRequestFeature)input.Http1Connection).Method = method;
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
                     Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(), input.Http1Connection));
 
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             using (var input = new TestInput())
             {
-                input.Http1Connection.Method = method;
+                ((IHttpRequestFeature)input.Http1Connection).Method = method;
                 var ex = Assert.Throws<BadHttpRequestException>(() =>
                     Http1MessageBody.For(HttpVersion.Http10, new HttpRequestHeaders(), input.Http1Connection));
 


### PR DESCRIPTION
For GET method `IsHead` test is performed on the string `Method` which since `GET` isn't reference equal to `HEAD` drops through to `String.Equals` -> `OrdinalIgnoreCaseComparer.Equals`

![](https://aoa.blob.core.windows.net/aspnet/ishead.png)

However the Parser starts with it as an Enum, which then gets converted to a string; so it can just be tested with the enum.

Rebased https://github.com/aspnet/KestrelHttpServer/pull/2027

Resolves: https://github.com/aspnet/KestrelHttpServer/issues/2020