### PR TITLE
Clean up flaky MaxRequestBufferSize tests

### DIFF
--- a/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -86,9 +86,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var bytesWrittenPollingInterval = TimeSpan.FromMilliseconds(bytesWrittenTimeout.TotalMilliseconds / 10);
             var maxSendSize = 4096;
 
-            // Initialize data with random bytes
-            (new Random()).NextBytes(data);
-
             var startReadingRequestBody = new TaskCompletionSource<object>();
             var clientFinishedSendingRequestBody = new TaskCompletionSource<object>();
             var lastBytesWritten = DateTime.MaxValue;
@@ -298,17 +295,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         context.Response.StatusCode = StatusCodes.Status500InternalServerError;
                         await context.Response.WriteAsync("Client sent more bytes than expectedBody.Length");
                         return;
-                    }
-
-                    // Verify bytes received match expectedBody
-                    for (int i = 0; i < expectedBody.Length; i++)
-                    {
-                        if (buffer[i] != expectedBody[i])
-                        {
-                            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
-                            await context.Response.WriteAsync($"Bytes received do not match expectedBody at position {i}");
-                            return;
-                        }
                     }
 
                     await context.Response.WriteAsync($"bytesRead: {bytesRead.ToString()}");

--- a/test/shared/PassThroughConnectionAdapter.cs
+++ b/test/shared/PassThroughConnectionAdapter.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.Testing
 {
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.Testing
 
         public Task<IAdaptedConnection> OnConnectionAsync(ConnectionAdapterContext context)
         {
-            var adapted = new AdaptedConnection(new LoggingStream(context.ConnectionStream, new TestApplicationErrorLogger()));
+            var adapted = new AdaptedConnection(new LoggingStream(context.ConnectionStream, NullLogger.Instance));
             return Task.FromResult<IAdaptedConnection>(adapted);
         }
 


### PR DESCRIPTION
I was debugging #2225 and had a reliable repro before John's logging changes. After his changes I could only cause OOMs. This change addresses the OOMs and the test now reliably passes.

I also removed the data corruption validation, there's a seperate test for that. These tests are much faster without it.