### PR TITLE
Added transfer format to Protocol.Abstractions

### DIFF
--- a/src/Protocols.Abstractions/Features/ITransferFormatFeature.cs
+++ b/src/Protocols.Abstractions/Features/ITransferFormatFeature.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Protocols.Features
+{
+    public interface ITransferFormatFeature
+    {
+        TransferFormat SupportedFormats { get; }
+        TransferFormat ActiveFormat { get; set; }
+    }
+}

--- a/src/Protocols.Abstractions/TransferFormat.cs
+++ b/src/Protocols.Abstractions/TransferFormat.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Protocols
+{
+    [Flags]
+    public enum TransferFormat
+    {
+        Binary = 0x01,
+        Text = 0x02
+    }
+}


### PR DESCRIPTION
For transports that let to choose the mode (binary or text) and ones that only support either (like server sent events only supports text).