### PR TITLE
Metadata is now a first class property on ConnectionContext

### DIFF
--- a/src/Kestrel.Transport.Abstractions/Internal/ConnectionMetadata.cs
+++ b/src/Kestrel.Transport.Abstractions/Internal/ConnectionMetadata.cs
@@ -1,0 +1,118 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
+{
+    internal class ConnectionMetadata : IDictionary<object, object>
+    {
+        public ConnectionMetadata()
+            : this(new Dictionary<object, object>())
+        {
+        }
+
+        public ConnectionMetadata(IDictionary<object, object> items)
+        {
+            Items = items;
+        }
+
+        public IDictionary<object, object> Items { get; }
+
+        // Replace the indexer with one that returns null for missing values
+        object IDictionary<object, object>.this[object key]
+        {
+            get
+            {
+                if (Items.TryGetValue(key, out var value))
+                {
+                    return value;
+                }
+                return null;
+            }
+            set { Items[key] = value; }
+        }
+
+        void IDictionary<object, object>.Add(object key, object value)
+        {
+            Items.Add(key, value);
+        }
+
+        bool IDictionary<object, object>.ContainsKey(object key)
+        {
+            return Items.ContainsKey(key);
+        }
+
+        ICollection<object> IDictionary<object, object>.Keys
+        {
+            get { return Items.Keys; }
+        }
+
+        bool IDictionary<object, object>.Remove(object key)
+        {
+            return Items.Remove(key);
+        }
+
+        bool IDictionary<object, object>.TryGetValue(object key, out object value)
+        {
+            return Items.TryGetValue(key, out value);
+        }
+
+        ICollection<object> IDictionary<object, object>.Values
+        {
+            get { return Items.Values; }
+        }
+
+        void ICollection<KeyValuePair<object, object>>.Add(KeyValuePair<object, object> item)
+        {
+            Items.Add(item);
+        }
+
+        void ICollection<KeyValuePair<object, object>>.Clear()
+        {
+            Items.Clear();
+        }
+
+        bool ICollection<KeyValuePair<object, object>>.Contains(KeyValuePair<object, object> item)
+        {
+            return Items.Contains(item);
+        }
+
+        void ICollection<KeyValuePair<object, object>>.CopyTo(KeyValuePair<object, object>[] array, int arrayIndex)
+        {
+            Items.CopyTo(array, arrayIndex);
+        }
+
+        int ICollection<KeyValuePair<object, object>>.Count
+        {
+            get { return Items.Count; }
+        }
+
+        bool ICollection<KeyValuePair<object, object>>.IsReadOnly
+        {
+            get { return Items.IsReadOnly; }
+        }
+
+        bool ICollection<KeyValuePair<object, object>>.Remove(KeyValuePair<object, object> item)
+        {
+            object value;
+            if (Items.TryGetValue(item.Key, out value) && Equals(item.Value, value))
+            {
+                return Items.Remove(item.Key);
+            }
+            return false;
+        }
+
+        IEnumerator<KeyValuePair<object, object>> IEnumerable<KeyValuePair<object, object>>.GetEnumerator()
+        {
+            return Items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return Items.GetEnumerator();
+        }
+    }
+}

--- a/src/Kestrel.Transport.Abstractions/Internal/TransportConnection.Features.cs
+++ b/src/Kestrel.Transport.Abstractions/Internal/TransportConnection.Features.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
                                                IHttpConnectionFeature,
                                                IConnectionIdFeature,
                                                IConnectionTransportFeature,
+                                               IConnectionMetadataFeature,
                                                IMemoryPoolFeature,
                                                IApplicationTransportFeature,
                                                ITransportSchedulerFeature
@@ -20,6 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         private static readonly Type IHttpConnectionFeatureType = typeof(IHttpConnectionFeature);
         private static readonly Type IConnectionIdFeatureType = typeof(IConnectionIdFeature);
         private static readonly Type IConnectionTransportFeatureType = typeof(IConnectionTransportFeature);
+        private static readonly Type IConnectionMetadataFeatureType = typeof(IConnectionMetadataFeature);
         private static readonly Type IMemoryPoolFeatureType = typeof(IMemoryPoolFeature);
         private static readonly Type IApplicationTransportFeatureType = typeof(IApplicationTransportFeature);
         private static readonly Type ITransportSchedulerFeatureType = typeof(ITransportSchedulerFeature);
@@ -27,6 +29,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
         private object _currentIHttpConnectionFeature;
         private object _currentIConnectionIdFeature;
         private object _currentIConnectionTransportFeature;
+        private object _currentIConnectionMetadataFeature;
         private object _currentIMemoryPoolFeature;
         private object _currentIApplicationTransportFeature;
         private object _currentITransportSchedulerFeature;
@@ -118,6 +121,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             set => Application = value;
         }
 
+        IDictionary<object, object> IConnectionMetadataFeature.Metadata
+        {
+            get => Metadata;
+            set => Metadata = value;
+        }
+
         PipeScheduler ITransportSchedulerFeature.InputWriterScheduler => InputWriterScheduler;
         PipeScheduler ITransportSchedulerFeature.OutputReaderScheduler => OutputReaderScheduler;
 
@@ -138,6 +147,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
                 if (key == IConnectionTransportFeatureType)
                 {
                     return _currentIConnectionTransportFeature;
+                }
+
+                if (key == IConnectionMetadataFeatureType)
+                {
+                    return _currentIConnectionMetadataFeature;
                 }
 
                 if (key == IMemoryPoolFeatureType)
@@ -178,6 +192,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
                 {
                     _currentIConnectionTransportFeature = value;
                 }
+                else if (key == IConnectionMetadataFeatureType)
+                {
+                    _currentIConnectionMetadataFeature = value;
+                }
                 else if (key == IMemoryPoolFeatureType)
                 {
                     _currentIMemoryPoolFeature = value;
@@ -210,6 +228,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             else if (typeof(TFeature) == typeof(IConnectionTransportFeature))
             {
                 return (TFeature)_currentIConnectionTransportFeature;
+            }
+            else if (typeof(TFeature) == typeof(IConnectionMetadataFeature))
+            {
+                return (TFeature)_currentIConnectionMetadataFeature;
             }
             else if (typeof(TFeature) == typeof(IMemoryPoolFeature))
             {
@@ -246,6 +268,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             else if (typeof(TFeature) == typeof(IConnectionTransportFeature))
             {
                 _currentIConnectionTransportFeature = instance;
+            }
+            else if (typeof(TFeature) == typeof(IConnectionMetadataFeature))
+            {
+                _currentIConnectionMetadataFeature = instance;
             }
             else if (typeof(TFeature) == typeof(IMemoryPoolFeature))
             {
@@ -284,6 +310,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
             if (_currentIConnectionTransportFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(IConnectionTransportFeatureType, _currentIConnectionTransportFeature);
+            }
+
+            if (_currentIConnectionMetadataFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(IConnectionMetadataFeatureType, _currentIConnectionMetadataFeature);
             }
 
             if (_currentIMemoryPoolFeature != null)

--- a/src/Kestrel.Transport.Abstractions/Internal/TransportConnection.cs
+++ b/src/Kestrel.Transport.Abstractions/Internal/TransportConnection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers;
+using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Net;
 using System.Threading;
@@ -7,11 +8,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
 {
     public abstract partial class TransportConnection
     {
+        private IDictionary<object, object> _metadata;
+
         public TransportConnection()
         {
             _currentIConnectionIdFeature = this;
             _currentIConnectionTransportFeature = this;
             _currentIHttpConnectionFeature = this;
+            _currentIConnectionMetadataFeature = this;
             _currentIApplicationTransportFeature = this;
             _currentIMemoryPoolFeature = this;
             _currentITransportSchedulerFeature = this;
@@ -30,6 +34,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
 
         public IDuplexPipe Transport { get; set; }
         public IDuplexPipe Application { get; set; }
+
+        public IDictionary<object, object> Metadata
+        {
+            get
+            {
+                // Lazily allocate connection metadata
+                return _metadata ?? (_metadata = new ConnectionMetadata());
+            }
+            set
+            {
+                _metadata = value;
+            }
+        }
 
         public PipeWriter Input => Application.Output;
         public PipeReader Output => Application.Input;

--- a/src/Protocols.Abstractions/ConnectionContext.cs
+++ b/src/Protocols.Abstractions/ConnectionContext.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Pipelines;
+﻿using System.Collections.Generic;
+using System.IO.Pipelines;
 using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Protocols
@@ -8,6 +9,8 @@ namespace Microsoft.AspNetCore.Protocols
         public abstract string ConnectionId { get; set; }
 
         public abstract IFeatureCollection Features { get; }
+
+        public abstract IDictionary<object, object> Metadata { get; set; }
 
         public abstract IDuplexPipe Transport { get; set; }
     }

--- a/src/Protocols.Abstractions/DefaultConnectionContext.cs
+++ b/src/Protocols.Abstractions/DefaultConnectionContext.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Pipelines;
+﻿using System.Collections.Generic;
+using System.IO.Pipelines;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Protocols.Features;
 
@@ -19,6 +20,9 @@ namespace Microsoft.AspNetCore.Protocols
         private IConnectionTransportFeature ConnectionTransportFeature =>
             _features.Fetch(ref _features.Cache.ConnectionTransport, _ => null);
 
+        private IConnectionMetadataFeature ConnectionMetadataFeature =>
+            _features.Fetch(ref _features.Cache.ConnectionMetadata, _ => null);
+
         public override string ConnectionId
         {
             get => ConnectionIdFeature.ConnectionId;
@@ -33,11 +37,19 @@ namespace Microsoft.AspNetCore.Protocols
             set => ConnectionTransportFeature.Transport = value;
         }
 
+        public override IDictionary<object, object> Metadata
+        {
+            get => ConnectionMetadataFeature.Metadata;
+            set => ConnectionMetadataFeature.Metadata = value;
+        }
+
         struct FeatureInterfaces
         {
             public IConnectionIdFeature ConnectionId;
 
             public IConnectionTransportFeature ConnectionTransport;
+
+            public IConnectionMetadataFeature ConnectionMetadata;
         }
     }
 }


### PR DESCRIPTION
- Make IConnectionMetadata a manatory top level feature on ConnectionContext
- TransportConnection will lazily manifest ConnectionMetadata on first access.
This should avoid allocations since Kestrel isn't using this today.

This basically exposes an Items property like what exists on HttpContext, it's extremely useful to round trip arbitrary state per connection from various actors in a system.