### PR TITLE
Revert "Enable xUnit diagnostic messages (#2505)"

### DIFF
--- a/test/xunit.runner.json
+++ b/test/xunit.runner.json
@@ -2,6 +2,5 @@
   "$schema": "http://json.schemastore.org/xunit.runner.schema",
   "appDomain": "denied",
   "methodDisplay": "method",
-  "diagnosticMessages": true,
   "longRunningTestSeconds": 60
 }


### PR DESCRIPTION
- xUnit diagnostic messages were enabled in #2505 to help identify hung tests
- However, this also enables log messages for non-serializable theory data (https://github.com/aspnet/KestrelHttpServer/issues/2509), which adds noise to logs
- It doesn't seem possible to disable the "non-serializable data" messages but keep the "long-running test" messages
- Converting all tests to serializable theory data is expensive and complicates test code
- The best solution for now is to revert xUnit diagnostic messages to disabled, and re-enable when needed to identify hung tests
