### PR TITLE
Disable AllowRenegotiation for HTTP/2

### DIFF
--- a/samples/Http2SampleApp/Http2SampleApp.csproj
+++ b/samples/Http2SampleApp/Http2SampleApp.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
   </PropertyGroup>

--- a/src/Kestrel.Core/Internal/HttpsConnectionAdapter.cs
+++ b/src/Kestrel.Core/Internal/HttpsConnectionAdapter.cs
@@ -158,6 +158,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
                 if ((_options.HttpProtocols & HttpProtocols.Http2) != 0)
                 {
                     sslOptions.ApplicationProtocols.Add(SslApplicationProtocol.Http2);
+                    // https://tools.ietf.org/html/rfc7540#section-9.2.1
+                    sslOptions.AllowRenegotiation = false;
                 }
 
                 if ((_options.HttpProtocols & HttpProtocols.Http1) != 0)

--- a/test/Kestrel.FunctionalTests/HttpsConnectionAdapterTests.cs
+++ b/test/Kestrel.FunctionalTests/HttpsConnectionAdapterTests.cs
@@ -12,6 +12,7 @@ using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -345,11 +346,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
-        [Fact]
-        public async Task CertificatePassedToHttpContext()
+        [Theory]
+        [InlineData(HttpProtocols.Http1)]
+        [InlineData(HttpProtocols.Http1AndHttp2)] // Make sure Http/1.1 doesn't regress with Http/2 enabled.
+        public async Task CertificatePassedToHttpContext(HttpProtocols httpProtocols)
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
             {
+                Protocols = httpProtocols,
                 ConnectionAdapters =
                 {
                     new HttpsConnectionAdapter(new HttpsConnectionAdapterOptions


### PR DESCRIPTION
#2251 This is a spec requirement.

I can't directly test it because SslStream doesn't have a client API to trigger a renegotiate. I added a test to ensure this didn't regress 1.1 client certs since renegotiation is often used to request optional client certs. We'll have to figure out http2 functional tests before I can write a http2 client cert test.