### PR TITLE
#2035 Do not await OnCompleted handlers before sending the Response

### DIFF
--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
@@ -737,10 +737,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 return Task.CompletedTask;
             }
-            else
-            {
-                return FireOnCompletedAwaited(onCompleted);
-            }
+            return FireOnCompletedAwaited(onCompleted);
         }
 
         private async Task FireOnCompletedAwaited(Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
@@ -552,11 +552,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 PauseStreams();
 
-                if (_onCompleted != null)
-                {
-                    await FireOnCompleted();
-                }
-
                 if (badRequestException == null)
                 {
                     // If _requestAbort is set, the connection has already been closed.
@@ -597,6 +592,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         // meaningful status code to log.
                         StatusCode = 0;
                     }
+                }
+
+                if (_onCompleted != null)
+                {
+                    await FireOnCompleted();
                 }
 
                 if (badRequestException != null)

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
@@ -737,6 +737,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 return Task.CompletedTask;
             }
+
             return FireOnCompletedAwaited(onCompleted);
         }
 

--- a/test/Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Kestrel.FunctionalTests/ResponseTests.cs
@@ -332,8 +332,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task OnCompletedShouldNotBlockAResponse()
         {
-            var cancel = new CancellationTokenSource();
-            var delay = Task.Delay(TimeSpan.FromMinutes(1), cancel.Token);
+            var delay = Task.Delay(TimeSpan.FromSeconds(20));
             var hostBuilder = TransportSelector.GetWebHostBuilder()
                 .UseKestrel()
                 .UseUrls("http://127.0.0.1:0/")
@@ -356,11 +355,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 using (var client = new HttpClient())
                 {
                     var response = await client.GetAsync($"http://127.0.0.1:{host.GetPort()}/");
-
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                    var isCompleted = delay.IsCompleted;
-                    cancel.Cancel();
-                    Assert.False(isCompleted);
+                    Assert.False(delay.IsCompleted);
                 }
             }
         }


### PR DESCRIPTION
We no longer await OnCompleted handlers running as part of the Response. This required some minor modifications to existing tests, adding two new tests and changing the intent of one test ThrowingInOnCompletedIsLoggedAndClosesConnection -> ThrowingInOnCompletedIsLogged. Look forward to some feedback 😄 