### PR TITLE
Updated Streams to override Memory and Span overloads

### DIFF
--- a/src/Kestrel.Core/Adapter/Internal/AdaptedPipeline.cs
+++ b/src/Kestrel.Core/Adapter/Internal/AdaptedPipeline.cs
@@ -79,15 +79,23 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
                         }
                         else if (buffer.IsSingleSegment)
                         {
+#if NETCOREAPP2_1
+                            await stream.WriteAsync(buffer.First);
+#else
                             var array = buffer.First.GetArray();
                             await stream.WriteAsync(array.Array, array.Offset, array.Count);
+#endif
                         }
                         else
                         {
                             foreach (var memory in buffer)
                             {
+#if NETCOREAPP2_1
+                                await stream.WriteAsync(memory);
+#else
                                 var array = memory.GetArray();
                                 await stream.WriteAsync(array.Array, array.Offset, array.Count);
+#endif
                             }
                         }
                     }
@@ -125,10 +133,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
 
                     var outputBuffer = Input.Writer.GetMemory(MinAllocBufferSize);
 
-                    var array = outputBuffer.GetArray();
                     try
                     {
+#if NETCOREAPP2_1
+                        var bytesRead = await stream.ReadAsync(outputBuffer);
+#else
+                        var array = outputBuffer.GetArray();
                         var bytesRead = await stream.ReadAsync(array.Array, array.Offset, array.Count);
+#endif
                         Input.Writer.Advance(bytesRead);
 
                         if (bytesRead == 0)

--- a/src/Kestrel.Core/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Kestrel.Core/Internal/Http/IHttpOutputProducer.cs
@@ -15,7 +15,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         Task FlushAsync(CancellationToken cancellationToken);
         Task Write100ContinueAsync(CancellationToken cancellationToken);
         void WriteResponseHeaders(int statusCode, string ReasonPhrase, HttpResponseHeaders responseHeaders);
-        Task WriteDataAsync(ArraySegment<byte> data, CancellationToken cancellationToken);
+        // The reason this is ReadOnlySpan and not ReadOnlyMemory is because writes are always
+        // synchronous. Flushing to get back pressure is the only time we truly go async but
+        // that's after the buffer is copied
+        Task WriteDataAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
         Task WriteStreamSuffixAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Kestrel.Core/Internal/Http/IHttpResponseControl.cs
+++ b/src/Kestrel.Core/Internal/Http/IHttpResponseControl.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     public interface IHttpResponseControl
     {
         void ProduceContinue();
-        Task WriteAsync(ArraySegment<byte> data, CancellationToken cancellationToken);
+        Task WriteAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken);
         Task FlushAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         private readonly byte[] _data = new byte[HeaderLength + MinAllowedMaxFrameSize];
 
-        public ArraySegment<byte> Raw => new ArraySegment<byte>(_data, 0, HeaderLength + Length);
+        public Span<byte> Raw => new Span<byte>(_data, 0, HeaderLength + Length);
 
         public int Length
         {

--- a/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public Task Write100ContinueAsync(CancellationToken cancellationToken) => _frameWriter.Write100ContinueAsync(_streamId);
 
-        public Task WriteDataAsync(ArraySegment<byte> data, CancellationToken cancellationToken)
+        public Task WriteDataAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken)
         {
             return _frameWriter.WriteDataAsync(_streamId, data, cancellationToken);
         }

--- a/src/Kestrel.Core/Internal/Http2/IHttp2FrameWriter.cs
+++ b/src/Kestrel.Core/Internal/Http2/IHttp2FrameWriter.cs
@@ -14,11 +14,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken));
         Task Write100ContinueAsync(int streamId);
         void WriteResponseHeaders(int streamId, int statusCode, IHeaderDictionary headers);
-        Task WriteDataAsync(int streamId, Span<byte> data, CancellationToken cancellationToken);
-        Task WriteDataAsync(int streamId, Span<byte> data, bool endStream, CancellationToken cancellationToken);
+        Task WriteDataAsync(int streamId, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
+        Task WriteDataAsync(int streamId, ReadOnlySpan<byte> data, bool endStream, CancellationToken cancellationToken);
         Task WriteRstStreamAsync(int streamId, Http2ErrorCode errorCode);
         Task WriteSettingsAckAsync();
-        Task WritePingAsync(Http2PingFrameFlags flags, Span<byte> payload);
+        Task WritePingAsync(Http2PingFrameFlags flags, ReadOnlySpan<byte> payload);
         Task WriteGoAwayAsync(int lastStreamId, Http2ErrorCode errorCode);
     }
 }

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -2136,10 +2136,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return Task.WhenAll(_runningStreams.Values.Select(tcs => tcs.Task)).TimeoutAfter(TestConstants.DefaultTimeout);
         }
 
-        private async Task SendAsync(ArraySegment<byte> span)
+        private Task SendAsync(ReadOnlySpan<byte> span)
         {
             var writableBuffer = _pair.Application.Output;
             writableBuffer.Write(span);
+            return FlushAsync(writableBuffer);
+        }
+
+        private static async Task FlushAsync(PipeWriter writableBuffer)
+        {
             await writableBuffer.FlushAsync();
         }
 

--- a/test/Kestrel.Core.Tests/HttpResponseStreamTests.cs
+++ b/test/Kestrel.Core.Tests/HttpResponseStreamTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var mockBodyControl = new Mock<IHttpBodyControlFeature>();
             mockBodyControl.Setup(m => m.AllowSynchronousIO).Returns(() => allowSynchronousIO);
             var mockHttpResponseControl = new Mock<IHttpResponseControl>();
-            mockHttpResponseControl.Setup(m => m.WriteAsync(It.IsAny<ArraySegment<byte>>(), CancellationToken.None)).Returns(Task.CompletedTask);
+            mockHttpResponseControl.Setup(m => m.WriteAsync(It.IsAny<ReadOnlyMemory<byte>>(), CancellationToken.None)).Returns(Task.CompletedTask);
 
             var stream = new HttpResponseStream(mockBodyControl.Object, mockHttpResponseControl.Object);
             stream.StartAcceptingWrites();

--- a/test/Kestrel.Core.Tests/MessageBodyTests.cs
+++ b/test/Kestrel.Core.Tests/MessageBodyTests.cs
@@ -426,7 +426,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var writeCount = 0;
             var writeTcs = new TaskCompletionSource<byte[]>();
-            var mockDestination = new Mock<Stream>();
+            var mockDestination = new Mock<Stream>() { CallBase = true };
 
             mockDestination
                 .Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), CancellationToken.None))
@@ -595,7 +595,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 // Time out on the next read
                 input.Http1Connection.SendTimeoutResponse();
 
-                var exception = await Assert.ThrowsAsync<BadHttpRequestException>(() => body.ReadAsync(new ArraySegment<byte>(new byte[1])));
+                var exception = await Assert.ThrowsAsync<BadHttpRequestException>(async () => await body.ReadAsync(new Memory<byte>(new byte[1])));
                 Assert.Equal(StatusCodes.Status408RequestTimeout, exception.StatusCode);
 
                 await body.StopAsync();

--- a/test/Kestrel.Core.Tests/TestHelpers/MockHttpResponseControl.cs
+++ b/test/Kestrel.Core.Tests/TestHelpers/MockHttpResponseControl.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests.TestHelpers
         {
         }
 
-        public Task WriteAsync(ArraySegment<byte> data, CancellationToken cancellationToken)
+        public Task WriteAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }


### PR DESCRIPTION
- Also plumbed Memory/Span through Kestrel over ArraySegment.
- Throw synchronously from the HttpRequestStream instead of async in some cases.

#2192 