### PR TITLE
Complete the transport pipes after connection middleware runs

### DIFF
--- a/src/Kestrel.Core/Internal/ConnectionDispatcher.cs
+++ b/src/Kestrel.Core/Internal/ConnectionDispatcher.cs
@@ -59,6 +59,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 {
                     Log.LogCritical(0, ex, $"{nameof(ConnectionDispatcher)}.{nameof(Execute)}() {connectionContext.ConnectionId}");
                 }
+                finally
+                {
+                    // Complete the transport PipeReader and PipeWriter after calling into application code
+                    connectionContext.Transport.Input.Complete();
+                    connectionContext.Transport.Output.Complete();
+                }
             }
         }
 


### PR DESCRIPTION
- It's a safe guard for code that doesn't complete the pipes (makes sure we don't leak memory).
- It simplifies writing ConnectionHandlers