### PR TITLE
[2.1.1] Provide clearer exception message for breaking change

### DIFF
--- a/src/Kestrel.Transport.Sockets/Properties/SocketsStrings.Designer.cs
+++ b/src/Kestrel.Transport.Sockets/Properties/SocketsStrings.Designer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             = new ResourceManager("Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketsStrings", typeof(SocketsStrings).GetTypeInfo().Assembly);
 
         /// <summary>
-        /// Only ListenType.IPEndPoint is supported.
+        /// Only ListenType.IPEndPoint is supported by the Socket Transport. To bind to other types of endpoints, try the Libuv Transport instead. https://github.com/aspnet/Announcements/issues/296
         /// </summary>
         internal static string OnlyIPEndPointsSupported
         {
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         }
 
         /// <summary>
-        /// Only ListenType.IPEndPoint is supported.
+        /// Only ListenType.IPEndPoint is supported by the Socket Transport. To bind to other types of endpoints, try the Libuv Transport instead. https://github.com/aspnet/Announcements/issues/296
         /// </summary>
         internal static string FormatOnlyIPEndPointsSupported()
             => GetString("OnlyIPEndPointsSupported");

--- a/src/Kestrel.Transport.Sockets/Properties/SocketsStrings.Designer.cs
+++ b/src/Kestrel.Transport.Sockets/Properties/SocketsStrings.Designer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             = new ResourceManager("Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketsStrings", typeof(SocketsStrings).GetTypeInfo().Assembly);
 
         /// <summary>
-        /// Only ListenType.IPEndPoint is supported by the Socket Transport. To bind to other types of endpoints, try the Libuv Transport instead. https://github.com/aspnet/Announcements/issues/296
+        /// Only ListenType.IPEndPoint is supported by the Socket Transport. https://go.microsoft.com/fwlink/?linkid=874850
         /// </summary>
         internal static string OnlyIPEndPointsSupported
         {
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         }
 
         /// <summary>
-        /// Only ListenType.IPEndPoint is supported by the Socket Transport. To bind to other types of endpoints, try the Libuv Transport instead. https://github.com/aspnet/Announcements/issues/296
+        /// Only ListenType.IPEndPoint is supported by the Socket Transport. https://go.microsoft.com/fwlink/?linkid=874850
         /// </summary>
         internal static string FormatOnlyIPEndPointsSupported()
             => GetString("OnlyIPEndPointsSupported");

--- a/src/Kestrel.Transport.Sockets/SocketsStrings.resx
+++ b/src/Kestrel.Transport.Sockets/SocketsStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="OnlyIPEndPointsSupported" xml:space="preserve">
-    <value>Only ListenType.IPEndPoint is supported by the Socket Transport. To bind to other types of endpoints, try the Libuv Transport instead. https://github.com/aspnet/Announcements/issues/296</value>
+    <value>Only ListenType.IPEndPoint is supported by the Socket Transport. https://go.microsoft.com/fwlink/?linkid=874850</value>
   </data>
   <data name="TransportAlreadyBound" xml:space="preserve">
     <value>Transport is already bound.</value>

--- a/src/Kestrel.Transport.Sockets/SocketsStrings.resx
+++ b/src/Kestrel.Transport.Sockets/SocketsStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="OnlyIPEndPointsSupported" xml:space="preserve">
-    <value>Only ListenType.IPEndPoint is supported.</value>
+    <value>Only ListenType.IPEndPoint is supported by the Socket Transport. To bind to other types of endpoints, try the Libuv Transport instead. https://github.com/aspnet/Announcements/issues/296</value>
   </data>
   <data name="TransportAlreadyBound" xml:space="preserve">
     <value>Transport is already bound.</value>


### PR DESCRIPTION
- In 2.1, the default transport (Sockets) can no longer bind to certain
  endpoint types (Unix domain sockets and open socket handles).

#2616