### PR TITLE
Remove netcoreapp2.0 test coverage

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <DeveloperBuildTestTfms>netcoreapp2.1</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
-    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' ">netcoreapp2.1;netcoreapp2.0</StandardTestTfms>
+    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' ">netcoreapp2.1</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
   </PropertyGroup>
 

--- a/test/Kestrel.Core.Tests/HttpRequestStreamTests.cs
+++ b/test/Kestrel.Core.Tests/HttpRequestStreamTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>());
             Assert.Throws<NotSupportedException>(() => stream.BeginWrite(new byte[1], 0, 1, null, null));
         }
-#elif NETCOREAPP2_0 || NETCOREAPP2_1
+#elif NETCOREAPP2_1
 #else
 #error Target framework needs to be updated
 #endif

--- a/test/Kestrel.FunctionalTests/GeneratedCodeTests.cs
+++ b/test/Kestrel.FunctionalTests/GeneratedCodeTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NETCOREAPP2_0 || NETCOREAPP2_1
+#if NETCOREAPP2_1
 using System.IO;
 using Xunit;
 


### PR DESCRIPTION
#2517 A series of tests have been consistently failing on netcoreapp2.0 on Mac due to an HttpClient issue. We're already planning to remove netcoreapp2.0 test coverage for 2.2.0 so I'm preemptively removing it here to get rid of the failures.