### PR TITLE
Remove dotnet tool install from instructions on using dotnet-dev-certs

### DIFF
--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -491,7 +491,7 @@
   </data>
   <data name="NoCertSpecifiedNoDevelopmentCertificateFound" xml:space="preserve">
     <value>Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found.
-To install the developer certificate first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet-dev-certs https --trust'.
+To generate a developer certificate run 'dotnet dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</value>
   </data>
   <data name="MultipleCertificateSources" xml:space="preserve">

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -1748,7 +1748,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
         /// <summary>
         /// Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found.
-        /// To install the developer certificate first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet-dev-certs https --trust'.
+        /// To generate a developer certificate run 'dotnet dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
         /// For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
         /// </summary>
         internal static string NoCertSpecifiedNoDevelopmentCertificateFound
@@ -1758,7 +1758,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
         /// <summary>
         /// Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found.
-        /// To install the developer certificate first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet-dev-certs https --trust'.
+        /// To generate a developer certificate run 'dotnet dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
         /// For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
         /// </summary>
         internal static string FormatNoCertSpecifiedNoDevelopmentCertificateFound()


### PR DESCRIPTION
This tool ships in-box, so the error message shouldn't instruct users to install it separately.