### PR TITLE
Add IConnection to Connections.Abstractions

### DIFF
--- a/src/Connections.Abstractions/IConnection.cs
+++ b/src/Connections.Abstractions/IConnection.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Connections
+{
+    public interface IConnection
+    {
+        IDuplexPipe Transport { get; }
+        IFeatureCollection Features { get; }
+
+        Task StartAsync();
+        Task StartAsync(TransferFormat transferFormat);
+        Task DisposeAsync();
+    }
+}


### PR DESCRIPTION
The end goal for 2.1 will be to merge `IConnection` and `ConnectionContext`, in the short term, we want to move this to a shipping assembly so that we can delete sockets.abstractions.