### PR TITLE
Removed automatic Upgrade header logic from UpgradeAsync to fix issue 2086

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Http1Connection.FeatureCollection.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1Connection.FeatureCollection.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
@@ -40,14 +39,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             StatusCode = StatusCodes.Status101SwitchingProtocols;
             ReasonPhrase = "Switching Protocols";
             ResponseHeaders["Connection"] = "Upgrade";
-            if (!ResponseHeaders.ContainsKey("Upgrade"))
-            {
-                StringValues values;
-                if (RequestHeaders.TryGetValue("Upgrade", out values))
-                {
-                    ResponseHeaders["Upgrade"] = values;
-                }
-            }
 
             await FlushAsync(default(CancellationToken));
 


### PR DESCRIPTION
Removed automatic Upgrade header logic from UpgradeAsync to fix issue #2086

- Removed code to set response headers -  connection and upgrade as it should be  set by caller e.g. WebSockets Middleware
- Fixed test cases - as connection would be set to "close" instead of "upgrade" after removing headers