### PR TITLE
Be explicit about PipeScheduler.Inline

### DIFF
--- a/test/Kestrel.Core.Tests/OutputProducerTests.cs
+++ b/test/Kestrel.Core.Tests/OutputProducerTests.cs
@@ -34,7 +34,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var pipeOptions = new PipeOptions
             (
                 pool: _memoryPool,
-                readerScheduler: Mock.Of<PipeScheduler>()
+                readerScheduler: Mock.Of<PipeScheduler>(),
+                writerScheduler: PipeScheduler.Inline
             );
 
             using (var socketOutput = CreateOutputProducer(pipeOptions))

--- a/test/Kestrel.Core.Tests/PipelineExtensionTests.cs
+++ b/test/Kestrel.Core.Tests/PipelineExtensionTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         public PipelineExtensionTests()
         {
-            _pipe = new Pipe(new PipeOptions(_memoryPool));
+            _pipe = new Pipe(new PipeOptions(_memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline));
         }
 
         public void Dispose()

--- a/test/Kestrel.Core.Tests/TestInput.cs
+++ b/test/Kestrel.Core.Tests/TestInput.cs
@@ -22,7 +22,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public TestInput()
         {
             _memoryPool = KestrelMemoryPool.Create();
-            var pair = DuplexPipe.CreateConnectionPair(_memoryPool);
+            var options = new PipeOptions(pool: _memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline);
+            var pair = DuplexPipe.CreateConnectionPair(options, options);
             Transport = pair.Transport;
             Application = pair.Application;
 

--- a/test/Kestrel.Transport.Libuv.Tests/LibuvConnectionTests.cs
+++ b/test/Kestrel.Transport.Libuv.Tests/LibuvConnectionTests.cs
@@ -62,11 +62,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             mockConnectionHandler.InputOptions = pool =>
                 new PipeOptions(
                     pool: pool,
-                    pauseWriterThreshold: 3);
+                    pauseWriterThreshold: 3,
+                    readerScheduler: PipeScheduler.Inline,
+                    writerScheduler: PipeScheduler.Inline);
 
             // We don't set the output writer scheduler here since we want to run the callback inline
 
-            mockConnectionHandler.OutputOptions = pool => new PipeOptions(pool: pool, readerScheduler: thread);
+            mockConnectionHandler.OutputOptions = pool => new PipeOptions(pool: pool, readerScheduler: thread, writerScheduler: PipeScheduler.Inline);
 
 
             Task connectionTask = null;
@@ -128,9 +130,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                     pool: pool,
                     pauseWriterThreshold: 3,
                     resumeWriterThreshold: 3,
-                    writerScheduler: mockScheduler.Object);
+                    writerScheduler: mockScheduler.Object,
+                    readerScheduler: PipeScheduler.Inline);
 
-            mockConnectionHandler.OutputOptions = pool => new PipeOptions(pool: pool, readerScheduler:thread );
+            mockConnectionHandler.OutputOptions = pool => new PipeOptions(pool: pool, readerScheduler: thread, writerScheduler: PipeScheduler.Inline);
 
             Task connectionTask = null;
             try

--- a/test/Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
+++ b/test/Kestrel.Transport.Libuv.Tests/LibuvOutputConsumerTests.cs
@@ -67,6 +67,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             (
                 pool: _memoryPool,
                 readerScheduler: _libuvThread,
+                writerScheduler: PipeScheduler.Inline,
                 pauseWriterThreshold: maxResponseBufferSize ?? 0,
                 resumeWriterThreshold: maxResponseBufferSize ?? 0
             );
@@ -103,6 +104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             (
                 pool: _memoryPool,
                 readerScheduler: _libuvThread,
+                writerScheduler: PipeScheduler.Inline,
                 pauseWriterThreshold: 0,
                 resumeWriterThreshold: 0
             );
@@ -151,6 +153,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             (
                 pool: _memoryPool,
                 readerScheduler: _libuvThread,
+                writerScheduler: PipeScheduler.Inline,
                 pauseWriterThreshold: 1,
                 resumeWriterThreshold: 1
             );
@@ -207,6 +210,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             (
                 pool: _memoryPool,
                 readerScheduler: _libuvThread,
+                writerScheduler: PipeScheduler.Inline,
                 pauseWriterThreshold: maxResponseBufferSize,
                 resumeWriterThreshold: maxResponseBufferSize
             );
@@ -271,6 +275,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                 (
                     pool: _memoryPool,
                     readerScheduler: _libuvThread,
+                    writerScheduler: PipeScheduler.Inline,
                     pauseWriterThreshold: maxResponseBufferSize,
                     resumeWriterThreshold: maxResponseBufferSize
                 );
@@ -435,6 +440,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                 (
                     pool: _memoryPool,
                     readerScheduler: _libuvThread,
+                    writerScheduler: PipeScheduler.Inline,
                     pauseWriterThreshold: maxResponseBufferSize,
                     resumeWriterThreshold: maxResponseBufferSize
                 );
@@ -519,6 +525,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                 (
                     pool: _memoryPool,
                     readerScheduler: _libuvThread,
+                    writerScheduler: PipeScheduler.Inline,
                     pauseWriterThreshold: maxResponseBufferSize,
                     resumeWriterThreshold: maxResponseBufferSize
                 );
@@ -601,6 +608,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             (
                 pool: _memoryPool,
                 readerScheduler: _libuvThread,
+                writerScheduler: PipeScheduler.Inline,
                 pauseWriterThreshold: maxResponseBufferSize,
                 resumeWriterThreshold: maxResponseBufferSize
             );
@@ -662,6 +670,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             (
                 pool: _memoryPool,
                 readerScheduler: _libuvThread,
+                writerScheduler: PipeScheduler.Inline,
                 pauseWriterThreshold: maxResponseBufferSize ?? 0,
                 resumeWriterThreshold: maxResponseBufferSize ?? 0
             );

--- a/test/Kestrel.Transport.Libuv.Tests/TestHelpers/MockConnectionHandler.cs
+++ b/test/Kestrel.Transport.Libuv.Tests/TestHelpers/MockConnectionHandler.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.TestHelpers
 {
     public class MockConnectionHandler : IConnectionHandler
     {
-        public Func<MemoryPool<byte>, PipeOptions> InputOptions { get; set; } = pool => new PipeOptions(pool);
-        public Func<MemoryPool<byte>, PipeOptions> OutputOptions { get; set; } = pool => new PipeOptions(pool);
+        public Func<MemoryPool<byte>, PipeOptions> InputOptions { get; set; } = pool => new PipeOptions(pool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline);
+        public Func<MemoryPool<byte>, PipeOptions> OutputOptions { get; set; } = pool => new PipeOptions(pool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline);
 
         public void OnConnection(IFeatureCollection features)
         {


### PR DESCRIPTION
When @pakrym upgraded to the new pipelines, we missed a few places that we were using the inline scheduler before. This change makes that explicit since the new default is thread pool. Hopefully, it'll make the tests less flaky.