### PR TITLE
Sockets: do 0 byte reads to avoid allocating memory for idle connections

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -13,6 +13,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
         }
 
+        public SocketAwaitableEventArgs WaitForDataAsync()
+        {
+            _awaitableEventArgs.SetBuffer(Array.Empty<byte>(), 0, 0);
+
+            if (!_socket.ReceiveAsync(_awaitableEventArgs))
+            {
+                _awaitableEventArgs.Complete();
+            }
+
+            return _awaitableEventArgs;
+        }
+
         public SocketAwaitableEventArgs ReceiveAsync(Memory<byte> buffer)
         {
 #if NETCOREAPP2_1


### PR DESCRIPTION
I cherry-picked 2283605b6b286ad105737547df0e6a769a90ae2d into a new branch on top of release/2.1.