### PR TITLE
Removed automatic Upgrade header logic from UpgradeAsync (#2086).

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Http1Connection.FeatureCollection.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1Connection.FeatureCollection.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
@@ -39,16 +38,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             StatusCode = StatusCodes.Status101SwitchingProtocols;
             ReasonPhrase = "Switching Protocols";
-            ResponseHeaders["Connection"] = "Upgrade";
-            if (!ResponseHeaders.ContainsKey("Upgrade"))
-            {
-                StringValues values;
-                if (RequestHeaders.TryGetValue("Upgrade", out values))
-                {
-                    ResponseHeaders["Upgrade"] = values;
-                }
-            }
-
+            
             await FlushAsync(default(CancellationToken));
 
             return _streams.Upgrade();


### PR DESCRIPTION
Fixes #2086.