### PR TITLE
Use LibuvThread inspired schedulers in socket transport

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
     "editor.tabSize": 2
   },
   "files.trimTrailingWhitespace": true,
-  "files.insertFinalNewline": true,
   "files.associations": {
     "*.props": "xml",
     "*.targets": "xml"

--- a/src/Kestrel.Transport.Sockets/Internal/CoalescingScheduler.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/CoalescingScheduler.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
+{
+    public class CoalescingScheduler
+    {
+        // Maximum times the work queues swapped and are processed in a single pass
+        private const int _maxLoops = 8;
+
+        private readonly object _workSync = new object();
+        private bool _doingWork;
+        private Queue<Action> _workAdding = new Queue<Action>(1024);
+        private Queue<Action> _workRunning = new Queue<Action>(1024);
+
+        public void Schedule(Action action)
+        {
+            bool scheduleWork;
+
+            lock (_workSync)
+            {
+                _workAdding.Enqueue(action);
+                scheduleWork = !_doingWork;
+                _doingWork = true;
+            }
+
+            if (scheduleWork)
+            {
+                ThreadPool.QueueUserWorkItem(s => ((CoalescingScheduler)s).DoWork(), this);
+            }
+        }
+
+        private void DoWork()
+        {
+            for (var i = 0; i < _maxLoops; i++)
+            {
+                Queue<Action> queue;
+                lock (_workSync)
+                {
+                    queue = _workAdding;
+                    _workAdding = _workRunning;
+                    _workRunning = queue;
+
+                    if (queue.Count == 0)
+                    {
+                        _doingWork = false;
+                        return;
+                    }
+                }
+
+                while (queue.Count != 0)
+                {
+                    queue.Dequeue()();
+                }
+            }
+
+            ThreadPool.QueueUserWorkItem(s => ((CoalescingScheduler)s).DoWork(), this);
+        }
+    }
+}

--- a/src/Kestrel.Transport.Sockets/Internal/CoalescingScheduler.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/CoalescingScheduler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         private readonly object _workSync = new object();
         private bool _doingWork;
 
-        public void Schedule(Action action)
+        public virtual void Schedule(Action action)
         {
             _actions.Enqueue(action);
             TriggerWork();

--- a/src/Kestrel.Transport.Sockets/Internal/CoalescingScheduler.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/CoalescingScheduler.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             }
         }
 
-        private class Work
+        private struct Work
         {
             public Action<object, object> CallbackAdapter;
             public object Callback;

--- a/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
@@ -8,21 +8,13 @@ using System.Threading;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
-    public class CoalescingScheduler : PipeScheduler
+    public class IOQueue : PipeScheduler
     {
-        private static readonly WaitCallback _doWorkCallback = s => ((CoalescingScheduler)s).DoWork();
-
-        private readonly ConcurrentQueue<Action> _actions = new ConcurrentQueue<Action>();
-        private readonly ConcurrentQueue<Work> _workItems = new ConcurrentQueue<Work>();
+        private static readonly WaitCallback _doWorkCallback = s => ((IOQueue)s).DoWork();
 
         private readonly object _workSync = new object();
+        private readonly ConcurrentQueue<Work> _workItems = new ConcurrentQueue<Work>();
         private bool _doingWork;
-
-        public virtual void Schedule(Action action)
-        {
-            _actions.Enqueue(action);
-            TriggerWork();
-        }
 
         public override void Schedule<T>(Action<T> action, T state)
         {
@@ -34,11 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             };
 
             _workItems.Enqueue(work);
-            TriggerWork();
-        }
 
-        private void TriggerWork()
-        {
             lock (_workSync)
             {
                 if (!_doingWork)
@@ -53,11 +41,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
             while (true)
             {
-                while (_actions.TryDequeue(out Action action))
-                {
-                    action();
-                }
-
                 while (_workItems.TryDequeue(out Work item))
                 {
                     item.CallbackAdapter(item.Callback, item.State);
@@ -65,7 +48,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
                 lock (_workSync)
                 {
-                    if (_actions.IsEmpty && _workItems.IsEmpty)
+                    if (_workItems.IsEmpty)
                     {
                         _doingWork = false;
                         return;

--- a/src/Kestrel.Transport.Sockets/Internal/SocketAwaitable.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketAwaitable.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -13,15 +14,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     {
         private static readonly Action _callbackCompleted = () => { };
 
-        private readonly CoalescingScheduler _coalescingScheduler;
+        private readonly PipeScheduler _ioScheduler;
 
         private Action _callback;
         private int _bytesTransferred;
         private SocketError _error;
 
-        public SocketAwaitable(CoalescingScheduler coalescingScheduler)
+        public SocketAwaitable(PipeScheduler ioScheduler)
         {
-            _coalescingScheduler = coalescingScheduler;
+            _ioScheduler = ioScheduler;
         }
 
         public SocketAwaitable GetAwaiter() => this;
@@ -63,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
             if (continuation != null)
             {
-                _coalescingScheduler.Schedule(continuation);
+                _ioScheduler.Schedule(c => c(), continuation);
             }
         }
     }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -47,17 +47,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             RemoteAddress = remoteEndPoint.Address;
             RemotePort = remoteEndPoint.Port;
 
-            var pipeScheduler = new CoalescingPipeScheduler(_scheduler);
-            InputWriterScheduler = pipeScheduler;
-            OutputReaderScheduler = pipeScheduler;
             _receiver = new SocketReceiver(_socket, _scheduler);
             _sender = new SocketSender(_socket, _scheduler);
         }
 
         public override MemoryPool<byte> MemoryPool { get; }
 
-        public override PipeScheduler InputWriterScheduler { get; }
-        public override PipeScheduler OutputReaderScheduler { get; }
+        public override PipeScheduler InputWriterScheduler => _scheduler;
+        public override PipeScheduler OutputReaderScheduler => _scheduler;
 
         public async Task StartAsync(IConnectionHandler connectionHandler)
         {
@@ -246,22 +243,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             }
 
             return error;
-        }
-
-
-        private class CoalescingPipeScheduler : PipeScheduler
-        {
-            private readonly CoalescingScheduler _scheduler;
-
-            public CoalescingPipeScheduler(CoalescingScheduler scheduler)
-            {
-                _scheduler = scheduler;
-            }
-
-            public override void Schedule<T>(Action<T> action, T state)
-            {
-                _scheduler.Schedule(() => action(state));
-            }
         }
     }
 }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO.Pipelines;
 using System.Net.Sockets;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
@@ -12,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         private readonly SocketAsyncEventArgs _eventArgs = new SocketAsyncEventArgs();
         private readonly SocketAwaitable _awaitable;
 
-        public SocketReceiver(Socket socket, CoalescingScheduler scheduler)
+        public SocketReceiver(Socket socket, PipeScheduler scheduler)
         {
             _socket = socket;
             _awaitable = new SocketAwaitable(scheduler);

--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -10,11 +10,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     {
         private readonly Socket _socket;
         private readonly SocketAsyncEventArgs _eventArgs = new SocketAsyncEventArgs();
-        private readonly SocketAwaitable _awaitable = new SocketAwaitable();
+        private readonly SocketAwaitable _awaitable;
 
-        public SocketReceiver(Socket socket)
+        public SocketReceiver(Socket socket, CoalescingScheduler scheduler)
         {
             _socket = socket;
+            _awaitable = new SocketAwaitable(scheduler);
             _eventArgs.UserToken = _awaitable;
             _eventArgs.Completed += (_, e) => ((SocketAwaitable)e.UserToken).Complete(e.BytesTransferred, e.SocketError);
         }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 
@@ -18,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         private List<ArraySegment<byte>> _bufferList;
 
-        public SocketSender(Socket socket, CoalescingScheduler scheduler)
+        public SocketSender(Socket socket, PipeScheduler scheduler)
         {
             _socket = socket;
             _awaitable = new SocketAwaitable(scheduler);

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
@@ -14,13 +14,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     {
         private readonly Socket _socket;
         private readonly SocketAsyncEventArgs _eventArgs = new SocketAsyncEventArgs();
-        private readonly SocketAwaitable _awaitable = new SocketAwaitable();
+        private readonly SocketAwaitable _awaitable;
 
         private List<ArraySegment<byte>> _bufferList;
 
-        public SocketSender(Socket socket)
+        public SocketSender(Socket socket, CoalescingScheduler scheduler)
         {
             _socket = socket;
+            _awaitable = new SocketAwaitable(scheduler);
             _eventArgs.UserToken = _awaitable;
             _eventArgs.Completed += (_, e) => ((SocketAwaitable)e.UserToken).Complete(e.BytesTransferred, e.SocketError);
         }

--- a/src/Kestrel.Transport.Sockets/SocketTransport.cs
+++ b/src/Kestrel.Transport.Sockets/SocketTransport.cs
@@ -19,13 +19,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
     internal sealed class SocketTransport : ITransport
     {
-        private const int _numSchedulers = 8;
-
         private readonly MemoryPool<byte> _memoryPool = KestrelMemoryPool.Create();
-        private readonly CoalescingScheduler[] _schedulers = new CoalescingScheduler[_numSchedulers];
         private readonly IEndPointInformation _endPointInformation;
         private readonly IConnectionHandler _handler;
         private readonly IApplicationLifetime _appLifetime;
+        private readonly int _numSchedulers;
+        private readonly CoalescingScheduler[] _schedulers;
         private readonly ISocketsTrace _trace;
         private Socket _listenSocket;
         private Task _listenTask;
@@ -36,6 +35,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             IEndPointInformation endPointInformation,
             IConnectionHandler handler,
             IApplicationLifetime applicationLifetime,
+            int ioLoopCount,
             ISocketsTrace trace)
         {
             Debug.Assert(endPointInformation != null);
@@ -47,7 +47,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             _endPointInformation = endPointInformation;
             _handler = handler;
             _appLifetime = applicationLifetime;
+            _numSchedulers = ioLoopCount;
             _trace = trace;
+
+            _schedulers = new CoalescingScheduler[_numSchedulers];
 
             for (var i = 0; i < _numSchedulers; i++)
             {

--- a/src/Kestrel.Transport.Sockets/SocketTransport.cs
+++ b/src/Kestrel.Transport.Sockets/SocketTransport.cs
@@ -131,32 +131,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         {
             try
             {
-                var nextSchedulerIndex = 0;
-
                 while (true)
                 {
-                    try
+                    for (var schedulerIndex = 0; schedulerIndex < _numSchedulers;  schedulerIndex++)
                     {
-                        var acceptSocket = await _listenSocket.AcceptAsync();
-                        acceptSocket.NoDelay = _endPointInformation.NoDelay;
+                        try
+                        {
+                            var acceptSocket = await _listenSocket.AcceptAsync();
+                            acceptSocket.NoDelay = _endPointInformation.NoDelay;
 
-                        var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers[nextSchedulerIndex], _trace);
-                        _ = connection.StartAsync(_handler);
-                    }
-                    catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
-                    {
-                        // REVIEW: Should there be a seperate log message for a connection reset this early?
-                        _trace.ConnectionReset(connectionId: "(null)");
-                    }
-                    catch (SocketException ex) when (!_unbinding)
-                    {
-                        _trace.ConnectionError(connectionId: "(null)", ex);
-                    }
-
-                    nextSchedulerIndex++;
-                    if (nextSchedulerIndex == _numSchedulers)
-                    {
-                        nextSchedulerIndex = 0;
+                            var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers[schedulerIndex], _trace);
+                            _ = connection.StartAsync(_handler);
+                        }
+                        catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+                        {
+                            // REVIEW: Should there be a seperate log message for a connection reset this early?
+                            _trace.ConnectionReset(connectionId: "(null)");
+                        }
+                        catch (SocketException ex) when (!_unbinding)
+                        {
+                            _trace.ConnectionError(connectionId: "(null)", ex);
+                        }
                     }
                 }
             }

--- a/src/Kestrel.Transport.Sockets/SocketTransportFactory.cs
+++ b/src/Kestrel.Transport.Sockets/SocketTransportFactory.cs
@@ -12,8 +12,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
     public sealed class SocketTransportFactory : ITransportFactory
     {
-        private readonly SocketsTrace _trace;
+        private readonly SocketTransportOptions _options;
         private readonly IApplicationLifetime _appLifetime;
+        private readonly SocketsTrace _trace;
 
         public SocketTransportFactory(
             IOptions<SocketTransportOptions> options,
@@ -33,6 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
+            _options = options.Value;
             _appLifetime = applicationLifetime;
             var logger  = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets");
             _trace = new SocketsTrace(logger);
@@ -55,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            return new SocketTransport(endPointInformation, handler, _appLifetime, _trace);
+            return new SocketTransport(endPointInformation, handler, _appLifetime, _options.IOLoopCountCount, _trace);
         }
     }
 }

--- a/src/Kestrel.Transport.Sockets/SocketTransportFactory.cs
+++ b/src/Kestrel.Transport.Sockets/SocketTransportFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            return new SocketTransport(endPointInformation, handler, _appLifetime, _options.IOLoopCountCount, _trace);
+            return new SocketTransport(endPointInformation, handler, _appLifetime, _options.IOQueueCount, _trace);
         }
     }
 }

--- a/src/Kestrel.Transport.Sockets/SocketTransportOptions.cs
+++ b/src/Kestrel.Transport.Sockets/SocketTransportOptions.cs
@@ -1,12 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
-    // TODO: Come up with some options
     public class SocketTransportOptions
     {
-
+        /// <summary>
+        /// The number of I/O loops used to process requests.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to half of <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
+        /// </remarks>
+        //public int IOLoopCountCount { get; set; } = ProcessorThreadCount;
+        public int IOLoopCountCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
     }
 }

--- a/src/Kestrel.Transport.Sockets/SocketTransportOptions.cs
+++ b/src/Kestrel.Transport.Sockets/SocketTransportOptions.cs
@@ -8,12 +8,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
     public class SocketTransportOptions
     {
         /// <summary>
-        /// The number of I/O loops used to process requests.
+        /// The number of I/O queues used to process requests. Set to 0 to directly schedule I/O to the ThreadPool.
         /// </summary>
         /// <remarks>
-        /// Defaults to half of <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
+        /// Defaults to <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
         /// </remarks>
-        //public int IOLoopCountCount { get; set; } = ProcessorThreadCount;
-        public int IOLoopCountCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
+        public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
     }
 }


### PR DESCRIPTION
Inspired by #2366. Looks like it might be a small improvement. We'll need to test more scenarios.

## Json Windows

### Libuv

```
[03:23:17.655] RequestsPerSecond:           452637
[03:23:17.656] Latency on load (ms):        0.7
[03:23:17.656] Max CPU (%):                 85
[03:23:17.656] WorkingSet (MB):             386
[03:23:17.656] Startup Main (ms):           419
[03:23:17.656] First Request (ms):          232.8
[03:23:17.657] Latency (ms):                0.8
[03:23:17.657] Socket Errors:               0
[03:23:17.657] Bad Responses:               0
[03:23:17.657] SDK:                         2.2.0-preview1-007522
[03:23:17.657] Runtime:                     2.1.0-preview2-26225-03
[03:23:17.657] ASP.NET Core:                2.1.0-preview2-30256
```

### Sockets

#### Before

```
[03:21:06.064] RequestsPerSecond:           287068
[03:21:06.065] Latency on load (ms):        3
[03:21:06.065] Max CPU (%):                 84
[03:21:06.065] WorkingSet (MB):             360
[03:21:06.065] Startup Main (ms):           382
[03:21:06.065] First Request (ms):          228.6
[03:21:06.066] Latency (ms):                0.7
[03:21:06.066] Socket Errors:               0
[03:21:06.066] Bad Responses:               0
[03:21:06.066] SDK:                         2.2.0-preview1-007522
[03:21:06.066] Runtime:                     2.1.0-preview2-26225-03
[03:21:06.066] ASP.NET Core:                2.1.0-preview2-30255
```

#### #2366

```
[03:18:42.707] RequestsPerSecond:           342340
[03:18:42.707] Latency on load (ms):        1.4
[03:18:42.708] Max CPU (%):                 85
[03:18:42.708] WorkingSet (MB):             363
[03:18:42.708] Startup Main (ms):           376
[03:18:42.708] First Request (ms):          228.9
[03:18:42.708] Latency (ms):                0.8
[03:18:42.708] Socket Errors:               0
[03:18:42.708] Bad Responses:               0
[03:18:42.708] SDK:                         2.2.0-preview1-007522
[03:18:42.708] Runtime:                     2.1.0-preview2-26225-03
[03:18:42.708] ASP.NET Core:                2.1.0-preview2-30255
```

#### After

```
[03:19:41.107] RequestsPerSecond:           376305
[03:19:41.107] Latency on load (ms):        0.8
[03:19:41.107] Max CPU (%):                 82
[03:19:41.107] WorkingSet (MB):             368
[03:19:41.108] Startup Main (ms):           389
[03:19:41.108] First Request (ms):          230.1
[03:19:41.108] Latency (ms):                0.9
[03:19:41.108] Socket Errors:               0
[03:19:41.108] Bad Responses:               0
[03:19:41.108] SDK:                         2.2.0-preview1-007522
[03:19:41.108] Runtime:                     2.1.0-preview2-26225-03
[03:19:41.108] ASP.NET Core:                2.1.0-preview2-30255
```