### PR TITLE
[2.1.1] Use correct TaskCompletionSource ctor

### DIFF
--- a/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs
+++ b/test/Kestrel.FunctionalTests/ConnectionLimitTests.cs
@@ -22,9 +22,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task ResetsCountWhenConnectionClosed()
         {
-            var requestTcs = new TaskCompletionSource<object>();
-            var releasedTcs = new TaskCompletionSource<object>();
-            var lockedTcs = new TaskCompletionSource<bool>();
+            var requestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releasedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var lockedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var counter = new EventRaisingResourceCounter(ResourceCounter.Quota(1));
             counter.OnLock += (s, e) => lockedTcs.TrySetResult(e);
             counter.OnRelease += (s, e) => releasedTcs.TrySetResult(null);
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task RejectsConnectionsWhenLimitReached()
         {
             const int max = 10;
-            var requestTcs = new TaskCompletionSource<object>();
+            var requestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = CreateServerWithMaxConnections(async context =>
             {
@@ -140,8 +140,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             const int count = 100;
             var opened = 0;
             var closed = 0;
-            var openedTcs = new TaskCompletionSource<object>();
-            var closedTcs = new TaskCompletionSource<object>();
+            var openedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var closedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var counter = new EventRaisingResourceCounter(ResourceCounter.Quota(uint.MaxValue));
 

--- a/test/Kestrel.FunctionalTests/HttpConnectionManagerTests.cs
+++ b/test/Kestrel.FunctionalTests/HttpConnectionManagerTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             using (var server = new TestServer(context =>
                 {
                     appStartedWh.Release();
-                    var tcs = new TaskCompletionSource<object>();
+                    var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
                     return tcs.Task;
                 },
                 new TestServiceContext(new LoggerFactory(), mockTrace.Object)))

--- a/test/Kestrel.FunctionalTests/HttpsTests.cs
+++ b/test/Kestrel.FunctionalTests/HttpsTests.cs
@@ -441,13 +441,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             public LogLevel LastLogLevel { get; set; }
             public EventId LastEventId { get; set; }
-            public TaskCompletionSource<object> LogTcs { get; } = new TaskCompletionSource<object>();
+            public TaskCompletionSource<object> LogTcs { get; } = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
             {
                 LastLogLevel = logLevel;
                 LastEventId = eventId;
-                Task.Run(() => LogTcs.SetResult(null));
+                LogTcs.SetResult(null);
             }
 
             public bool IsEnabled(LogLevel logLevel)

--- a/test/Kestrel.FunctionalTests/HttpsTests.cs
+++ b/test/Kestrel.FunctionalTests/HttpsTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task DoesNotThrowObjectDisposedExceptionFromWriteAsyncAfterConnectionIsAborted()
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var loggerProvider = new HandshakeErrorLoggerProvider();
             LoggerFactory.AddProvider(loggerProvider);
             var hostBuilder = TransportSelector.GetWebHostBuilder()

--- a/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Kestrel.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -89,8 +89,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             // Initialize data with random bytes
             (new Random()).NextBytes(data);
 
-            var startReadingRequestBody = new TaskCompletionSource<object>();
-            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>();
+            var startReadingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var lastBytesWritten = DateTime.MaxValue;
 
             using (var host = StartWebHost(maxRequestBufferSize, data, connectionAdapter, startReadingRequestBody, clientFinishedSendingRequestBody))
@@ -181,8 +181,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var bytesWrittenPollingInterval = TimeSpan.FromMilliseconds(bytesWrittenTimeout.TotalMilliseconds / 10);
             var maxSendSize = 4096;
 
-            var startReadingRequestBody = new TaskCompletionSource<object>();
-            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>();
+            var startReadingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientFinishedSendingRequestBody = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var lastBytesWritten = DateTime.MaxValue;
 
             using (var host = StartWebHost(16 * 1024, data, false, startReadingRequestBody, clientFinishedSendingRequestBody))

--- a/test/Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Kestrel.FunctionalTests/RequestTests.cs
@@ -1217,10 +1217,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             const int connectionFinSentEventId = 7;
             const int maxRequestBufferSize = 4096;
 
-            var readCallbackUnwired = new TaskCompletionSource<object>(TaskContinuationOptions.RunContinuationsAsynchronously);
-            var clientClosedConnection = new TaskCompletionSource<object>(TaskContinuationOptions.RunContinuationsAsynchronously);
-            var serverClosedConnection = new TaskCompletionSource<object>(TaskContinuationOptions.RunContinuationsAsynchronously);
-            var appFuncCompleted = new TaskCompletionSource<object>(TaskContinuationOptions.RunContinuationsAsynchronously);
+            var readCallbackUnwired = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientClosedConnection = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var serverClosedConnection = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appFuncCompleted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var mockLogger = new Mock<ILogger>();
             mockLogger
@@ -1276,9 +1276,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 await serverClosedConnection.Task;
 
-                // TaskContinuationOptions.RunContinuationsAsynchronously sometimes runs inline anyway in
-                // situations such as this where the awaiter starts awaiting right when SetResult is called.
-                _ = Task.Run(() => appFuncCompleted.SetResult(null));
+                appFuncCompleted.SetResult(null);
             }, testContext, listenOptions))
             {
                 using (var connection = server.CreateConnection())
@@ -1308,7 +1306,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [MemberData(nameof(ConnectionAdapterData))]
         public async Task AppCanHandleClientAbortingConnectionMidRequest(ListenOptions listenOptions)
         {
-            var readTcs = new TaskCompletionSource<Exception>(TaskContinuationOptions.RunContinuationsAsynchronously);
+            var readTcs = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var mockKestrelTrace = new Mock<KestrelTrace>(Logger) { CallBase = true };
             var testContext = new TestServiceContext()

--- a/test/Kestrel.FunctionalTests/RequestTests.cs
+++ b/test/Kestrel.FunctionalTests/RequestTests.cs
@@ -578,8 +578,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task ConnectionClosedTokenFiresOnClientFIN(ListenOptions listenOptions)
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var appStartedTcs = new TaskCompletionSource<object>();
-            var connectionClosedTcs = new TaskCompletionSource<object>();
+            var appStartedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(context =>
             {
@@ -613,7 +613,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task ConnectionClosedTokenFiresOnServerFIN(ListenOptions listenOptions)
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var connectionClosedTcs = new TaskCompletionSource<object>();
+            var connectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(context =>
             {
@@ -649,7 +649,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task ConnectionClosedTokenFiresOnServerAbort(ListenOptions listenOptions)
         {
             var testContext = new TestServiceContext(LoggerFactory);
-            var connectionClosedTcs = new TaskCompletionSource<object>();
+            var connectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(context =>
             {
@@ -694,9 +694,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [InlineData("http://localhost/path%20with%20space?q=abc%20123", "/path with space", "abc 123")]
         public async Task CanHandleRequestsWithUrlInAbsoluteForm(string requestUrl, string expectedPath, string queryValue)
         {
-            var pathTcs = new TaskCompletionSource<PathString>();
-            var rawTargetTcs = new TaskCompletionSource<string>();
-            var queryTcs = new TaskCompletionSource<IQueryCollection>();
+            var pathTcs = new TaskCompletionSource<PathString>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var rawTargetTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var queryTcs = new TaskCompletionSource<IQueryCollection>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(async context =>
                  {
@@ -1135,8 +1135,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             var testContext = new TestServiceContext(LoggerFactory);
 
-            var readTcs = new TaskCompletionSource<object>();
-            var registrationTcs = new TaskCompletionSource<int>();
+            var readTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var registrationTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             var requestId = 0;
 
             using (var server = new TestServer(async httpContext =>

--- a/test/Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Kestrel.FunctionalTests/ResponseTests.cs
@@ -2336,9 +2336,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             const int maxRequestBufferSize = 2048;
 
             var requestAborted = false;
-            var readCallbackUnwired = new TaskCompletionSource<object>(TaskContinuationOptions.RunContinuationsAsynchronously);
-            var clientClosedConnection = new TaskCompletionSource<object>(TaskContinuationOptions.RunContinuationsAsynchronously);
-            var writeTcs = new TaskCompletionSource<Exception>(TaskContinuationOptions.RunContinuationsAsynchronously);
+            var readCallbackUnwired = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientClosedConnection = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var writeTcs = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var mockKestrelTrace = new Mock<KestrelTrace>(Logger) { CallBase = true };
             var mockLogger = new Mock<ILogger>();
@@ -2401,9 +2401,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 }
                 catch (Exception ex)
                 {
-                    // TaskContinuationOptions.RunContinuationsAsynchronously sometimes runs inline anyway in
-                    // situations such as this where the awaiter starts awaiting right when SetResult is called.
-                    _ = Task.Run(() => writeTcs.SetException(ex));
+                    writeTcs.SetException(ex);
                     throw;
                 }
 
@@ -2443,7 +2441,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             const int responseBodySize = responseBodySegmentSize * responseBodySegmentCount;
 
             var requestAborted = false;
-            var appCompletedTcs = new TaskCompletionSource<object>(TaskContinuationOptions.RunContinuationsAsynchronously);
+            var appCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var mockKestrelTrace = new Mock<KestrelTrace>(Logger) { CallBase = true };
             var testContext = new TestServiceContext()
@@ -2474,9 +2472,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 {
                     // WriteAsync shouldn't throw without a CancellationToken passed in. Unfortunately a ECONNRESET UvException sometimes gets thrown.
                     // This will be fixed by https://github.com/aspnet/KestrelHttpServer/pull/2547
-                    // TaskContinuationOptions.RunContinuationsAsynchronously sometimes runs inline anyway in
-                    // situations such as this where the awaiter starts awaiting right when SetResult is called.
-                    _ = Task.Run(() => appCompletedTcs.SetResult(null));
+                    appCompletedTcs.SetResult(null);
                 }
             }, testContext, listenOptions))
             {

--- a/test/Kestrel.FunctionalTests/ResponseTests.cs
+++ b/test/Kestrel.FunctionalTests/ResponseTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task OnCompleteCalledEvenWhenOnStartingNotCalled()
         {
             var onStartingCalled = false;
-            var onCompletedTcs = new TaskCompletionSource<object>();
+            var onCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var hostBuilder = TransportSelector.GetWebHostBuilder()
                 .UseKestrel()
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task OnCompletedShouldNotBlockAResponse()
         {
-            var delayTcs = new TaskCompletionSource<object>();
+            var delayTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var hostBuilder = TransportSelector.GetWebHostBuilder()
                 .UseKestrel()
                 .UseUrls("http://127.0.0.1:0/")
@@ -375,7 +375,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task InvalidChunkedEncodingInRequestShouldNotBlockOnCompleted()
         {
-            var onCompletedTcs = new TaskCompletionSource<object>();
+            var onCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(httpContext =>
             {
@@ -418,7 +418,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             mockHttpContextFactory.Setup(f => f.Create(It.IsAny<IFeatureCollection>()))
                 .Returns<IFeatureCollection>(fc => new DefaultHttpContext(fc));
 
-            var disposedTcs = new TaskCompletionSource<int>();
+            var disposedTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             mockHttpContextFactory.Setup(f => f.Dispose(It.IsAny<HttpContext>()))
                 .Callback<HttpContext>(c =>
                 {
@@ -619,7 +619,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             const string response = "hello, world";
 
-            var logTcs = new TaskCompletionSource<object>();
+            var logTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockKestrelTrace = new Mock<IKestrelTrace>();
             mockKestrelTrace
                 .Setup(trace => trace.ConnectionHeadResponseBodyWrite(It.IsAny<string>(), response.Length))
@@ -808,7 +808,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task WhenAppWritesLessThanContentLengthErrorLogged()
         {
-            var logTcs = new TaskCompletionSource<object>();
+            var logTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockTrace = new Mock<IKestrelTrace>();
             mockTrace
                 .Setup(trace => trace.ApplicationError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<InvalidOperationException>()))
@@ -1182,7 +1182,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         {
             var connectionClosed = new ManualResetEventSlim();
             var requestStarted = new ManualResetEventSlim();
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(async httpContext =>
             {
@@ -2279,7 +2279,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             // Ensure string is long enough to disable write-behind buffering
             var largeString = new string('a', maxBytesPreCompleted + 1);
 
-            var writeTcs = new TaskCompletionSource<object>();
+            var writeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var requestAbortedWh = new ManualResetEventSlim();
             var requestStartWh = new ManualResetEventSlim();
 
@@ -2619,7 +2619,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var testContext= new TestServiceContext(LoggerFactory);
 
             var callOrder = new Stack<int>();
-            var onStartingTcs = new TaskCompletionSource<object>();
+            var onStartingTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(async context =>
             {
@@ -2671,7 +2671,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var testContext= new TestServiceContext(LoggerFactory);
 
             var callOrder = new Stack<int>();
-            var onCompletedTcs = new TaskCompletionSource<object>();
+            var onCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (var server = new TestServer(async context =>
             {
@@ -2815,10 +2815,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 var responseSize = chunks * chunkSize;
                 var chunkData = new byte[chunkSize];
 
-                var responseRateTimeoutMessageLogged = new TaskCompletionSource<object>();
-                var connectionStopMessageLogged = new TaskCompletionSource<object>();
-                var requestAborted = new TaskCompletionSource<object>();
-                var appFuncCompleted = new TaskCompletionSource<object>();
+                var responseRateTimeoutMessageLogged = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var connectionStopMessageLogged = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var requestAborted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var appFuncCompleted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 var mockKestrelTrace = new Mock<IKestrelTrace>();
                 mockKestrelTrace
@@ -2906,10 +2906,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
             var certificate = new X509Certificate2(TestResources.TestCertificatePath, "testPassword");
 
-            var responseRateTimeoutMessageLogged = new TaskCompletionSource<object>();
-            var connectionStopMessageLogged = new TaskCompletionSource<object>();
-            var aborted = new TaskCompletionSource<object>();
-            var appFuncCompleted = new TaskCompletionSource<object>();
+            var responseRateTimeoutMessageLogged = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectionStopMessageLogged = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var aborted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appFuncCompleted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var mockKestrelTrace = new Mock<IKestrelTrace>();
             mockKestrelTrace
@@ -2998,10 +2998,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var responseSize = bufferCount * bufferSize;
             var buffer = new byte[bufferSize];
 
-            var responseRateTimeoutMessageLogged = new TaskCompletionSource<object>();
-            var connectionStopMessageLogged = new TaskCompletionSource<object>();
-            var requestAborted = new TaskCompletionSource<object>();
-            var appFuncCompleted = new TaskCompletionSource<object>();
+            var responseRateTimeoutMessageLogged = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectionStopMessageLogged = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var requestAborted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appFuncCompleted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var mockKestrelTrace = new Mock<IKestrelTrace>();
             mockKestrelTrace
@@ -3085,7 +3085,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             var chunkData = new byte[chunkSize];
 
             var requestAborted = false;
-            var appFuncCompleted = new TaskCompletionSource<object>();
+            var appFuncCompleted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockKestrelTrace = new Mock<IKestrelTrace>();
 
             var testContext = new TestServiceContext

--- a/test/Kestrel.FunctionalTests/TestHelpers/HostNameIsReachableAttribute.cs
+++ b/test/Kestrel.FunctionalTests/TestHelpers/HostNameIsReachableAttribute.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         public static async Task<Socket> ConnectToHost(string hostName, int port)
         {
-            var tcs = new TaskCompletionSource<Socket>();
+            var tcs = new TaskCompletionSource<Socket>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var socketArgs = new SocketAsyncEventArgs();
             socketArgs.RemoteEndPoint = new DnsEndPoint(hostName, port);

--- a/test/Kestrel.FunctionalTests/UpgradeTests.cs
+++ b/test/Kestrel.FunctionalTests/UpgradeTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task ResponseThrowsAfterUpgrade()
         {
-            var upgrade = new TaskCompletionSource<bool>();
+            var upgrade = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (var server = new TestServer(async context =>
             {
                 var feature = context.Features.Get<IHttpUpgradeFeature>();
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             const string send = "Custom protocol send";
             const string recv = "Custom protocol recv";
 
-            var upgrade = new TaskCompletionSource<bool>();
+            var upgrade = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (var server = new TestServer(async context =>
             {
                 try
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task UpgradeCannotBeCalledMultipleTimes()
         {
-            var upgradeTcs = new TaskCompletionSource<object>();
+            var upgradeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (var server = new TestServer(async context =>
             {
                 var feature = context.Features.Get<IHttpUpgradeFeature>();
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task ThrowsWhenUpgradingNonUpgradableRequest()
         {
-            var upgradeTcs = new TaskCompletionSource<bool>();
+            var upgradeTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (var server = new TestServer(async context =>
             {
                  var feature = context.Features.Get<IHttpUpgradeFeature>();
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         public async Task RejectsUpgradeWhenLimitReached()
         {
             const int limit = 10;
-            var upgradeTcs = new TaskCompletionSource<object>();
+            var upgradeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var serviceContext = new TestServiceContext(LoggerFactory);
             serviceContext.ConnectionManager = new HttpConnectionManager(serviceContext.Log, ResourceCounter.Quota(limit));
 

--- a/test/Kestrel.Transport.Libuv.Tests/ListenerPrimaryTests.cs
+++ b/test/Kestrel.Transport.Libuv.Tests/ListenerPrimaryTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             Assert.Equal("Primary", await HttpClientSlim.GetStringAsync(address));
 
             // Create a pipe connection and keep it open without sending any data
-            var connectTcs = new TaskCompletionSource<object>();
+            var connectTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var connectionTrace = new LibuvTrace(new TestApplicationErrorLogger());
             var pipe = new UvPipeHandle(connectionTrace);
 

--- a/test/shared/TestConnection.cs
+++ b/test/shared/TestConnection.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Testing
 
         public Task WaitForConnectionClose()
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var eventArgs = new SocketAsyncEventArgs();
             eventArgs.SetBuffer(new byte[128], 0, 128);
             eventArgs.Completed += ReceiveAsyncCompleted;


### PR DESCRIPTION
These are test only changes. It's the combination of the following PRs backported for release/2.1:

- https://github.com/aspnet/KestrelHttpServer/pull/2531
- https://github.com/aspnet/KestrelHttpServer/pull/2567
- Parts of https://github.com/aspnet/KestrelHttpServer/pull/2526
- Parts of https://github.com/aspnet/KestrelHttpServer/pull/2547