### PR TITLE
Reduce Sockets mainloop Send/Receive statemachine size

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -240,13 +240,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                     break;
                 }
 
+                var end = buffer.End;
+                var isCompleted = result.IsCompleted;
                 if (!buffer.IsEmpty)
                 {
-                    var end = buffer.End;
                     await _sender.SendAsync(buffer);
-                    Output.AdvanceTo(end);
                 }
-                else if (result.IsCompleted)
+
+                Output.AdvanceTo(end);
+
+                if (isCompleted)
                 {
                     break;
                 }


### PR DESCRIPTION
Removed from sending statemachine struct 16+16+16+16+8+8 = 80 bytes (5 object refs)
Added to sending statemachine struct 16+8 = 24 bytes (1 object ref)

So 56 byte reduction overall and 4 object refs (slower copies) removed.

Similar to https://github.com/aspnet/KestrelHttpServer/pull/2313


### Before

DoSend.MoveNext is **4 `.try`s deep** in il

![image](https://user-images.githubusercontent.com/1142958/37270756-624540da-25a6-11e8-8524-f39d7d3bb1ce.png)

### After

ProcessSends.MoveNext is **1 `.try`s deep** in il


Removed (larger due to padding/alignment): 
* `ReadResult { ReadOnlySequence { 2 x SequencePosition { object, int } }, bool }`
* `ReadOnlySequence { 2 x SequencePosition { object, int } }`
* `Exception`

Added
* `SequencePosition { object, int }`
* `bool`

![image](https://user-images.githubusercontent.com/1142958/37273984-be2e7aaa-25b1-11e8-8729-b3a09480dbdf.png)
