### PR TITLE
Interlocked.Read/Add in SocketConnection only for 32-bit systems

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -61,21 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         public override MemoryPool<byte> MemoryPool { get; }
         public override PipeScheduler InputWriterScheduler => _scheduler;
         public override PipeScheduler OutputReaderScheduler => _scheduler;
-
-        public override long TotalBytesWritten
-        {
-            get
-            {
-                if (IntPtr.Size == sizeof(long))
-                {
-                    return _totalBytesWritten;
-                }
-                else
-                {
-                    return Interlocked.Read(ref _totalBytesWritten);
-                }
-            }
-        }
+        public override long TotalBytesWritten => Volatile.Read(ref _totalBytesWritten);
 
         public async Task StartAsync()
         {


### PR DESCRIPTION
...on 64-bit system `long` reads are already atomic,, so they can be made way faster than with an interlocked operation.

The JIT will eliminate the dead-branch.

----

PS: Hope that I don't get bothersome...