### PR TITLE
Moved kestrel specific features into transport abstractions

### DIFF
--- a/src/Connections.Abstractions/DefaultConnectionContext.cs
+++ b/src/Connections.Abstractions/DefaultConnectionContext.cs
@@ -17,7 +17,6 @@ namespace Microsoft.AspNetCore.Connections
                                             IConnectionIdFeature,
                                             IConnectionItemsFeature,
                                             IConnectionTransportFeature,
-                                            IApplicationTransportFeature,
                                             IConnectionUserFeature
     {
         public DefaultConnectionContext() :
@@ -39,7 +38,6 @@ namespace Microsoft.AspNetCore.Connections
             Features.Set<IConnectionItemsFeature>(this);
             Features.Set<IConnectionIdFeature>(this);
             Features.Set<IConnectionTransportFeature>(this);
-            Features.Set<IApplicationTransportFeature>(this);
         }
 
         public DefaultConnectionContext(string id, IDuplexPipe transport, IDuplexPipe application)

--- a/src/Kestrel.Core/Internal/HttpConnectionMiddleware.cs
+++ b/src/Kestrel.Core/Internal/HttpConnectionMiddleware.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
@@ -69,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             var connection = new HttpConnection(httpConnectionContext);
 
             var processingTask = connection.StartRequestProcessing(_application);
-            
+
             connectionContext.Transport.Input.OnWriterCompleted((error, state) =>
             {
                 ((HttpConnection)state).Abort(error);

--- a/src/Kestrel.Transport.Abstractions/Internal/IApplicationTransportFeature.cs
+++ b/src/Kestrel.Transport.Abstractions/Internal/IApplicationTransportFeature.cs
@@ -5,7 +5,7 @@ using System.Buffers;
 using System.IO.Pipelines;
 using System.Threading;
 
-namespace Microsoft.AspNetCore.Connections.Features
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
 {
     public interface IApplicationTransportFeature
     {

--- a/src/Kestrel.Transport.Abstractions/Internal/ITransportSchedulerFeature.cs
+++ b/src/Kestrel.Transport.Abstractions/Internal/ITransportSchedulerFeature.cs
@@ -5,7 +5,7 @@ using System.Buffers;
 using System.IO.Pipelines;
 using System.Threading;
 
-namespace Microsoft.AspNetCore.Connections.Features
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
 {
     public interface ITransportSchedulerFeature
     {


### PR DESCRIPTION
Move `IApplicationTransportFeature` and `ITransportSchedulerFeature` to **Kestrel.Transport.Abstractions**. I didn't move the `IMemoryPoolFeature` yet because it may be important when creating new adapted pipes