### PR TITLE
Improve reliability of MaxRequestBufferSizeTests.LargeUpload

### DIFF
--- a/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -53,15 +53,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     // Client is typically paused after uploading this many bytes:
                     // 
                     // OS                   connectionAdapter   Transport   min pause (MB)      max pause (MB)
-                    // ---------------      --------------      ---------   --------------      --------------
+                    // ----------------     -----------------   ---------   --------------      --------------
                     // Windows 10 1803      false               Libuv       6                   13
                     // Windows 10 1803      false               Sockets     7                   24
                     // Windows 10 1803      true                Libuv       12                  12
                     // Windows 10 1803      true                Sockets     12                  36
-                    // Ubuntu 18.04         false                           
-                    // Ubuntu 18.04         true                            
-                    // OS X High Sierra     false                           
-                    // OS X High Sierra     true                            
+                    // Ubuntu 18.04         false               Libuv       13                  15
+                    // Ubuntu 18.04         false               Sockets     13                  15
+                    // Ubuntu 18.04         true                Libuv       19                  20
+                    // Ubuntu 18.04         true                Sockets     18                  20
+                    // OS X High Sierra     false               Libuv
+                    // OS X High Sierra     false               Sockets
+                    // OS X High Sierra     true                Libuv
+                    // OS X High Sierra     true                Sockets
                     Tuple.Create((long?)5 * 1024 * 1024, true),
 
                     // Even though maxRequestBufferSize < _dataLength, client should not be paused since the

--- a/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     // Client is typically paused after uploading this many bytes:
                     // 
                     // OS                   connectionAdapter   Transport   min pause (MB)      max pause (MB)
-                    // ----------------     -----------------   ---------   --------------      --------------
+                    // ---------------      -----------------   ---------   --------------      --------------
                     // Windows 10 1803      false               Libuv       6                   13
                     // Windows 10 1803      false               Sockets     7                   24
                     // Windows 10 1803      true                Libuv       12                  12
@@ -62,10 +62,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     // Ubuntu 18.04         false               Sockets     13                  15
                     // Ubuntu 18.04         true                Libuv       19                  20
                     // Ubuntu 18.04         true                Sockets     18                  20
-                    // OS X High Sierra     false               Libuv
-                    // OS X High Sierra     false               Sockets
-                    // OS X High Sierra     true                Libuv
-                    // OS X High Sierra     true                Sockets
+                    // macOS 10.13.4        false               Libuv       6                   6
+                    // macOS 10.13.4        false               Sockets     6                   6
+                    // macOS 10.13.4        true                Libuv       11                  11
+                    // macOS 10.13.4        true                Sockets     11                  11
                     Tuple.Create((long?)5 * 1024 * 1024, true),
 
                     // Even though maxRequestBufferSize < _dataLength, client should not be paused since the

--- a/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -162,15 +162,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                             await Task.Delay(bytesWrittenPollingInterval);
                         }
 
-                        // TODO: Remove logging
-                        var path = Path.Combine(Path.GetTempPath(), "MaxRequestBufferSizeTests");
-                        Directory.CreateDirectory(path);
-                        var transport = (this.GetType().Assembly.FullName.ToLowerInvariant().Contains("libuv")) ?
-                            "libuv" : "sockets";
-                        var filename = Path.Combine(path,
-                            string.Join("_", transport, maxRequestBufferSize, connectionAdapter, expectPause) + ".txt");
-                        File.AppendAllLines(filename, new[] { bytesWritten.ToString() });
-
                         // Verify the number of bytes written before the client was paused.
                         Assert.InRange(bytesWritten, minimumExpectedBytesWritten, maximumExpectedBytesWritten);
 


### PR DESCRIPTION
- Increase _dataLength from 20MB to 40MB to improve reliability of Sockets on Windows
- Addresses https://github.com/aspnet/KestrelHttpServer/issues/2225