### PR TITLE
Add clearer exception message to HttpResponseStream ODE

### DIFF
--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -500,7 +500,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http2NotSupported" xml:space="preserve">
     <value>HTTP/2 support is experimental, see https://go.microsoft.com/fwlink/?linkid=866785 to enable it.</value>
   </data>
-  <data name="WritingToResponseAfterResponseEnded" xml:space="preserve">
-    <value>Cannot write to the response because the response has ended.</value>
+  <data name="WritingToResponseBodyAfterResponseCompleted" xml:space="preserve">
+    <value>Cannot write to the response body, the response has completed.</value>
   </data>
 </root>

--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -500,4 +500,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http2NotSupported" xml:space="preserve">
     <value>HTTP/2 support is experimental, see https://go.microsoft.com/fwlink/?linkid=866785 to enable it.</value>
   </data>
+  <data name="WritingToResponseAfterResponseEnded" xml:space="preserve">
+    <value>Cannot write to the response because the response has ended.</value>
+  </data>
 </root>

--- a/src/Kestrel.Core/Internal/Http/HttpResponseStream.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpResponseStream.cs
@@ -158,8 +158,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     break;
                 case HttpStreamState.Closed:
-                    throw new ObjectDisposedException(nameof(HttpResponseStream));
-                case HttpStreamState.Aborted:
+					throw new ObjectDisposedException(nameof(HttpResponseStream), CoreStrings.WritingToResponseAfterResponseEnded);
+				case HttpStreamState.Aborted:
                     if (cancellationToken.IsCancellationRequested)
                     {
                         // Aborted state only throws on write if cancellationToken requests it

--- a/src/Kestrel.Core/Internal/Http/HttpResponseStream.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpResponseStream.cs
@@ -158,8 +158,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     break;
                 case HttpStreamState.Closed:
-					throw new ObjectDisposedException(nameof(HttpResponseStream), CoreStrings.WritingToResponseAfterResponseEnded);
-				case HttpStreamState.Aborted:
+                    throw new ObjectDisposedException(nameof(HttpResponseStream), CoreStrings.WritingToResponseBodyAfterResponseCompleted);
+                case HttpStreamState.Aborted:
                     if (cancellationToken.IsCancellationRequested)
                     {
                         // Aborted state only throws on write if cancellationToken requests it

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -878,18 +878,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal static string FormatWritingToResponseBodyNotSupported(object statusCode)
             => string.Format(CultureInfo.CurrentCulture, GetString("WritingToResponseBodyNotSupported", "statusCode"), statusCode);
 
-		/// <summary>
-		/// Cannot write to the response because the response has ended.
-		/// </summary>
-		internal static string WritingToResponseAfterResponseEnded
-		{
-			get => GetString("WritingToResponseAfterResponseEnded");
-		}
+        /// <summary>
+        /// Cannot write to the response body, the response has completed.
+        /// </summary>
+        internal static string WritingToResponseBodyAfterResponseCompleted
+        {
+            get => GetString("WritingToResponseBodyAfterResponseCompleted");
+        }
 
-		/// <summary>
-		/// Connection shutdown abnormally.
-		/// </summary>
-		internal static string ConnectionShutdownError
+        /// <summary>
+        /// Connection shutdown abnormally.
+        /// </summary>
+        internal static string ConnectionShutdownError
         {
             get => GetString("ConnectionShutdownError");
         }

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -878,10 +878,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal static string FormatWritingToResponseBodyNotSupported(object statusCode)
             => string.Format(CultureInfo.CurrentCulture, GetString("WritingToResponseBodyNotSupported", "statusCode"), statusCode);
 
-        /// <summary>
-        /// Connection shutdown abnormally.
-        /// </summary>
-        internal static string ConnectionShutdownError
+		/// <summary>
+		/// Cannot write to the response because the response has ended.
+		/// </summary>
+		internal static string WritingToResponseAfterResponseEnded
+		{
+			get => GetString("WritingToResponseAfterResponseEnded");
+		}
+
+		/// <summary>
+		/// Connection shutdown abnormally.
+		/// </summary>
+		internal static string ConnectionShutdownError
         {
             get => GetString("ConnectionShutdownError");
         }

--- a/test/Kestrel.Core.Tests/HttpResponseStreamTests.cs
+++ b/test/Kestrel.Core.Tests/HttpResponseStreamTests.cs
@@ -99,8 +99,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var stream = new HttpResponseStream(Mock.Of<IHttpBodyControlFeature>(), Mock.Of<IHttpResponseControl>());
             stream.StartAcceptingWrites();
             stream.StopAcceptingWrites();
-            Assert.Throws<ObjectDisposedException>(() => { stream.WriteAsync(new byte[1], 0, 1); });
-        }
+			var ex = Assert.Throws<ObjectDisposedException>(() => { stream.WriteAsync(new byte[1], 0, 1); });
+			Assert.Contains(CoreStrings.WritingToResponseAfterResponseEnded, ex.Message);
+		}
 
         [Fact]
         public async Task SynchronousWritesThrowIfDisallowedByIHttpBodyControlFeature()

--- a/test/Kestrel.Core.Tests/HttpResponseStreamTests.cs
+++ b/test/Kestrel.Core.Tests/HttpResponseStreamTests.cs
@@ -99,9 +99,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var stream = new HttpResponseStream(Mock.Of<IHttpBodyControlFeature>(), Mock.Of<IHttpResponseControl>());
             stream.StartAcceptingWrites();
             stream.StopAcceptingWrites();
-			var ex = Assert.Throws<ObjectDisposedException>(() => { stream.WriteAsync(new byte[1], 0, 1); });
-			Assert.Contains(CoreStrings.WritingToResponseAfterResponseEnded, ex.Message);
-		}
+            var ex = Assert.Throws<ObjectDisposedException>(() => { stream.WriteAsync(new byte[1], 0, 1); });
+            Assert.Contains(CoreStrings.WritingToResponseBodyAfterResponseCompleted, ex.Message);
+        }
 
         [Fact]
         public async Task SynchronousWritesThrowIfDisallowedByIHttpBodyControlFeature()


### PR DESCRIPTION
This adds a clearer message to the ObjectDisposedException thrown from HttpResponseStream, when a write is attempted after the HTTP response has ended

fixes #2299 