### PR TITLE
Http[Request|Response]Stream.ValidateState made inlineable

### DIFF
--- a/src/Kestrel.Core/Internal/Http/HttpRequestStream.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpRequestStream.cs
@@ -196,10 +196,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             var state = _state;
             if (state == HttpStreamState.Open)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
+                cancellationToken.ThrowIfCancellationRequested();
             }
             else if (state == HttpStreamState.Closed)
             {

--- a/src/Kestrel.Core/Internal/Http/HttpResponseStream.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpResponseStream.cs
@@ -152,11 +152,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             var state = _state;
             if (state == HttpStreamState.Open || state == HttpStreamState.Aborted)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    // Aborted state only throws on write if cancellationToken requests it
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
+				// Aborted state only throws on write if cancellationToken requests it
+				cancellationToken.ThrowIfCancellationRequested();
             }
             else
             {


### PR DESCRIPTION
Instead of the `switch` `if` is used and the code got tightened.
Now it is inlined in the methods, that other than the call to `ValidateState` just forward to the `Read/Write`-methods.