### PR TITLE
Clean up protocol abstractions

### DIFF
--- a/src/Kestrel.Core/Internal/ConnectionHandler.cs
+++ b/src/Kestrel.Core/Internal/ConnectionHandler.cs
@@ -28,31 +28,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         private IKestrelTrace Log => _serviceContext.Log;
 
-        public void OnConnection(IFeatureCollection features)
+        public void OnConnection(TransportConnection connection)
         {
-            var connectionContext = new DefaultConnectionContext(features);
-
-            var applicationFeature = connectionContext.Features.Get<IApplicationTransportFeature>();
-            var memoryPoolFeature = connectionContext.Features.Get<IMemoryPoolFeature>();
-            var schedulingFeatue = connectionContext.Features.Get<ITransportSchedulerFeature>();
-
             // REVIEW: Unfortunately, we still need to use the service context to create the pipes since the settings
             // for the scheduler and limits are specified here
-            var inputOptions = GetInputPipeOptions(_serviceContext, memoryPoolFeature.MemoryPool, schedulingFeatue.InputWriterScheduler);
-            var outputOptions = GetOutputPipeOptions(_serviceContext, memoryPoolFeature.MemoryPool, schedulingFeatue.OutputReaderScheduler);
+            var inputOptions = GetInputPipeOptions(_serviceContext, connection.MemoryPool, connection.InputWriterScheduler);
+            var outputOptions = GetOutputPipeOptions(_serviceContext, connection.MemoryPool, connection.OutputReaderScheduler);
 
             var pair = DuplexPipe.CreateConnectionPair(inputOptions, outputOptions);
 
             // Set the transport and connection id
-            connectionContext.ConnectionId = CorrelationIdGenerator.GetNextId();
-            connectionContext.Transport = pair.Transport;
+            connection.ConnectionId = CorrelationIdGenerator.GetNextId();
+            connection.Transport = pair.Transport;
 
             // This *must* be set before returning from OnConnection
-            applicationFeature.Application = pair.Application;
+            connection.Application = pair.Application;
 
             // REVIEW: This task should be tracked by the server for graceful shutdown
             // Today it's handled specifically for http but not for aribitrary middleware
-            _ = Execute(connectionContext);
+            _ = Execute(new DefaultConnectionContext(connection));
         }
 
         private async Task Execute(ConnectionContext connectionContext)

--- a/src/Kestrel.Core/Internal/ConnectionHandler.cs
+++ b/src/Kestrel.Core/Internal/ConnectionHandler.cs
@@ -32,12 +32,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         {
             var connectionContext = new DefaultConnectionContext(features);
 
-            var transportFeature = connectionContext.Features.Get<IConnectionTransportFeature>();
+            var applicationFeature = connectionContext.Features.Get<IApplicationTransportFeature>();
+            var memoryPoolFeature = connectionContext.Features.Get<IMemoryPoolFeature>();
+            var schedulingFeatue = connectionContext.Features.Get<ITransportSchedulerFeature>();
 
             // REVIEW: Unfortunately, we still need to use the service context to create the pipes since the settings
             // for the scheduler and limits are specified here
-            var inputOptions = GetInputPipeOptions(_serviceContext, transportFeature.MemoryPool, transportFeature.InputWriterScheduler);
-            var outputOptions = GetOutputPipeOptions(_serviceContext, transportFeature.MemoryPool, transportFeature.OutputReaderScheduler);
+            var inputOptions = GetInputPipeOptions(_serviceContext, memoryPoolFeature.MemoryPool, schedulingFeatue.InputWriterScheduler);
+            var outputOptions = GetOutputPipeOptions(_serviceContext, memoryPoolFeature.MemoryPool, schedulingFeatue.OutputReaderScheduler);
 
             var pair = DuplexPipe.CreateConnectionPair(inputOptions, outputOptions);
 
@@ -46,7 +48,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             connectionContext.Transport = pair.Transport;
 
             // This *must* be set before returning from OnConnection
-            transportFeature.Application = pair.Application;
+            applicationFeature.Application = pair.Application;
 
             // REVIEW: This task should be tracked by the server for graceful shutdown
             // Today it's handled specifically for http but not for aribitrary middleware

--- a/src/Kestrel.Core/Internal/HttpConnectionMiddleware.cs
+++ b/src/Kestrel.Core/Internal/HttpConnectionMiddleware.cs
@@ -33,7 +33,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         {
             // We need the transport feature so that we can cancel the output reader that the transport is using
             // This is a bit of a hack but it preserves the existing semantics
-            var transportFeature = connectionContext.Features.Get<IConnectionTransportFeature>();
+            var applicationFeature = connectionContext.Features.Get<IApplicationTransportFeature>();
+            var memoryPoolFeature = connectionContext.Features.Get<IMemoryPoolFeature>();
 
             var httpConnectionId = Interlocked.Increment(ref _lastHttpConnectionId);
 
@@ -44,10 +45,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 Protocols = _protocols,
                 ServiceContext = _serviceContext,
                 ConnectionFeatures = connectionContext.Features,
-                MemoryPool = transportFeature.MemoryPool,
+                MemoryPool = memoryPoolFeature.MemoryPool,
                 ConnectionAdapters = _connectionAdapters,
                 Transport = connectionContext.Transport,
-                Application = transportFeature.Application
+                Application = applicationFeature.Application
             };
 
             var connectionFeature = connectionContext.Features.Get<IHttpConnectionFeature>();

--- a/src/Kestrel.Transport.Abstractions/Internal/IConnectionHandler.cs
+++ b/src/Kestrel.Transport.Abstractions/Internal/IConnectionHandler.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
 {
     public interface IConnectionHandler
     {
-        void OnConnection(IFeatureCollection features);
+        void OnConnection(TransportConnection connection);
     }
 }

--- a/src/Kestrel.Transport.Abstractions/Internal/TransportConnection.cs
+++ b/src/Kestrel.Transport.Abstractions/Internal/TransportConnection.cs
@@ -12,6 +12,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             _currentIConnectionIdFeature = this;
             _currentIConnectionTransportFeature = this;
             _currentIHttpConnectionFeature = this;
+            _currentIApplicationTransportFeature = this;
+            _currentIMemoryPoolFeature = this;
+            _currentITransportSchedulerFeature = this;
         }
 
         public IPAddress RemoteAddress { get; set; }

--- a/src/Protocols.Abstractions/ConnectionBuilderExtensions.cs
+++ b/src/Protocols.Abstractions/ConnectionBuilderExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Protocols
+{
+    public static class ConnectionBuilderExtensions
+    {
+        public static IConnectionBuilder Use(this IConnectionBuilder connectionBuilder, Func<ConnectionContext, Func<Task>, Task> middleware)
+        {
+            return connectionBuilder.Use(next =>
+            {
+                return context =>
+                {
+                    Func<Task> simpleNext = () => next(context);
+                    return middleware(context, simpleNext);
+                };
+            });
+        }
+
+        public static IConnectionBuilder Run(this IConnectionBuilder connectionBuilder, Func<ConnectionContext, Task> middleware)
+        {
+            return connectionBuilder.Use(next =>
+            {
+                return context =>
+                {
+                    return middleware(context);
+                };
+            });
+        }
+    }
+}

--- a/src/Protocols.Abstractions/DuplexPipe.cs
+++ b/src/Protocols.Abstractions/DuplexPipe.cs
@@ -14,10 +14,6 @@ namespace System.IO.Pipelines
 
         public PipeWriter Output { get; }
 
-        public void Dispose()
-        {
-        }
-
         public static DuplexPipePair CreateConnectionPair(PipeOptions inputOptions, PipeOptions outputOptions)
         {
             var input = new Pipe(inputOptions);

--- a/src/Protocols.Abstractions/Features/ConnectionBuilder.cs
+++ b/src/Protocols.Abstractions/Features/ConnectionBuilder.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Protocols
+{
+    public class ConnectionBuilder : IConnectionBuilder
+    {
+        private readonly IList<Func<ConnectionDelegate, ConnectionDelegate>> _components = new List<Func<ConnectionDelegate, ConnectionDelegate>>();
+
+        public IServiceProvider ApplicationServices { get; }
+
+        public ConnectionBuilder(IServiceProvider applicationServices)
+        {
+            ApplicationServices = applicationServices;
+        }
+
+        public IConnectionBuilder Use(Func<ConnectionDelegate, ConnectionDelegate> middleware)
+        {
+            _components.Add(middleware);
+            return this;
+        }
+
+        public ConnectionDelegate Build()
+        {
+            ConnectionDelegate app = features =>
+            {
+                return Task.CompletedTask;
+            };
+
+            foreach (var component in _components.Reverse())
+            {
+                app = component(app);
+            }
+
+            return app;
+        }
+    }
+}

--- a/src/Protocols.Abstractions/Features/IApplicationTransportFeature.cs
+++ b/src/Protocols.Abstractions/Features/IApplicationTransportFeature.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
@@ -7,8 +7,8 @@ using System.Threading;
 
 namespace Microsoft.AspNetCore.Protocols.Features
 {
-    public interface IConnectionTransportFeature
+    public interface IApplicationTransportFeature
     {
-        IDuplexPipe Transport { get; set; }
+        IDuplexPipe Application { get; set; }
     }
 }

--- a/src/Protocols.Abstractions/Features/IConnectionHeartbeatFeature.cs
+++ b/src/Protocols.Abstractions/Features/IConnectionHeartbeatFeature.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Protocols.Features
+{
+    public interface IConnectionHeartbeatFeature
+    {
+        void OnHeartbeat(Action<object> action, object state);
+    }
+}

--- a/src/Protocols.Abstractions/Features/IConnectionIdFeature.cs
+++ b/src/Protocols.Abstractions/Features/IConnectionIdFeature.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Protocols.Features
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Protocols.Features
 {
     public interface IConnectionIdFeature
     {

--- a/src/Protocols.Abstractions/Features/IConnectionInherentKeepAliveFeature.cs
+++ b/src/Protocols.Abstractions/Features/IConnectionInherentKeepAliveFeature.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Protocols.Features
+{
+    /// <summary>
+    /// Indicates if the connection transport has an "inherent keep-alive", which means that the transport will automatically
+    /// inform the client that it is still present.
+    /// </summary>
+    /// <remarks>
+    /// The most common example of this feature is the Long Polling HTTP transport, which must (due to HTTP limitations) terminate
+    /// each poll within a particular interval and return a signal indicating "the server is still here, but there is no data yet".
+    /// This feature allows applications to add keep-alive functionality, but limit it only to transports that don't have some kind
+    /// of inherent keep-alive.
+    /// </remarks>
+    public interface IConnectionInherentKeepAliveFeature
+    {
+        TimeSpan KeepAliveInterval { get; }
+    }
+}

--- a/src/Protocols.Abstractions/Features/IConnectionMetadataFeature.cs
+++ b/src/Protocols.Abstractions/Features/IConnectionMetadataFeature.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Protocols.Features
+{
+    public interface IConnectionMetadataFeature
+    {
+        IDictionary<object, object> Metadata { get; set; }
+    }
+}

--- a/src/Protocols.Abstractions/Features/IConnectionUserFeature.cs
+++ b/src/Protocols.Abstractions/Features/IConnectionUserFeature.cs
@@ -1,0 +1,9 @@
+using System.Security.Claims;
+
+namespace Microsoft.AspNetCore.Protocols.Features
+{
+    public interface IConnectionUserFeature
+    {
+        ClaimsPrincipal User { get; set; }
+    }
+}

--- a/src/Protocols.Abstractions/Features/IMemoryPoolFeature.cs
+++ b/src/Protocols.Abstractions/Features/IMemoryPoolFeature.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
@@ -7,8 +7,8 @@ using System.Threading;
 
 namespace Microsoft.AspNetCore.Protocols.Features
 {
-    public interface IConnectionTransportFeature
+    public interface IMemoryPoolFeature
     {
-        IDuplexPipe Transport { get; set; }
+        MemoryPool<byte> MemoryPool { get; }
     }
 }

--- a/src/Protocols.Abstractions/Features/ITransportSchedulerFeature.cs
+++ b/src/Protocols.Abstractions/Features/ITransportSchedulerFeature.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
@@ -7,8 +7,10 @@ using System.Threading;
 
 namespace Microsoft.AspNetCore.Protocols.Features
 {
-    public interface IConnectionTransportFeature
+    public interface ITransportSchedulerFeature
     {
-        IDuplexPipe Transport { get; set; }
+        PipeScheduler InputWriterScheduler { get; }
+
+        PipeScheduler OutputReaderScheduler { get; }
     }
 }

--- a/test/Kestrel.Core.Tests/ConnectionHandlerTests.cs
+++ b/test/Kestrel.Core.Tests/ConnectionHandlerTests.cs
@@ -45,12 +45,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(((TestKestrelTrace)serviceContext.Log).Logger.Scopes.IsEmpty);
         }
 
-        private class TestConnection : FeatureCollection, IConnectionIdFeature, IConnectionTransportFeature
+        private class TestConnection : FeatureCollection,
+                                       IConnectionIdFeature,
+                                       IConnectionTransportFeature,
+                                       IApplicationTransportFeature,
+                                       IMemoryPoolFeature,
+                                       ITransportSchedulerFeature
         {
             public TestConnection()
             {
                 Set<IConnectionIdFeature>(this);
                 Set<IConnectionTransportFeature>(this);
+                Set<IApplicationTransportFeature>(this);
+                Set<IMemoryPoolFeature>(this);
+                Set<ITransportSchedulerFeature>(this);
             }
 
             public MemoryPool<byte> MemoryPool { get; } = KestrelMemoryPool.Create();

--- a/test/Kestrel.Core.Tests/ConnectionHandlerTests.cs
+++ b/test/Kestrel.Core.Tests/ConnectionHandlerTests.cs
@@ -45,32 +45,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(((TestKestrelTrace)serviceContext.Log).Logger.Scopes.IsEmpty);
         }
 
-        private class TestConnection : FeatureCollection,
-                                       IConnectionIdFeature,
-                                       IConnectionTransportFeature,
-                                       IApplicationTransportFeature,
-                                       IMemoryPoolFeature,
-                                       ITransportSchedulerFeature
+        private class TestConnection : TransportConnection
         {
-            public TestConnection()
-            {
-                Set<IConnectionIdFeature>(this);
-                Set<IConnectionTransportFeature>(this);
-                Set<IApplicationTransportFeature>(this);
-                Set<IMemoryPoolFeature>(this);
-                Set<ITransportSchedulerFeature>(this);
-            }
+            public override MemoryPool<byte> MemoryPool { get; } = KestrelMemoryPool.Create();
 
-            public MemoryPool<byte> MemoryPool { get; } = KestrelMemoryPool.Create();
+            public override PipeScheduler InputWriterScheduler => PipeScheduler.ThreadPool;
 
-            public IDuplexPipe Transport { get; set; }
-            public IDuplexPipe Application { get; set; }
-
-            public PipeScheduler InputWriterScheduler => PipeScheduler.ThreadPool;
-
-            public PipeScheduler OutputReaderScheduler => PipeScheduler.ThreadPool;
-
-            public string ConnectionId { get; set; }
+            public override PipeScheduler OutputReaderScheduler => PipeScheduler.ThreadPool;
         }
     }
 }

--- a/test/Kestrel.Transport.Libuv.Tests/TestHelpers/MockConnectionHandler.cs
+++ b/test/Kestrel.Transport.Libuv.Tests/TestHelpers/MockConnectionHandler.cs
@@ -20,13 +20,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.TestHelpers
         {
             var connectionContext = new DefaultConnectionContext(features);
 
-            var feature = connectionContext.Features.Get<IConnectionTransportFeature>();
+            var applicationFeature = connectionContext.Features.Get<IApplicationTransportFeature>();
+            var memoryPoolFeature = connectionContext.Features.Get<IMemoryPoolFeature>();
 
-            Input = new Pipe(InputOptions(feature.MemoryPool));
-            Output = new Pipe(OutputOptions(feature.MemoryPool));
+            Input = new Pipe(InputOptions(memoryPoolFeature.MemoryPool));
+            Output = new Pipe(OutputOptions(memoryPoolFeature.MemoryPool));
 
             connectionContext.Transport = new DuplexPipe(Input.Reader, Output.Writer);
-            feature.Application = new DuplexPipe(Output.Reader, Input.Writer);
+            applicationFeature.Application = new DuplexPipe(Output.Reader, Input.Writer);
         }
 
         public Pipe Input { get; private set; }


### PR DESCRIPTION
- This change aims to clean up the feature interfaces
 used by kestrel and exposed by protocol absractions. It splits out the
 IConnectionTransportFeature into smaller features that may or may
 not be implemented on the connection.
- Added all of the features from Socket.Abstractions
in an attempt to make it go away completely. As a result
the helper methods and extensions have all been added here.