### PR TITLE
Add benchmark using InMemoryTransport

### DIFF
--- a/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
@@ -52,17 +52,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         }
 
         [Benchmark]
-        public void Plaintext()
+        public async Task Plaintext()
         {
-            _connection.SendRequestAsync(RequestParsingData.PlaintextTechEmpowerRequest).Wait();
-            _connection.GetResponseAsync(_plaintextExpectedResponseLength).Wait();
+            await _connection.SendRequestAsync(RequestParsingData.PlaintextTechEmpowerRequest);
+            await _connection.GetResponseAsync(_plaintextExpectedResponseLength);
         }
 
         [Benchmark(OperationsPerInvoke = RequestParsingData.Pipelining)]
-        public void PlaintextPipelined()
+        public async Task PlaintextPipelined()
         {
-            _connection.SendRequestAsync(RequestParsingData.PlaintextTechEmpowerPipelinedRequests).Wait();
-            _connection.GetResponseAsync(_plaintextPipelinedExpectedResponseLength).Wait();
+            await _connection.SendRequestAsync(RequestParsingData.PlaintextTechEmpowerPipelinedRequests);
+            await _connection.GetResponseAsync(_plaintextPipelinedExpectedResponseLength);
         }
 
         public class InMemoryTransportFactory : ITransportFactory

--- a/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    public class InMemoryTransportBenchmark
+    {
+        // Must use explicit line endings to ensure identical string on all platforms
+        private static readonly byte[] _plaintextRequest = Encoding.UTF8.GetBytes(
+            "GET /plaintext HTTP/1.1\r\n" +
+            "Host: localhost\r\n" +
+            "Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7\r\n" +
+            "Connection: keep-alive\r\n" +
+            "\r\n");
+
+        private const int _plaintextExpectedResponseLength = 132;
+
+        private const int PipelineDepth = 16;
+        private static readonly byte[] _plaintextPipelinedRequest =
+            Enumerable.Range(0, PipelineDepth).SelectMany(_ => _plaintextRequest).ToArray();
+        private const int _plaintextPipelinedExpectedResponseLength = _plaintextExpectedResponseLength * PipelineDepth;
+
+        private IWebHost _host;
+        private InMemoryConnection _connection;
+
+        [GlobalSetup(Target = nameof(Plaintext) + "," + nameof(PlaintextPipelined))]
+        public void GlobalSetupPlaintext()
+        {
+            var transportFactory = new InMemoryTransportFactory();
+
+            _host = new WebHostBuilder()
+                // Prevent VS from attaching to hosting startup which could impact results
+                .UseSetting("preventHostingStartup", "true")
+                .UseKestrel()
+                .UseUrls("http://127.0.0.1:5000")
+                .ConfigureServices(services => services.AddSingleton<ITransportFactory>(transportFactory))
+                .Configure(app => app.UseMiddleware<PlaintextMiddleware>())
+                .Build();
+
+            _host.Start();
+
+            _connection = transportFactory.Connections.Values.Single().Single();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            _host.Dispose();
+        }
+
+        [Benchmark]
+        public void Plaintext()
+        {
+            _connection.SendRequestAsync(_plaintextRequest).Wait();
+            _connection.GetResponseAsync(_plaintextExpectedResponseLength).Wait();
+        }
+
+        [Benchmark(OperationsPerInvoke = PipelineDepth)]
+        public void PlaintextPipelined()
+        {
+            _connection.SendRequestAsync(_plaintextPipelinedRequest).Wait();
+            _connection.GetResponseAsync(_plaintextPipelinedExpectedResponseLength).Wait();
+        }
+
+        public class InMemoryTransportFactory : ITransportFactory
+        {
+            private readonly int _connectionsPerEndPoint;
+
+            private readonly Dictionary<IEndPointInformation, IReadOnlyList<InMemoryConnection>> _connections =
+                new Dictionary<IEndPointInformation, IReadOnlyList<InMemoryConnection>>();
+
+            public IReadOnlyDictionary<IEndPointInformation, IReadOnlyList<InMemoryConnection>> Connections => _connections;
+
+            public InMemoryTransportFactory(int connectionsPerEndPoint = 1)
+            {
+                _connectionsPerEndPoint = connectionsPerEndPoint;
+            }
+
+            public ITransport Create(IEndPointInformation endPointInformation, IConnectionHandler handler)
+            {
+                var connections = new InMemoryConnection[_connectionsPerEndPoint];
+                for (var i = 0; i < _connectionsPerEndPoint; i++)
+                {
+                    connections[i] = new InMemoryConnection();
+                }
+
+                _connections.Add(endPointInformation, connections);
+
+                return new InMemoryTransport(handler, connections);
+            }
+        }
+
+        public class InMemoryTransport : ITransport
+        {
+            private readonly IConnectionHandler _handler;
+            private readonly IReadOnlyList<InMemoryConnection> _connections;
+
+            public InMemoryTransport(IConnectionHandler handler, IReadOnlyList<InMemoryConnection> connections)
+            {
+                _handler = handler;
+                _connections = connections;
+            }
+
+            public Task BindAsync()
+            {
+                foreach (var connection in _connections)
+                {
+                    _handler.OnConnection(connection);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            public Task StopAsync()
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task UnbindAsync()
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        public class InMemoryConnection : TransportConnection
+        {
+            public Task SendRequestAsync(byte[] request)
+            {
+                return Input.WriteAsync(request);
+            }
+
+            public async Task<byte[]> GetResponseAsync(int length)
+            {
+                while (true)
+                {
+                    var result = await Output.ReadAsync();
+                    var buffer = result.Buffer;
+                    var consumed = buffer.Start;
+                    var examined = buffer.End;
+
+                    try
+                    {
+                        if (buffer.Length >= length)
+                        {
+                            var response = buffer.Slice(0, length);
+                            consumed = response.End;
+                            examined = response.End;
+                            return response.ToArray();
+                        }
+                    }
+                    finally
+                    {
+                        Output.AdvanceTo(consumed, examined);
+                    }
+                }
+            }
+        }
+
+        // Copied from https://github.com/aspnet/benchmarks/blob/dev/src/Benchmarks/Middleware/PlaintextMiddleware.cs
+        public class PlaintextMiddleware
+        {
+            private static readonly PathString _path = new PathString("/plaintext");
+            private static readonly byte[] _helloWorldPayload = Encoding.UTF8.GetBytes("Hello, World!");
+
+            private readonly RequestDelegate _next;
+
+            public PlaintextMiddleware(RequestDelegate next)
+            {
+                _next = next;
+            }
+
+            public Task Invoke(HttpContext httpContext)
+            {
+                if (httpContext.Request.Path.StartsWithSegments(_path, StringComparison.Ordinal))
+                {
+                    return WriteResponse(httpContext.Response);
+                }
+
+                return _next(httpContext);
+            }
+
+            public static Task WriteResponse(HttpResponse response)
+            {
+                var payloadLength = _helloWorldPayload.Length;
+                response.StatusCode = 200;
+                response.ContentType = "text/plain";
+                response.ContentLength = payloadLength;
+                return response.Body.WriteAsync(_helloWorldPayload, 0, payloadLength);
+            }
+        }
+
+    }
+}

--- a/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
@@ -45,6 +45,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
                 // Prevent VS from attaching to hosting startup which could impact results
                 .UseSetting("preventHostingStartup", "true")
                 .UseKestrel()
+                // Bind to a single non-HTTPS endpoint
                 .UseUrls("http://127.0.0.1:5000")
                 .ConfigureServices(services => services.AddSingleton<ITransportFactory>(transportFactory))
                 .Configure(app => app.UseMiddleware<PlaintextMiddleware>())

--- a/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         [GlobalSetup(Target = nameof(Plaintext) + "," + nameof(PlaintextPipelined))]
         public void GlobalSetupPlaintext()
         {
-            var transportFactory = new InMemoryTransportFactory();
+            var transportFactory = new InMemoryTransportFactory(connectionsPerEndPoint: 1);
 
             _host = new WebHostBuilder()
                 // Prevent VS from attaching to hosting startup which could impact results
@@ -53,6 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             _host.Start();
 
+            // Ensure there is a single endpoint and single connection
             _connection = transportFactory.Connections.Values.Single().Single();
         }
 
@@ -85,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 
             public IReadOnlyDictionary<IEndPointInformation, IReadOnlyList<InMemoryConnection>> Connections => _connections;
 
-            public InMemoryTransportFactory(int connectionsPerEndPoint = 1)
+            public InMemoryTransportFactory(int connectionsPerEndPoint)
             {
                 _connectionsPerEndPoint = connectionsPerEndPoint;
             }

--- a/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/InMemoryTransportBenchmark.cs
@@ -18,20 +18,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
 {
     public class InMemoryTransportBenchmark
     {
-        // Must use explicit line endings to ensure identical string on all platforms
-        private static readonly byte[] _plaintextRequest = Encoding.UTF8.GetBytes(
-            "GET /plaintext HTTP/1.1\r\n" +
-            "Host: localhost\r\n" +
-            "Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7\r\n" +
-            "Connection: keep-alive\r\n" +
-            "\r\n");
-
         private const int _plaintextExpectedResponseLength = 132;
-
-        private const int PipelineDepth = 16;
-        private static readonly byte[] _plaintextPipelinedRequest =
-            Enumerable.Range(0, PipelineDepth).SelectMany(_ => _plaintextRequest).ToArray();
-        private const int _plaintextPipelinedExpectedResponseLength = _plaintextExpectedResponseLength * PipelineDepth;
+        private const int _plaintextPipelinedExpectedResponseLength = _plaintextExpectedResponseLength * RequestParsingData.Pipelining;
 
         private IWebHost _host;
         private InMemoryConnection _connection;
@@ -66,14 +54,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         [Benchmark]
         public void Plaintext()
         {
-            _connection.SendRequestAsync(_plaintextRequest).Wait();
+            _connection.SendRequestAsync(RequestParsingData.PlaintextTechEmpowerRequest).Wait();
             _connection.GetResponseAsync(_plaintextExpectedResponseLength).Wait();
         }
 
-        [Benchmark(OperationsPerInvoke = PipelineDepth)]
+        [Benchmark(OperationsPerInvoke = RequestParsingData.Pipelining)]
         public void PlaintextPipelined()
         {
-            _connection.SendRequestAsync(_plaintextPipelinedRequest).Wait();
+            _connection.SendRequestAsync(RequestParsingData.PlaintextTechEmpowerPipelinedRequests).Wait();
             _connection.GetResponseAsync(_plaintextPipelinedExpectedResponseLength).Wait();
         }
 

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview2-15721
-commithash:f9bb4be59e39938ec59a6975257e26099b0d03c1
+version:2.1.0-preview2-15726
+commithash:599e691c41f502ed9e062b1822ce13b673fc916e


### PR DESCRIPTION
Results from my dev machine:

Method |     Mean |     Error |    StdDev |      Op/s | Allocated |
------------------- |---------:|----------:|----------:|----------:|----------:|
Plaintext | 9.734 us | 0.5443 us | 0.8147 us | 102,729.6 |     232 B |
PlaintextPipelined | 6.002 us | 0.0678 us | 0.1015 us | 166,607.3 |      21 B |

For comparison, here are the `RequestParsing` benchmarks on the same machine:

Method |       Mean |     Error |    StdDev |        Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
----------------------------------------- |-----------:|----------:|----------:|------------:|-------:|---------:|-------:|----------:|
PlaintextTechEmpower | 1,380.3 ns |  8.413 ns |  12.59 ns |   724,481.9 |   1.00 |     0.00 | 0.0010 |     344 B |
PipelinedPlaintextTechEmpower | 1,137.2 ns | 33.750 ns |  50.52 ns |   879,351.3 |   0.82 |     0.04 | 0.0013 |     344 B |

CC: @benaadams 