### PR TITLE
Include exceptions when displaying test logs

### DIFF
--- a/test/Kestrel.FunctionalTests/HttpsTests.cs
+++ b/test/Kestrel.FunctionalTests/HttpsTests.cs
@@ -412,7 +412,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             {
                 if (logLevel == LogLevel.Error)
                 {
-                    var log = $"Log {logLevel}[{eventId}]: {formatter(state, exception)} {exception?.Message}";
+                    var log = $"Log {logLevel}[{eventId}]: {formatter(state, exception)} {exception}";
                     _errorMessages.Add(log);
                 }
 

--- a/test/Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Kestrel.FunctionalTests/RequestTests.cs
@@ -409,7 +409,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 .Setup(logger => logger.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<object>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>()))
                 .Callback<LogLevel, EventId, object, Exception, Func<object, Exception, string>>((logLevel, eventId, state, exception, formatter) =>
                 {
-                    var log = $"Log {logLevel}[{eventId}]: {formatter(state, exception)} {exception?.Message}";
+                    var log = $"Log {logLevel}[{eventId}]: {formatter(state, exception)} {exception}";
                     _output.WriteLine(log);
 
                     if (eventId.Id == _connectionResetEventId)

--- a/test/shared/TestApplicationErrorLogger.cs
+++ b/test/shared/TestApplicationErrorLogger.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Testing
             if (logLevel == LogLevel.Critical && ThrowOnCriticalErrors)
 #endif
             {
-                var log = $"Log {logLevel}[{eventId}]: {formatter(state, exception)} {exception?.Message}";
+                var log = $"Log {logLevel}[{eventId}]: {formatter(state, exception)} {exception}";
 
                 Console.WriteLine(log);
 


### PR DESCRIPTION
Yesterday's PR didn't include stack traces.