### PR TITLE
Wait off the ConnectionClosed token to stop tracking ConnectionCallback

### DIFF
--- a/src/Kestrel.Core/Internal/ConnectionDispatcher.cs
+++ b/src/Kestrel.Core/Internal/ConnectionDispatcher.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         private IKestrelTrace Log => _serviceContext.Log;
 
-        public void OnConnection(TransportConnection connection)
+        public Task OnConnection(TransportConnection connection)
         {
             // REVIEW: Unfortunately, we still need to use the service context to create the pipes since the settings
             // for the scheduler and limits are specified here
@@ -44,9 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             // This *must* be set before returning from OnConnection
             connection.Application = pair.Application;
 
-            // REVIEW: This task should be tracked by the server for graceful shutdown
-            // Today it's handled specifically for http but not for aribitrary middleware
-            _ = Execute(connection);
+            return Execute(connection);
         }
 
         private async Task Execute(ConnectionContext connectionContext)

--- a/src/Kestrel.Transport.Abstractions/Internal/IConnectionDispatcher.cs
+++ b/src/Kestrel.Transport.Abstractions/Internal/IConnectionDispatcher.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Http.Features;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal
 {
     public interface IConnectionDispatcher
     {
-        void OnConnection(TransportConnection connection);
+        Task OnConnection(TransportConnection connection);
     }
 }

--- a/src/Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 {
-    public partial class LibuvConnection : TransportConnection
+    public partial class LibuvConnection : TransportConnection, IDisposable
     {
         private static readonly int MinAllocBufferSize = KestrelMemoryPool.MinimumSegmentSize / 2;
 
@@ -109,6 +109,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
         {
             // This cancels any pending I/O.
             Thread.Post(s => s.Dispose(), _socket);
+        }
+
+        // Only called after connection middleware is complete which means the ConnectionClosed token has fired.
+        public void Dispose()
+        {
+            _connectionClosedTokenSource.Dispose();
         }
 
         // Called on Libuv thread
@@ -223,7 +229,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             try
             {
                 _connectionClosedTokenSource.Cancel();
-                _connectionClosedTokenSource.Dispose();
             }
             catch (Exception ex)
             {

--- a/src/Kestrel.Transport.Libuv/Internal/Listener.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/Listener.cs
@@ -181,11 +181,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
         protected virtual void DispatchConnection(UvStreamHandle socket)
         {
-            var connection = new LibuvConnection(socket, Log, Thread);
-
-            TransportContext.ConnectionDispatcher.OnConnection(connection);
-
-            _ = connection.Start();
+            // REVIEW: This task should be tracked by the server for graceful shutdown
+            // Today it's handled specifically for http but not for aribitrary middleware
+            _ = HandleConnectionAsync(socket);
         }
 
         public virtual async Task DisposeAsync()

--- a/src/Kestrel.Transport.Libuv/Internal/ListenerSecondary.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/ListenerSecondary.cs
@@ -159,19 +159,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
                 return;
             }
 
-            try
-            {
-                var connection = new LibuvConnection(acceptSocket, Log, Thread);
-
-                TransportContext.ConnectionDispatcher.OnConnection(connection);
-
-                _ = connection.Start();
-            }
-            catch (UvException ex)
-            {
-                Log.LogError(0, ex, "ListenerSecondary.OnConnection");
-                acceptSocket.Dispose();
-            }
+            // REVIEW: This task should be tracked by the server for graceful shutdown
+            // Today it's handled specifically for http but not for aribitrary middleware
+            _ = HandleConnectionAsync(acceptSocket);
         }
 
         private void FreeBuffer()

--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
-    internal sealed class SocketConnection : TransportConnection
+    internal sealed class SocketConnection : TransportConnection, IDisposable
     {
         private static readonly int MinAllocBufferSize = KestrelMemoryPool.MinimumSegmentSize / 2;
 
@@ -89,6 +89,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
             // Try to gracefully close the socket to match libuv behavior.
             Shutdown();
+        }
+
+        // Only called after connection middleware is complete which means the ConnectionClosed token has fired.
+        public void Dispose()
+        {
+            _connectionClosedTokenSource.Dispose();
         }
 
         private async Task DoReceive()
@@ -281,7 +287,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             try
             {
                 _connectionClosedTokenSource.Cancel();
-                _connectionClosedTokenSource.Dispose();
             }
             catch (Exception ex)
             {

--- a/test/Kestrel.Transport.Libuv.Tests/TestHelpers/MockConnectionDispatcher.cs
+++ b/test/Kestrel.Transport.Libuv.Tests/TestHelpers/MockConnectionDispatcher.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Buffers;
 using System.IO.Pipelines;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Connections.Features;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.TestHelpers
@@ -16,13 +14,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.TestHelpers
         public Func<MemoryPool<byte>, PipeOptions> InputOptions { get; set; } = pool => new PipeOptions(pool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         public Func<MemoryPool<byte>, PipeOptions> OutputOptions { get; set; } = pool => new PipeOptions(pool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
 
-        public void OnConnection(TransportConnection connection)
+        public Task OnConnection(TransportConnection connection)
         {
             Input = new Pipe(InputOptions(connection.MemoryPool));
             Output = new Pipe(OutputOptions(connection.MemoryPool));
 
             connection.Transport = new DuplexPipe(Input.Reader, Output.Writer);
             connection.Application = new DuplexPipe(Output.Reader, Input.Writer);
+
+            return Task.CompletedTask;
         }
 
         public Pipe Input { get; private set; }


### PR DESCRIPTION
- The prior strategy of waiting for the pipe completed callbacks doesn't work
  because blocks are returned to the memory pool after the callbacks are fired.

#2565