### PR TITLE
Use ReferenceEquals not MulticastDelegate.equals

### DIFF
--- a/src/Kestrel.Transport.Libuv/Internal/LibuvAwaitable.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/LibuvAwaitable.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
         };
 
         public LibuvAwaitable<TRequest> GetAwaiter() => this;
-        public bool IsCompleted => _callback == _callbackCompleted;
+        public bool IsCompleted => ReferenceEquals(_callback, _callbackCompleted);
 
         public UvWriteResult GetResult()
         {
@@ -54,8 +54,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             // There should never be a race between IsCompleted and OnCompleted since both operations
             // should always be on the libuv thread
 
-            if (_callback == _callbackCompleted ||
-                Interlocked.CompareExchange(ref _callback, continuation, null) == _callbackCompleted)
+            if (ReferenceEquals(_callback, _callbackCompleted) ||
+                ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
             {
                 Debug.Fail($"{typeof(LibuvAwaitable<TRequest>)}.{nameof(OnCompleted)} raced with {nameof(IsCompleted)}, running callback inline.");
 

--- a/src/Kestrel.Transport.Sockets/Internal/SocketAwaitable.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketAwaitable.cs
@@ -18,11 +18,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         private SocketError _error;
 
         public SocketAwaitable GetAwaiter() => this;
-        public bool IsCompleted => _callback == _callbackCompleted;
+        public bool IsCompleted => ReferenceEquals(_callback, _callbackCompleted);
 
         public int GetResult()
         {
-            Debug.Assert(_callback == _callbackCompleted);
+            Debug.Assert(ReferenceEquals(_callback, _callbackCompleted));
 
             _callback = null;
 
@@ -36,8 +36,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public void OnCompleted(Action continuation)
         {
-            if (_callback == _callbackCompleted ||
-                Interlocked.CompareExchange(ref _callback, continuation, null) == _callbackCompleted)
+            if (ReferenceEquals(_callback, _callbackCompleted) ||
+                ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
             {
                 continuation();
             }


### PR DESCRIPTION
It never inlines because its chunky equals method 
[MulticastDelegate.cs#L57-L132](https://github.com/dotnet/coreclr/blob/df5a0272078d3102a9e1f84c1b46af3b128b7012/src/mscorlib/src/System/MulticastDelegate.cs#L57-L132)
