### PR TITLE
Consumes request before closing connection

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Http1MessageBody.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1MessageBody.cs
@@ -294,6 +294,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 RequestUpgrade = true;
             }
 
+            public override bool IsEmpty => true;
+
             protected override bool Read(ReadOnlyBuffer<byte> readableBuffer, PipeWriter writableBuffer, out SequencePosition consumed, out SequencePosition examined)
             {
                 Copy(readableBuffer, writableBuffer);

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
@@ -533,7 +533,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             await ProduceEnd();
 
                             // ForZeroContentLength does not complete the reader nor the writer
-                            if (!messageBody.IsEmpty && _keepAlive)
+                            if (!messageBody.IsEmpty)
                             {
                                 // Finish reading the request body in case the app did not.
                                 await messageBody.ConsumeAsync();

--- a/test/shared/TestHttp1Connection.cs
+++ b/test/shared/TestHttp1Connection.cs
@@ -25,9 +25,16 @@ namespace Microsoft.AspNetCore.Testing
             set => _keepAlive = value;
         }
 
+        public MessageBody NextMessageBody { private get; set; }
+
         public Task ProduceEndAsync()
         {
             return ProduceEnd();
+        }
+
+        protected override MessageBody CreateMessageBody()
+        {
+            return NextMessageBody ?? base.CreateMessageBody();
         }
     }
 }


### PR DESCRIPTION
Hi,
first time contributor here, I'm trying to work on #2276.

I've spent quite a bit of time on this but I can't see any better way to write a test. Any suggestion?

I've also marked the Upgrade message body as empty, as there is no message to be consumed in an Upgrade request.
