### PR TITLE
Don't throw in HttpRequestStream.Flush

### DIFF
--- a/src/Kestrel.Core/Internal/Http/HttpRequestStream.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpRequestStream.cs
@@ -38,12 +38,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public override void Flush()
         {
-            throw new NotSupportedException();
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
-            throw new NotSupportedException();
+            return Task.CompletedTask;
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/test/Kestrel.Core.Tests/HttpRequestStreamTests.cs
+++ b/test/Kestrel.Core.Tests/HttpRequestStreamTests.cs
@@ -98,17 +98,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #endif
 
         [Fact]
-        public void FlushThrows()
+        // Read-only streams should support Flush according to https://github.com/dotnet/corefx/pull/27327#pullrequestreview-98384813
+        public void FlushDoesNotThrow()
         {
             var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>());
-            Assert.Throws<NotSupportedException>(() => stream.Flush());
+            stream.Flush();
         }
 
         [Fact]
-        public async Task FlushAsyncThrows()
+        public async Task FlushAsyncDoesNotThrow()
         {
             var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>());
-            await Assert.ThrowsAsync<NotSupportedException>(() => stream.FlushAsync());
+            await stream.FlushAsync();
         }
 
         [Fact]


### PR DESCRIPTION
Because read-only streams apparently can have Flush semantics and this behavior is expected by some of built-in stream wrappers (e. g. CryptoStream)

https://github.com/dotnet/corefx/pull/27327#pullrequestreview-98384813
https://github.com/aspnet/KestrelHttpServer/issues/2341