### PR TITLE
 Fixed a parser bug found when trying out the array pool

### DIFF
--- a/src/Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpParser.cs
@@ -213,12 +213,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             var index = reader.CurrentSegmentIndex;
                             int ch1;
                             int ch2;
+                            var needAdvance = false;
 
                             // Fast path, we're still looking at the same span
                             if (remaining >= 2)
                             {
                                 ch1 = pBuffer[index];
                                 ch2 = pBuffer[index + 1];
+
+                                needAdvance = true;
                             }
                             else
                             {
@@ -244,7 +247,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                                 {
                                     // If we got 2 bytes from the span directly so skip ahead 2 so that
                                     // the reader's state matches what we expect
-                                    if (index == reader.CurrentSegmentIndex)
+                                    if (needAdvance)
                                     {
                                         reader.Advance(2);
                                     }

--- a/src/Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpParser.cs
@@ -213,15 +213,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             var index = reader.CurrentSegmentIndex;
                             int ch1;
                             int ch2;
-                            var needAdvance = false;
+                            var readAhead = false;
 
                             // Fast path, we're still looking at the same span
                             if (remaining >= 2)
                             {
                                 ch1 = pBuffer[index];
                                 ch2 = pBuffer[index + 1];
-
-                                needAdvance = true;
                             }
                             else
                             {
@@ -232,6 +230,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                                 // Possibly split across spans
                                 ch1 = reader.Read();
                                 ch2 = reader.Read();
+
+                                readAhead = true;
                             }
 
                             if (ch1 == ByteCR)
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                                 {
                                     // If we got 2 bytes from the span directly so skip ahead 2 so that
                                     // the reader's state matches what we expect
-                                    if (needAdvance)
+                                    if (!readAhead)
                                     {
                                         reader.Advance(2);
                                     }
@@ -262,7 +262,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                             // We moved the reader so look ahead 2 bytes so reset both the reader
                             // and the index
-                            if (index != reader.CurrentSegmentIndex)
+                            if (readAhead)
                             {
                                 reader = start;
                                 index = reader.CurrentSegmentIndex;

--- a/test/Kestrel.Core.Tests/HttpParserTests.cs
+++ b/test/Kestrel.Core.Tests/HttpParserTests.cs
@@ -386,6 +386,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(buffer.End, examined);
         }
 
+        [Fact]
+        public void ParseHeadersWithGratuitouslySplitBuffers()
+        {
+            var parser = CreateParser(_nullTrace);
+            var buffer = ReadOnlySequenceFactory.CreateSegments(
+                Encoding.ASCII.GetBytes("Host:\r\nConnecti"),
+                Encoding.ASCII.GetBytes("on"),
+                Encoding.ASCII.GetBytes(":"),
+                Encoding.ASCII.GetBytes(" "),
+                Encoding.ASCII.GetBytes("k"),
+                Encoding.ASCII.GetBytes("e"),
+                Encoding.ASCII.GetBytes("e"),
+                Encoding.ASCII.GetBytes("p"),
+                Encoding.ASCII.GetBytes("-"),
+                Encoding.ASCII.GetBytes("a"),
+                Encoding.ASCII.GetBytes("l"),
+                Encoding.ASCII.GetBytes("i"),
+                Encoding.ASCII.GetBytes("v"),
+                Encoding.ASCII.GetBytes("e"),
+                Encoding.ASCII.GetBytes("\r"),
+                Encoding.ASCII.GetBytes("\n\r"),
+                Encoding.ASCII.GetBytes("\n"));
+
+            var requestHandler = new RequestHandler();
+            var result = parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out _);
+
+            Assert.True(result);
+        }
+
         private void VerifyHeader(
             string headerName,
             string rawHeaderValue,

--- a/test/Kestrel.Core.Tests/HttpParserTests.cs
+++ b/test/Kestrel.Core.Tests/HttpParserTests.cs
@@ -27,8 +27,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             string expectedMethod,
             string expectedRawTarget,
             string expectedRawPath,
-// This warns that theory methods should use all of their parameters,
-// but this method is using a shared data collection with Http1ConnectionTests.TakeStartLineSetsHttpProtocolProperties and others.
+            // This warns that theory methods should use all of their parameters,
+            // but this method is using a shared data collection with Http1ConnectionTests.TakeStartLineSetsHttpProtocolProperties and others.
 #pragma warning disable xUnit1026
             string expectedDecodedPath,
             string expectedQueryString,
@@ -390,24 +390,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void ParseHeadersWithGratuitouslySplitBuffers()
         {
             var parser = CreateParser(_nullTrace);
-            var buffer = ReadOnlySequenceFactory.CreateSegments(
-                Encoding.ASCII.GetBytes("Host:\r\nConnecti"),
-                Encoding.ASCII.GetBytes("on"),
-                Encoding.ASCII.GetBytes(":"),
-                Encoding.ASCII.GetBytes(" "),
-                Encoding.ASCII.GetBytes("k"),
-                Encoding.ASCII.GetBytes("e"),
-                Encoding.ASCII.GetBytes("e"),
-                Encoding.ASCII.GetBytes("p"),
-                Encoding.ASCII.GetBytes("-"),
-                Encoding.ASCII.GetBytes("a"),
-                Encoding.ASCII.GetBytes("l"),
-                Encoding.ASCII.GetBytes("i"),
-                Encoding.ASCII.GetBytes("v"),
-                Encoding.ASCII.GetBytes("e"),
-                Encoding.ASCII.GetBytes("\r"),
-                Encoding.ASCII.GetBytes("\n\r"),
-                Encoding.ASCII.GetBytes("\n"));
+            var buffer = BytePerSegmentTestSequenceFactory.Instance.CreateWithContent("Host:\r\nConnection: keep-alive\r\n\r\n");
 
             var requestHandler = new RequestHandler();
             var result = parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out _);
@@ -419,19 +402,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void ParseHeadersWithGratuitouslySplitBuffers2()
         {
             var parser = CreateParser(_nullTrace);
-            var buffer = ReadOnlySequenceFactory.CreateSegments(
-                Encoding.ASCII.GetBytes("A: B"),
-                Encoding.ASCII.GetBytes("\r"),
-                Encoding.ASCII.GetBytes("\n"),
-                Encoding.ASCII.GetBytes("B"),
-                Encoding.ASCII.GetBytes(":"),
-                Encoding.ASCII.GetBytes(" "),
-                Encoding.ASCII.GetBytes("C"),
-                Encoding.ASCII.GetBytes("\r"),
-                Encoding.ASCII.GetBytes("\n"),
-                Encoding.ASCII.GetBytes("\r"),
-                Encoding.ASCII.GetBytes("\n")
-                );
+            var buffer = BytePerSegmentTestSequenceFactory.Instance.CreateWithContent("A:B\r\nB: C\r\n\r\n");
 
             var requestHandler = new RequestHandler();
             var result = parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out _);
@@ -520,6 +491,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 RawPath = path.GetAsciiStringNonNullCharacters();
                 Query = query.GetAsciiStringNonNullCharacters();
                 PathEncoded = pathEncoded;
+            }
+        }
+
+        // Doesn't put empty blocks inbetween every byte
+        internal class BytePerSegmentTestSequenceFactory : ReadOnlySequenceFactory
+        {
+            public static ReadOnlySequenceFactory Instance { get; } = new HttpParserTests.BytePerSegmentTestSequenceFactory();
+
+            public override ReadOnlySequence<byte> CreateOfSize(int size)
+            {
+                return CreateWithContent(new byte[size]);
+            }
+
+            public override ReadOnlySequence<byte> CreateWithContent(byte[] data)
+            {
+                var segments = new List<byte[]>();
+
+                foreach (var b in data)
+                {
+                    segments.Add(new[] { b });
+                }
+
+                return CreateSegments(segments.ToArray());
             }
         }
     }

--- a/test/Kestrel.Core.Tests/HttpParserTests.cs
+++ b/test/Kestrel.Core.Tests/HttpParserTests.cs
@@ -415,6 +415,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(result);
         }
 
+        [Fact]
+        public void ParseHeadersWithGratuitouslySplitBuffers2()
+        {
+            var parser = CreateParser(_nullTrace);
+            var buffer = ReadOnlySequenceFactory.CreateSegments(
+                Encoding.ASCII.GetBytes("A: B"),
+                Encoding.ASCII.GetBytes("\r"),
+                Encoding.ASCII.GetBytes("\n"),
+                Encoding.ASCII.GetBytes("B"),
+                Encoding.ASCII.GetBytes(":"),
+                Encoding.ASCII.GetBytes(" "),
+                Encoding.ASCII.GetBytes("C"),
+                Encoding.ASCII.GetBytes("\r"),
+                Encoding.ASCII.GetBytes("\n"),
+                Encoding.ASCII.GetBytes("\r"),
+                Encoding.ASCII.GetBytes("\n")
+                );
+
+            var requestHandler = new RequestHandler();
+            var result = parser.ParseHeaders(requestHandler, buffer, out var consumed, out var examined, out _);
+
+            Assert.True(result);
+        }
+
         private void VerifyHeader(
             string headerName,
             string rawHeaderValue,


### PR DESCRIPTION
- When using the array pool (https://github.com/aspnet/KestrelHttpServer/issues/2449), we get terrible block density (@pakrym we need to look into this as SignalR is using this pool currently with pipelines) and as a result
the header parser was failing.
- This fixes the case where the parser needed to read ahead 2 bytes at the end
(which is unrealistic) at the beginning of every header parse to determine if it's at the end. Previously we were comparing the current index to the reader index is incorrect
since we may end up at the same index in another segment. Now we just check a boolean to determine if we did read ahead or not.

Here's what debugging revealed:

![image](https://user-images.githubusercontent.com/95136/38170282-2c059a2a-3536-11e8-916c-92678917d7b4.png)


/cc @jkotas