### PR TITLE
CorrelationIdGenerator uses string.Create and avoids bounds-checks

### DIFF
--- a/src/Kestrel.Core/Internal/Http/ChunkWriter.cs
+++ b/src/Kestrel.Core/Internal/Http/ChunkWriter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
@@ -21,19 +22,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public static ArraySegment<byte> BeginChunkBytes(int dataCount)
         {
-            var bytes = new byte[10]
-            {
-                _hex[((dataCount >> 0x1c) & 0x0f)],
-                _hex[((dataCount >> 0x18) & 0x0f)],
-                _hex[((dataCount >> 0x14) & 0x0f)],
-                _hex[((dataCount >> 0x10) & 0x0f)],
-                _hex[((dataCount >> 0x0c) & 0x0f)],
-                _hex[((dataCount >> 0x08) & 0x0f)],
-                _hex[((dataCount >> 0x04) & 0x0f)],
-                _hex[((dataCount >> 0x00) & 0x0f)],
-                (byte)'\r',
-                (byte)'\n',
-            };
+            var bytes = new byte[10];
+            ref var r = ref bytes[0];
+            ref var hex = ref _hex[0];
+
+            Unsafe.Add(ref r, 0) = Unsafe.Add(ref hex, (dataCount >> 0x1c) & 0x0f);
+            Unsafe.Add(ref r, 1) = Unsafe.Add(ref hex, (dataCount >> 0x18) & 0x0f);
+            Unsafe.Add(ref r, 2) = Unsafe.Add(ref hex, (dataCount >> 0x14) & 0x0f);
+            Unsafe.Add(ref r, 3) = Unsafe.Add(ref hex, (dataCount >> 0x10) & 0x0f);
+            Unsafe.Add(ref r, 4) = Unsafe.Add(ref hex, (dataCount >> 0x0c) & 0x0f);
+            Unsafe.Add(ref r, 5) = Unsafe.Add(ref hex, (dataCount >> 0x08) & 0x0f);
+            Unsafe.Add(ref r, 6) = Unsafe.Add(ref hex, (dataCount >> 0x04) & 0x0f);
+            Unsafe.Add(ref r, 7) = Unsafe.Add(ref hex, (dataCount >> 0x00) & 0x0f);
+            Unsafe.Add(ref r, 8) = (byte)'\r';
+            Unsafe.Add(ref r, 9) = (byte)'\n';
 
             // Determine the most-significant non-zero nibble
             int total, shift;

--- a/src/Kestrel.Core/Internal/Infrastructure/CorrelationIdGenerator.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/CorrelationIdGenerator.cs
@@ -3,13 +3,19 @@
 
 using System;
 using System.Threading;
+using System.Runtime.CompilerServices;
+
+#if NETCOREAPP2_1
+using System.Buffers;
+using System.Runtime.InteropServices;
+#endif
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
     internal static class CorrelationIdGenerator
     {
         // Base32 encoding - in ascii sort order for easy text based sorting
-        private static readonly string _encode32Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUV";
+        private static readonly char[] _encode32Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUV".ToCharArray();
 
         // Seed the _lastConnectionId for this application instance with
         // the number of 100-nanosecond intervals that have elapsed since 12:00:00 midnight, January 1, 0001
@@ -24,25 +30,48 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             // and ~600% faster than calling long.ToString() on x86 in tight loops of 1 million+ iterations
             // See: https://github.com/aspnet/Hosting/pull/385
 
+#if NETCOREAPP2_1
+            return string.Create(13, id, _spanAction);
+#else
             // stackalloc to allocate array on stack rather than heap
             char* charBuffer = stackalloc char[13];
+            ref char encodeChars = ref _encode32Chars[0];
 
-            charBuffer[0] = _encode32Chars[(int)(id >> 60) & 31];
-            charBuffer[1] = _encode32Chars[(int)(id >> 55) & 31];
-            charBuffer[2] = _encode32Chars[(int)(id >> 50) & 31];
-            charBuffer[3] = _encode32Chars[(int)(id >> 45) & 31];
-            charBuffer[4] = _encode32Chars[(int)(id >> 40) & 31];
-            charBuffer[5] = _encode32Chars[(int)(id >> 35) & 31];
-            charBuffer[6] = _encode32Chars[(int)(id >> 30) & 31];
-            charBuffer[7] = _encode32Chars[(int)(id >> 25) & 31];
-            charBuffer[8] = _encode32Chars[(int)(id >> 20) & 31];
-            charBuffer[9] = _encode32Chars[(int)(id >> 15) & 31];
-            charBuffer[10] = _encode32Chars[(int)(id >> 10) & 31];
-            charBuffer[11] = _encode32Chars[(int)(id >> 5) & 31];
-            charBuffer[12] = _encode32Chars[(int)id & 31];
+            FillBuffer(ref Unsafe.AsRef<char>(charBuffer), id, ref encodeChars);
 
             // string ctor overload that takes char*
             return new string(charBuffer, 0, 13);
+#endif
+        }
+
+#if NETCOREAPP2_1
+        private static readonly SpanAction<char, long> _spanAction = FillBufferAction;
+
+        private static void FillBufferAction(Span<char> charBuffer, long id)
+        {
+            ref char buffer = ref MemoryMarshal.GetReference(charBuffer);
+            ref char encodeChars = ref _encode32Chars[0];
+
+            FillBuffer(ref buffer, id, ref encodeChars);
+        }
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void FillBuffer(ref char buffer, long id, ref char encodeChars)
+        {
+            Unsafe.Add(ref buffer, 0) = Unsafe.Add(ref encodeChars, (int)(id >> 60) & 31);
+            Unsafe.Add(ref buffer, 1) = Unsafe.Add(ref encodeChars, (int)(id >> 55) & 31);
+            Unsafe.Add(ref buffer, 2) = Unsafe.Add(ref encodeChars, (int)(id >> 50) & 31);
+            Unsafe.Add(ref buffer, 3) = Unsafe.Add(ref encodeChars, (int)(id >> 45) & 31);
+            Unsafe.Add(ref buffer, 4) = Unsafe.Add(ref encodeChars, (int)(id >> 40) & 31);
+            Unsafe.Add(ref buffer, 5) = Unsafe.Add(ref encodeChars, (int)(id >> 35) & 31);
+            Unsafe.Add(ref buffer, 6) = Unsafe.Add(ref encodeChars, (int)(id >> 30) & 31);
+            Unsafe.Add(ref buffer, 7) = Unsafe.Add(ref encodeChars, (int)(id >> 25) & 31);
+            Unsafe.Add(ref buffer, 8) = Unsafe.Add(ref encodeChars, (int)(id >> 20) & 31);
+            Unsafe.Add(ref buffer, 9) = Unsafe.Add(ref encodeChars, (int)(id >> 15) & 31);
+            Unsafe.Add(ref buffer, 10) = Unsafe.Add(ref encodeChars, (int)(id >> 10) & 31);
+            Unsafe.Add(ref buffer, 11) = Unsafe.Add(ref encodeChars, (int)(id >> 5) & 31);
+            Unsafe.Add(ref buffer, 12) = Unsafe.Add(ref encodeChars, (int)(id >> 0) & 31);
         }
     }
 }


### PR DESCRIPTION
# Description

For `netcoreapp2.1` `string.Create` is used instead of a stack allocation and then copying to the string.

The bound-checks are removed for both targetframeworks.

# Benchmarks

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
Frequency=2742192 Hz, Resolution=364.6718 ns, Timer=TSC
.NET Core SDK=2.1.300-rc1-008673
  [Host] : .NET Core 2.1.0-rc1 (CoreCLR 4.6.26426.02, CoreFX 4.6.26426.04), 64bit RyuJIT
  Clr    : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3101.0
  Core   : .NET Core 2.1.0-rc1 (CoreCLR 4.6.26426.02, CoreFX 4.6.26426.04), 64bit RyuJIT


```
|                 Method |  Job | Runtime |     Mean |     Error |    StdDev | Scaled |  Gen 0 | Allocated |
|----------------------- |----- |-------- |---------:|----------:|----------:|-------:|-------:|----------:|
|                Default |  Clr |     Clr | 30.55 ns | 0.3343 ns | 0.2610 ns |   1.00 | 0.0178 |      56 B |
|           StringCreate |  Clr |     Clr | 30.72 ns | 0.3675 ns | 0.3437 ns |   1.01 | 0.0178 |      56 B |
| StringCreateSpanUnsafe |  Clr |     Clr | 29.00 ns | 0.1565 ns | 0.1463 ns |   0.95 | 0.0178 |      56 B |
|                        |      |         |          |           |           |        |        |           |
|                Default | Core |    Core | 38.56 ns | 0.7330 ns | 0.6498 ns |   1.00 | 0.0178 |      56 B |
|           StringCreate | Core |    Core | 29.07 ns | 0.1224 ns | 0.1022 ns |   0.75 | 0.0178 |      56 B |
| StringCreateSpanUnsafe | Core |    Core | 24.21 ns | 0.1273 ns | 0.1129 ns |   0.63 | 0.0178 |      56 B |

[Default](https://github.com/gfoidl/Benchmarks/blob/c14386b94f74389bc57d0b36d2c2d63f0a1b0b26/aspnet/Kestrel/CorrelationIdGenerator/CorrelationIdGenerator/CorrelationIdGenerators/CorrelationIdGenerator.cs) is the current implementation in _dev_.
[StringCreate](https://github.com/gfoidl/Benchmarks/blob/c14386b94f74389bc57d0b36d2c2d63f0a1b0b26/aspnet/Kestrel/CorrelationIdGenerator/CorrelationIdGenerator/CorrelationIdGenerators/CorrelationIdGenerator1.cs) is for reference when just `string.Create` is used (only applyable for `netcoreapp2.1`.
[StringCreateSpanUnsafe](https://github.com/gfoidl/Benchmarks/blob/c14386b94f74389bc57d0b36d2c2d63f0a1b0b26/aspnet/Kestrel/CorrelationIdGenerator/CorrelationIdGenerator/CorrelationIdGenerators/CorrelationIdGenerator2.cs) is this PR.