### PR TITLE
Making performance improvements to sockets

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public override MemoryPool<byte> MemoryPool { get; }
         public override PipeScheduler InputWriterScheduler => PipeScheduler.Inline;
-        public override PipeScheduler OutputReaderScheduler => GlobalThreadPoolScheduler.Default;
+        public override PipeScheduler OutputReaderScheduler => PipeScheduler.ThreadPool;
 
         public async Task StartAsync(IConnectionHandler connectionHandler)
         {
@@ -240,33 +240,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             }
 
             return error;
-        }
-
-        // This scheduler runs on the global thread pool queue instead of the local queue
-        // We can delete this when we get a new pipelines build since that's the new default.
-        // In the current version that Kestrel uses, we're using local queues instead of the global one.
-        private class GlobalThreadPoolScheduler : PipeScheduler
-        {
-            public static GlobalThreadPoolScheduler Default = new GlobalThreadPoolScheduler();
-
-            public override void Schedule(Action action)
-            {
-                System.Threading.ThreadPool.QueueUserWorkItem(s =>
-                {
-                    ((Action)s)();
-                },
-                action);
-            }
-
-            public override void Schedule(Action<object> action, object state)
-            {
-                System.Threading.ThreadPool.QueueUserWorkItem(s =>
-                {
-                    var t = (Tuple<Action<object>, object>)s;
-                    t.Item1(t.Item2);
-                },
-                Tuple.Create(action, state));
-            }
         }
     }
 }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -10,7 +10,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     {
         private readonly Socket _socket;
         private readonly SocketAsyncEventArgs _eventArgs = new SocketAsyncEventArgs();
-        private readonly SocketAwaitable _awaitable = new SocketAwaitable();
+
+        // Dispatch read continuations to the thread pool, this allows us to not tie up the IO thread
+        // when running read completions.
+        private readonly SocketAwaitable _awaitable = new SocketAwaitable(runContinuationsAsynchronously: true);
 
         public SocketReceiver(Socket socket)
         {

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     {
         private readonly Socket _socket;
         private readonly SocketAsyncEventArgs _eventArgs = new SocketAsyncEventArgs();
-        private readonly SocketAwaitable _awaitable = new SocketAwaitable();
+        private readonly SocketAwaitable _awaitable = new SocketAwaitable(runContinuationsAsynchronously: false);
 
         private List<ArraySegment<byte>> _bufferList;
 


### PR DESCRIPTION
- Run SocketAwaitable continuations asynchronously for reads (Didn't seem to make much of a difference for writes)
- Run using the global thread pool queues instead
of using local queues.

Theories:
- We're freeing up the IO thread immediately to do more work (get more completions) so we can do more work if we dispatch.
- Queuing to the local queue incurred more work stealing instead of the current thread picking it up to do more.

## Plaintext Linux

### Libuv:

#### Thread count default

```
[02:36:04.381] RequestsPerSecond:           1552129
[02:36:04.381] Latency on load (ms):        2.9
[02:36:04.381] Max CPU (%):                 98
[02:36:04.381] WorkingSet (MB):             403
[02:36:04.382] Startup Main (ms):           492
[02:36:04.382] First Request (ms):          192.4
[02:36:04.382] Latency (ms):                0.7
[02:36:04.382] Socket Errors:               0
[02:36:04.382] Bad Responses:               0
[02:36:04.382] SDK:                         2.2.0-preview1-007522
[02:36:04.382] Runtime:                     2.1.0-preview2-26225-03
[02:36:04.382] ASP.NET Core:                2.1.0-preview2-30242
```

#### Thread count 2

```
[02:40:17.288] RequestsPerSecond:           1591637
[02:40:17.288] Latency on load (ms):        1.6
[02:40:17.288] Max CPU (%):                 97
[02:40:17.288] WorkingSet (MB):             405
[02:40:17.288] Startup Main (ms):           477
[02:40:17.288] First Request (ms):          191
[02:40:17.288] Latency (ms):                0.8
[02:40:17.288] Socket Errors:               0
[02:40:17.288] Bad Responses:               0
[02:40:17.289] SDK:                         2.2.0-preview1-007522
[02:40:17.289] Runtime:                     2.1.0-preview2-26225-03
[02:40:17.289] ASP.NET Core:                2.1.0-preview2-30242
```

### Sockets:

#### Before:

```
[02:42:05.259] RequestsPerSecond:           1450885
[02:42:05.259] Latency on load (ms):        2.5
[02:42:05.259] Max CPU (%):                 99
[02:42:05.259] WorkingSet (MB):             407
[02:42:05.259] Startup Main (ms):           407
[02:42:05.260] First Request (ms):          192.3
[02:42:05.260] Latency (ms):                0.9
[02:42:05.260] Socket Errors:               0
[02:42:05.260] Bad Responses:               0
[02:42:05.260] SDK:                         2.2.0-preview1-007522
[02:42:05.260] Runtime:                     2.1.0-preview2-26225-03
[02:42:05.260] ASP.NET Core:                2.1.0-preview2-30242
```

#### After:

```
[02:43:48.984] RequestsPerSecond:           1534075
[02:43:48.984] Latency on load (ms):        1.5
[02:43:48.984] Max CPU (%):                 99
[02:43:48.984] WorkingSet (MB):             410
[02:43:48.984] Startup Main (ms):           410
[02:43:48.984] First Request (ms):          189
[02:43:48.985] Latency (ms):                0.9
[02:43:48.985] Socket Errors:               0
[02:43:48.985] Bad Responses:               0
[02:43:48.985] SDK:                         2.2.0-preview1-007522
[02:43:48.985] Runtime:                     2.1.0-preview2-26225-03
[02:43:48.985] ASP.NET Core:                2.1.0-preview2-30242
```

## Plaintext Windows

### Libuv:

#### Thread count default

```
[02:31:14.077] RequestsPerSecond:           1569046
[02:31:14.077] Latency on load (ms):        3.6
[02:31:14.077] Max CPU (%):                 92
[02:31:14.078] WorkingSet (MB):             385
[02:31:14.078] Startup Main (ms):           440
[02:31:14.078] First Request (ms):          143.9
[02:31:14.078] Latency (ms):                0.8
[02:31:14.078] Socket Errors:               0
[02:31:14.078] Bad Responses:               0
[02:31:14.078] SDK:                         2.2.0-preview1-007522
[02:31:14.078] Runtime:                     2.1.0-preview2-26225-03
[02:31:14.078] ASP.NET Core:                2.1.0-preview2-30242
```

#### Thread count 2

```
[02:38:43.195] RequestsPerSecond:           1833182
[02:38:43.195] Latency on load (ms):        1.3
[02:38:43.195] Max CPU (%):                 92
[02:38:43.195] WorkingSet (MB):             385
[02:38:43.195] Startup Main (ms):           418
[02:38:43.195] First Request (ms):          146.3
[02:38:43.195] Latency (ms):                0.8
[02:38:43.195] Socket Errors:               0
[02:38:43.195] Bad Responses:               0
[02:38:43.195] SDK:                         2.2.0-preview1-007522
[02:38:43.196] Runtime:                     2.1.0-preview2-26225-03
[02:38:43.196] ASP.NET Core:                2.1.0-preview2-30242
```

### Sockets:

#### Before

```
[02:33:22.076] RequestsPerSecond:           1637189
[02:33:22.076] Latency on load (ms):        9.2
[02:33:22.076] Max CPU (%):                 93
[02:33:22.076] WorkingSet (MB):             386
[02:33:22.077] Startup Main (ms):           377
[02:33:22.077] First Request (ms):          141.9
[02:33:22.077] Latency (ms):                0.8
[02:33:22.077] Socket Errors:               0
[02:33:22.077] Bad Responses:               0
[02:33:22.077] SDK:                         2.2.0-preview1-007522
[02:33:22.077] Runtime:                     2.1.0-preview2-26225-03
[02:33:22.077] ASP.NET Core:                2.1.0-preview2-30242
```

#### After

```
[01:54:15.852] RequestsPerSecond:           1810187
[01:54:15.852] Latency on load (ms):        1.7
[01:54:15.852] Max CPU (%):                 93
[01:54:15.852] WorkingSet (MB):             379
[01:54:15.852] Startup Main (ms):           380
[01:54:15.852] First Request (ms):          140.6
[01:54:15.853] Latency (ms):                0.7
[01:54:15.853] Socket Errors:               0
[01:54:15.853] Bad Responses:               0
```


## Json Linux

### Libuv

```
[02:50:53.012] RequestsPerSecond:           404439
[02:50:53.012] Latency on load (ms):        1.1
[02:50:53.012] Max CPU (%):                 98
[02:50:53.012] WorkingSet (MB):             403
[02:50:53.012] Startup Main (ms):           468
[02:50:53.012] First Request (ms):          282.1
[02:50:53.012] Latency (ms):                0.8
[02:50:53.012] Socket Errors:               0
[02:50:53.012] Bad Responses:               0
[02:50:53.012] SDK:                         2.2.0-preview1-007522
[02:50:53.012] Runtime:                     2.1.0-preview2-26225-03
[02:50:53.013] ASP.NET Core:                2.1.0-preview2-30242
```

### Sockets

#### Before

```
[02:48:02.883] RequestsPerSecond:           258183
[02:48:02.883] Latency on load (ms):        1.4
[02:48:02.883] Max CPU (%):                 98
[02:48:02.883] WorkingSet (MB):             403
[02:48:02.883] Startup Main (ms):           409
[02:48:02.884] First Request (ms):          283
[02:48:02.884] Latency (ms):                0.7
[02:48:02.884] Socket Errors:               0
[02:48:02.884] Bad Responses:               0
[02:48:02.884] SDK:                         2.2.0-preview1-007522
[02:48:02.884] Runtime:                     2.1.0-preview2-26225-03
[02:48:02.884] ASP.NET Core:                2.1.0-preview2-30242
```

#### After

```
[02:46:09.887] RequestsPerSecond:           304399
[02:46:09.887] Latency on load (ms):        1
[02:46:09.887] Max CPU (%):                 98
[02:46:09.887] WorkingSet (MB):             407
[02:46:09.887] Startup Main (ms):           404
[02:46:09.888] First Request (ms):          292.7
[02:46:09.888] Latency (ms):                0.7
[02:46:09.888] Socket Errors:               0
[02:46:09.888] Bad Responses:               0
[02:46:09.888] SDK:                         2.2.0-preview1-007522
[02:46:09.888] Runtime:                     2.1.0-preview2-26225-03
[02:46:09.888] ASP.NET Core:                2.1.0-preview2-30242
```

## Json Windows

### Libuv

```
[02:52:30.244] RequestsPerSecond:           451311
[02:52:30.244] Latency on load (ms):        0.7
[02:52:30.244] Max CPU (%):                 85
[02:52:30.244] WorkingSet (MB):             386
[02:52:30.244] Startup Main (ms):           423
[02:52:30.244] First Request (ms):          235.5
[02:52:30.244] Latency (ms):                0.8
[02:52:30.244] Socket Errors:               0
[02:52:30.245] Bad Responses:               0
[02:52:30.245] SDK:                         2.2.0-preview1-007522
[02:52:30.245] Runtime:                     2.1.0-preview2-26225-03
[02:52:30.245] ASP.NET Core:                2.1.0-preview2-30242
```

### Sockets

#### Before

```
[02:54:28.433] RequestsPerSecond:           299985
[02:54:28.433] Latency on load (ms):        7
[02:54:28.433] Max CPU (%):                 84
[02:54:28.434] WorkingSet (MB):             372
[02:54:28.434] Startup Main (ms):           376
[02:54:28.434] First Request (ms):          229.2
[02:54:28.434] Latency (ms):                0.8
[02:54:28.434] Socket Errors:               0
[02:54:28.434] Bad Responses:               0
[02:54:28.434] SDK:                         2.2.0-preview1-007522
[02:54:28.434] Runtime:                     2.1.0-preview2-26225-03
[02:54:28.434] ASP.NET Core:                2.1.0-preview2-30242
```

#### After

```
[02:55:24.440] RequestsPerSecond:           349936
[02:55:24.440] Latency on load (ms):        1.4
[02:55:24.440] Max CPU (%):                 84
[02:55:24.440] WorkingSet (MB):             368
[02:55:24.440] Startup Main (ms):           377
[02:55:24.440] First Request (ms):          228
[02:55:24.440] Latency (ms):                0.7
[02:55:24.440] Socket Errors:               0
[02:55:24.440] Bad Responses:               0
[02:55:24.440] SDK:                         2.2.0-preview1-007522
[02:55:24.440] Runtime:                     2.1.0-preview2-26225-03
[02:55:24.440] ASP.NET Core:                2.1.0-preview2-30242
```