### PR TITLE
Remove check for above debug logs

### DIFF
--- a/test/Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Kestrel.FunctionalTests/RequestTests.cs
@@ -269,7 +269,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             var connectionStarted = new SemaphoreSlim(0);
             var connectionReset = new SemaphoreSlim(0);
-            var loggedHigherThanDebug = false;
 
             var mockLogger = new Mock<ILogger>();
             mockLogger
@@ -286,11 +285,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     else if (eventId.Id == _connectionResetEventId)
                     {
                         connectionReset.Release();
-                    }
-
-                    if (logLevel > LogLevel.Debug)
-                    {
-                        loggedHigherThanDebug = true;
                     }
                 });
 
@@ -321,15 +315,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 // and therefore not logged.
                 Assert.True(await connectionReset.WaitAsync(TestConstants.DefaultTimeout));
             }
-
-            Assert.False(loggedHigherThanDebug);
         }
 
         [Fact]
         public async Task ConnectionResetBetweenRequestsIsLoggedAsDebug()
         {
             var connectionReset = new SemaphoreSlim(0);
-            var loggedHigherThanDebug = false;
 
             var mockLogger = new Mock<ILogger>();
             mockLogger
@@ -342,11 +333,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     if (eventId.Id == _connectionResetEventId)
                     {
                         connectionReset.Release();
-                    }
-
-                    if (logLevel > LogLevel.Debug)
-                    {
-                        loggedHigherThanDebug = true;
                     }
                 });
 
@@ -389,8 +375,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 // and therefore not logged.
                 Assert.True(await connectionReset.WaitAsync(TestConstants.DefaultTimeout));
             }
-
-            Assert.False(loggedHigherThanDebug);
         }
 
         [Fact]
@@ -399,7 +383,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var requestStarted = new SemaphoreSlim(0);
             var connectionReset = new SemaphoreSlim(0);
             var connectionClosing = new SemaphoreSlim(0);
-            var loggedHigherThanDebug = false;
 
             var mockLogger = new Mock<ILogger>();
             mockLogger
@@ -414,11 +397,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     if (eventId.Id == _connectionResetEventId)
                     {
                         connectionReset.Release();
-                    }
-
-                    if (logLevel > LogLevel.Debug)
-                    {
-                        loggedHigherThanDebug = true;
                     }
                 });
 
@@ -457,8 +435,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 Assert.True(await connectionReset.WaitAsync(TestConstants.DefaultTimeout), "Connection reset event should have been logged");
                 connectionClosing.Release();
             }
-
-            Assert.False(loggedHigherThanDebug, "Logged event should not have been higher than debug.");
         }
 
         [Fact]


### PR DESCRIPTION
Remove the check for above debug logs. We *do* sometimes log informational messages for these categories and  that isn't an issue. I think these checks were there before we added more transports and more logs.

Here's an example test failure:

```
[xUnit.net 00:01:28.1786400]     ConnectionResetMidRequestIsLoggedAsDebug [FAIL]
[xUnit.net 00:01:28.1804620]       Logged event should not have been higher than debug.
[xUnit.net 00:01:28.1806360]       Expected: False
[xUnit.net 00:01:28.1808340]       Actual:   True
[xUnit.net 00:01:28.1826170]       Stack Trace:
[xUnit.net 00:01:28.1843850]         /_/test/Kestrel.FunctionalTests/RequestTests.cs(461,0): at Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.RequestTests.<ConnectionResetMidRequestIsLoggedAsDebug>d__15.MoveNext()
[xUnit.net 00:01:28.1845330]         --- End of stack trace from previous location where exception was thrown ---
[xUnit.net 00:01:28.1846390]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[xUnit.net 00:01:28.1847490]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[xUnit.net 00:01:28.1848320]         --- End of stack trace from previous location where exception was thrown ---
[xUnit.net 00:01:28.1849260]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[xUnit.net 00:01:28.1850150]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[xUnit.net 00:01:28.1850970]         --- End of stack trace from previous location where exception was thrown ---
[xUnit.net 00:01:28.1852160]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[xUnit.net 00:01:28.1854760]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[xUnit.net 00:01:28.1872260]       Output:
[xUnit.net 00:01:28.1874090]         Debug: Connection id "0HLBM0N2I6612" started.
[xUnit.net 00:01:28.1876530]         Debug: Connection id "0HLBM0N2I6612" reset.
[xUnit.net 00:01:28.1878600]         Debug: Connection id "0HLBM0N2I6612" completed keep alive response.
[xUnit.net 00:01:28.1879980]         Debug: Connection id "0HLBM0N2I6612" disconnecting.
[xUnit.net 00:01:28.1881100]         Information: Connection id "0HLBM0N2I6612" communication error.
[xUnit.net 00:01:28.1882140]         Debug: Connection id "0HLBM0N2I6612" sending FIN.
[xUnit.net 00:01:28.1883190]         Debug: Connection id "0HLBM0N2I6612" stopped.
Failed   ConnectionResetMidRequestIsLoggedAsDebug
Error Message:
 Logged event should not have been higher than debug.
Expected: False
```

Communication error is reported as Information.