### PR TITLE
Fix Http2ConnectionTests flakiness

### DIFF
--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -123,7 +123,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         public Http2ConnectionTests()
         {
-            _pair = DuplexPipe.CreateConnectionPair(_memoryPool);
+            var inlineSchedulingPipeOptions = new PipeOptions(
+                pool: _memoryPool,
+                readerScheduler: PipeScheduler.Inline,
+                writerScheduler: PipeScheduler.Inline
+            );
+
+            _pair = DuplexPipe.CreateConnectionPair(inlineSchedulingPipeOptions, inlineSchedulingPipeOptions);
 
             _noopApplication = context => Task.CompletedTask;
 


### PR DESCRIPTION
- The default PipeScheduler got switched from Inline to ThreadPool.
- This switches the Http2ConnectionTests PipeScheduler back to ThreadPool.

Fixes #2359