### PR TITLE
Receive and send RST frames

### DIFF
--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -227,6 +227,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         void IHttpRequestLifetimeFeature.Abort()
         {
+            ApplicationAbort();
+        }
+
+        protected virtual void ApplicationAbort()
+        {
             Log.ApplicationAbortedConnection(ConnectionId, TraceIdentifier);
             Abort(new ConnectionAbortedException(CoreStrings.ConnectionAbortedByApplication));
         }

--- a/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
@@ -73,7 +73,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public void Abort(ConnectionAbortedException abortReason)
         {
-            // TODO: RST_STREAM?
             Dispose();
         }
 
@@ -128,13 +127,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             lock (_dataWriterLock)
             {
+                // The HPACK header compressor is stateful, if we compress headers for an aborted stream we must send them.
+                // Optimize for not compressing or sending them.
                 if (_completed)
                 {
                     return;
                 }
 
-                // The HPACK header compressor is stateful, if we compress headers for an aborted stream we must send them.
-                // Optimize for not compressing or sending them.
                 _frameWriter.WriteResponseHeaders(_streamId, statusCode, responseHeaders);
             }
         }
@@ -178,6 +177,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
                 _dataPipe.Writer.Complete();
                 return _dataWriteProcessingTask;
+            }
+        }
+
+        public Task WriteRstStreamAsync(Http2ErrorCode error)
+        {
+            lock (_dataWriterLock)
+            {
+                // Always send the reset even if the response body is _completed. The request body may not have completed yet.
+
+                Dispose();
+
+                return _frameWriter.WriteRstStreamAsync(_streamId, error);
             }
         }
 


### PR DESCRIPTION
 #2462 @halter73 I still need to finish the logging and error messages, but I wanted to show you the concept first.
Once the client has sent us a reset for a given stream we should stop sending headers or data on that stream. The request continues normally and OnStarting still triggers, you only see the error if you check RequestAborted or pass a cancellable token to WriteAsync.