### PR TITLE
Enforce max frame size 

### DIFF
--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -497,9 +497,6 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="MultipleCertificateSources" xml:space="preserve">
     <value>The endpoint {endpointName} specified multiple certificate sources.</value>
   </data>
-  <data name="Http2NotSupported" xml:space="preserve">
-    <value>HTTP/2 support is experimental, see https://go.microsoft.com/fwlink/?linkid=866785 to enable it.</value>
-  </data>
   <data name="WritingToResponseBodyAfterResponseCompleted" xml:space="preserve">
     <value>Cannot write to the response body, the response has completed.</value>
   </data>
@@ -517,5 +514,8 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   </data>
   <data name="ConnectionTimedOutByServer" xml:space="preserve">
     <value>The connection was timed out by the server.</value>
+  </data>
+  <data name="Http2ErrorFrameOverLimit" xml:space="preserve">
+    <value>The received frame size of {size} exceeds the limit {limit}.</value>
   </data>
 </root>

--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     {
                         if (!readableBuffer.IsEmpty)
                         {
-                            if (Http2FrameReader.ReadFrame(readableBuffer, _incomingFrame, out consumed, out examined))
+                            if (Http2FrameReader.ReadFrame(readableBuffer, _incomingFrame, _serverSettings.MaxFrameSize, out consumed, out examined))
                             {
                                 Log.LogTrace($"Connection id {ConnectionId} received {_incomingFrame.Type} frame with flags 0x{_incomingFrame.Flags:x} and length {_incomingFrame.Length} for stream ID {_incomingFrame.StreamId}");
                                 await ProcessFrameAsync<TContext>(application);

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -1779,20 +1779,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             => string.Format(CultureInfo.CurrentCulture, GetString("MultipleCertificateSources", "endpointName"), endpointName);
 
         /// <summary>
-        /// HTTP/2 support is experimental, see https://go.microsoft.com/fwlink/?linkid=866785 to enable it.
-        /// </summary>
-        internal static string Http2NotSupported
-        {
-            get => GetString("Http2NotSupported");
-        }
-
-        /// <summary>
-        /// HTTP/2 support is experimental, see https://go.microsoft.com/fwlink/?linkid=866785 to enable it.
-        /// </summary>
-        internal static string FormatHttp2NotSupported()
-            => GetString("Http2NotSupported");
-
-        /// <summary>
         /// Cannot write to the response body, the response has completed.
         /// </summary>
         internal static string WritingToResponseBodyAfterResponseCompleted
@@ -1875,6 +1861,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// </summary>
         internal static string FormatConnectionTimedOutByServer()
             => GetString("ConnectionTimedOutByServer");
+
+        /// <summary>
+        /// The received frame size of {size} exceeds the limit {limit}.
+        /// </summary>
+        internal static string Http2ErrorFrameOverLimit
+        {
+            get => GetString("Http2ErrorFrameOverLimit");
+        }
+
+        /// <summary>
+        /// The received frame size of {size} exceeds the limit {limit}.
+        /// </summary>
+        internal static string FormatHttp2ErrorFrameOverLimit(object size, object limit)
+            => string.Format(CultureInfo.CurrentCulture, GetString("Http2ErrorFrameOverLimit", "size", "limit"), size, limit);
 
         private static string GetString(string name, params string[] formatterNames)
         {


### PR DESCRIPTION
#2651 The MaxFrameSize setting wasn't being enforced so instead you'd get an ArgumentOutOfRangeException for frames larger than the buffer. The h2spec test 4.2 found this, but it wasn't actually failing because the exception was still handled and terminated the connection, only with the wrong http2 error.