### PR TITLE
Re-enable ConnectionCountingReturnsToZero on non-macOS machines

### DIFF
--- a/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs
+++ b/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Tests;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -134,7 +135,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [Fact(Skip = "https://github.com/aspnet/KestrelHttpServer/issues/2282")]
+        [Fact]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "https://github.com/aspnet/KestrelHttpServer/issues/2282")]
         public async Task ConnectionCountingReturnsToZero()
         {
             const int count = 100;


### PR DESCRIPTION
I don't think we should disable this everywhere because it's flaky on macOS. I ran all the ConnectionLimitTests for ~16 hours on Windows and ~1 hour on Linux with 0 failures. I would not be surprised if the macOS failures are once again related to descriptor limits.

#2282