### PR TITLE
Reenable api check

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,4 @@
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- https://github.com/aspnet/KestrelHttpServer/issues/2350 -->
-    <EnableApiCheck>false</EnableApiCheck>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Addresses https://github.com/aspnet/KestrelHttpServer/issues/2350. We have updated the runtimes of the buildtools which unblocked this issue. However won't we be broken again when something changes in the runtime future? Do we want to keep doing this or wait for the overhaul of the API checks at https://github.com/aspnet/BuildTools/issues/594?

Tested locally.