### PR TITLE
make IConnectionInherentKeepAliveFeature a boolean feature

### DIFF
--- a/src/Connections.Abstractions/Features/IConnectionInherentKeepAliveFeature.cs
+++ b/src/Connections.Abstractions/Features/IConnectionInherentKeepAliveFeature.cs
@@ -19,6 +19,6 @@ namespace Microsoft.AspNetCore.Connections.Features
     /// </remarks>
     public interface IConnectionInherentKeepAliveFeature
     {
-        TimeSpan KeepAliveInterval { get; }
+        bool HasInherentKeepAlive { get; }
     }
 }


### PR DESCRIPTION
Not used in Kestrel, but it's used by SignalR. 

We don't ever use the `TimeSpan`, and instead use the presence of the feature. This means we have to actually create a class implementing this and put it in the feature collection. We want to change to implement this interface directly on the ConnectionContext. See https://github.com/aspnet/SignalR/issues/1976

SignalR will treat the absence of this feature as equivalent to `HasInherentKeepAlive` being `false`.