### PR TITLE
Use TaskCreationOptions.RunContinuationsAsynchronously a lot

### DIFF
--- a/test/Kestrel.Core.Tests/MessageBodyTests.cs
+++ b/test/Kestrel.Core.Tests/MessageBodyTests.cs
@@ -405,7 +405,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public async Task CopyToAsyncDoesNotCopyBlocks()
         {
             var writeCount = 0;
-            var writeTcs = new TaskCompletionSource<(byte[], int, int)>();
+            var writeTcs = new TaskCompletionSource<(byte[], int, int)>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockDestination = new Mock<Stream>() { CallBase = true };
 
             mockDestination
@@ -454,7 +454,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.Equal((segment.Array, segment.Offset, bytes.Length), await writeTcs.Task);
 
                 // Verify the again when GetMemory returns the tail space of the same block.
-                writeTcs = new TaskCompletionSource<(byte[], int, int)>();
+                writeTcs = new TaskCompletionSource<(byte[], int, int)>(TaskCreationOptions.RunContinuationsAsynchronously);
                 bytes = Encoding.ASCII.GetBytes("World!");
                 buffer = http1Connection.RequestBodyPipe.Writer.GetMemory(2048);
                 Assert.True(MemoryMarshal.TryGetArray(buffer, out segment));

--- a/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs
+++ b/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs
@@ -22,9 +22,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task ResetsCountWhenConnectionClosed()
         {
-            var requestTcs = new TaskCompletionSource<object>();
-            var releasedTcs = new TaskCompletionSource<object>();
-            var lockedTcs = new TaskCompletionSource<bool>();
+            var requestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releasedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var lockedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var counter = new EventRaisingResourceCounter(ResourceCounter.Quota(1));
             counter.OnLock += (s, e) => lockedTcs.TrySetResult(e);
             counter.OnRelease += (s, e) => releasedTcs.TrySetResult(null);
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task RejectsConnectionsWhenLimitReached()
         {
             const int max = 10;
-            var requestTcs = new TaskCompletionSource<object>();
+            var requestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = CreateServerWithMaxConnections(async context =>
             {
@@ -140,8 +140,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             const int count = 100;
             var opened = 0;
             var closed = 0;
-            var openedTcs = new TaskCompletionSource<object>();
-            var closedTcs = new TaskCompletionSource<object>();
+            var openedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var closedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var counter = new EventRaisingResourceCounter(ResourceCounter.Quota(uint.MaxValue));
 

--- a/test/Kestrel.FunctionalTests/HttpsTests.cs
+++ b/test/Kestrel.FunctionalTests/HttpsTests.cs
@@ -244,7 +244,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task DoesNotThrowObjectDisposedExceptionFromWriteAsyncAfterConnectionIsAborted()
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var loggerProvider = new HandshakeErrorLoggerProvider();
             LoggerFactory.AddProvider(loggerProvider);
             var hostBuilder = TransportSelector.GetWebHostBuilder()

--- a/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -87,8 +87,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var bytesWrittenPollingInterval = TimeSpan.FromMilliseconds(bytesWrittenTimeout.TotalMilliseconds / 10);
             var maxSendSize = 4096;
 
-            var startReadingRequestBody = new TaskCompletionSource<object>();
-            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>();
+            var startReadingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var lastBytesWritten = DateTime.MaxValue;
 
             var memoryPoolFactory = new DiagnosticMemoryPoolFactory(allowLateReturn: true);
@@ -183,8 +183,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var bytesWrittenPollingInterval = TimeSpan.FromMilliseconds(bytesWrittenTimeout.TotalMilliseconds / 10);
             var maxSendSize = 4096;
 
-            var startReadingRequestBody = new TaskCompletionSource<object>();
-            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>();
+            var startReadingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var lastBytesWritten = DateTime.MaxValue;
 
             var memoryPoolFactory = new DiagnosticMemoryPoolFactory(allowLateReturn: true);

--- a/test/Kestrel.FunctionalTests/UpgradeTests.cs
+++ b/test/Kestrel.FunctionalTests/UpgradeTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task ResponseThrowsAfterUpgrade()
         {
-            var upgrade = new TaskCompletionSource<bool>();
+            var upgrade = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (var server = new TestServer(async context =>
             {
                 var feature = context.Features.Get<IHttpUpgradeFeature>();
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             const string send = "Custom protocol send";
             const string recv = "Custom protocol recv";
 
-            var upgrade = new TaskCompletionSource<bool>();
+            var upgrade = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (var server = new TestServer(async context =>
             {
                 try
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task UpgradeCannotBeCalledMultipleTimes()
         {
-            var upgradeTcs = new TaskCompletionSource<object>();
+            var upgradeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (var server = new TestServer(async context =>
             {
                 var feature = context.Features.Get<IHttpUpgradeFeature>();
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task ThrowsWhenUpgradingNonUpgradableRequest()
         {
-            var upgradeTcs = new TaskCompletionSource<bool>();
+            var upgradeTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (var server = new TestServer(async context =>
             {
                  var feature = context.Features.Get<IHttpUpgradeFeature>();
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task RejectsUpgradeWhenLimitReached()
         {
             const int limit = 10;
-            var upgradeTcs = new TaskCompletionSource<object>();
+            var upgradeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var serviceContext = new TestServiceContext(LoggerFactory);
             serviceContext.ConnectionManager = new HttpConnectionManager(serviceContext.Log, ResourceCounter.Quota(limit));
 

--- a/test/Kestrel.Transport.Libuv.Tests/ListenerPrimaryTests.cs
+++ b/test/Kestrel.Transport.Libuv.Tests/ListenerPrimaryTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             Assert.Equal("Primary", await HttpClientSlim.GetStringAsync(address));
 
             // Create a pipe connection and keep it open without sending any data
-            var connectTcs = new TaskCompletionSource<object>();
+            var connectTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var connectionTrace = new LibuvTrace(new TestApplicationErrorLogger());
             var pipe = new UvPipeHandle(connectionTrace);
 


### PR DESCRIPTION
Carpet bombing with `TaskCreationOptions.RunContinuationsAsynchronously`