### PR TITLE
Enable Http/2 by default

### DIFF
--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -354,9 +354,6 @@
   <data name="EndPointRequiresAtLeastOneProtocol" xml:space="preserve">
     <value>An endpoint must be configured to serve at least one protocol.</value>
   </data>
-  <data name="EndPointRequiresTlsForHttp1AndHttp2" xml:space="preserve">
-    <value>Using both HTTP/1.x and HTTP/2 on the same endpoint requires the use of TLS.</value>
-  </data>
   <data name="EndPointHttp2NotNegotiated" xml:space="preserve">
     <value>HTTP/2 over TLS was not negotiated on an HTTP/2-only endpoint.</value>
   </data>

--- a/src/Kestrel.Core/Internal/HttpConnection.cs
+++ b/src/Kestrel.Core/Internal/HttpConnection.cs
@@ -363,11 +363,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 error = CoreStrings.EndPointRequiresAtLeastOneProtocol;
             }
 
-            if (!hasTls && http1Enabled && http2Enabled)
-            {
-                error = CoreStrings.EndPointRequiresTlsForHttp1AndHttp2;
-            }
-
             if (!http1Enabled && http2Enabled && hasTls && !Http2Id.Span.SequenceEqual(applicationProtocol.Span))
             {
                 error = CoreStrings.EndPointHttp2NotNegotiated;
@@ -377,6 +372,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             {
                 Log.LogError(0, error);
                 return HttpProtocols.None;
+            }
+
+            if (!hasTls && http1Enabled)
+            {
+                // Even if Http2 was enabled, default to Http1 because it's ambiguous without ALPN.
+                return HttpProtocols.Http1;
             }
 
             return http2Enabled && (!hasTls || Http2Id.Span.SequenceEqual(applicationProtocol.Span)) ? HttpProtocols.Http2 : HttpProtocols.Http1;

--- a/src/Kestrel.Core/ListenOptions.cs
+++ b/src/Kestrel.Core/ListenOptions.cs
@@ -126,8 +126,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// <summary>
         /// The protocols enabled on this endpoint.
         /// </summary>
-        /// <remarks>Defaults to HTTP/1.x only.</remarks>
-        public HttpProtocols Protocols { get; set; } = HttpProtocols.Http1;
+        /// <remarks>Defaults to HTTP/1.x and HTTP/2.</remarks>
+        public HttpProtocols Protocols { get; set; } = HttpProtocols.Http1AndHttp2;
 
         /// <summary>
         /// Gets the <see cref="List{IConnectionAdapter}"/> that allows each connection <see cref="System.IO.Stream"/>

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -1117,20 +1117,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             => GetString("EndPointRequiresAtLeastOneProtocol");
 
         /// <summary>
-        /// Using both HTTP/1.x and HTTP/2 on the same endpoint requires the use of TLS.
-        /// </summary>
-        internal static string EndPointRequiresTlsForHttp1AndHttp2
-        {
-            get => GetString("EndPointRequiresTlsForHttp1AndHttp2");
-        }
-
-        /// <summary>
-        /// Using both HTTP/1.x and HTTP/2 on the same endpoint requires the use of TLS.
-        /// </summary>
-        internal static string FormatEndPointRequiresTlsForHttp1AndHttp2()
-            => GetString("EndPointRequiresTlsForHttp1AndHttp2");
-
-        /// <summary>
         /// HTTP/2 over TLS was not negotiated on an HTTP/2-only endpoint.
         /// </summary>
         internal static string EndPointHttp2NotNegotiated

--- a/test/Kestrel.Core.Tests/ListenOptionsTests.cs
+++ b/test/Kestrel.Core.Tests/ListenOptionsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void ProtocolsDefault()
         {
             var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0));
-            Assert.Equal(HttpProtocols.Http1, listenOptions.Protocols);
+            Assert.Equal(HttpProtocols.Http1AndHttp2, listenOptions.Protocols);
         }
 
         [Fact]

--- a/test/Kestrel.FunctionalTests/HttpProtocolSelectionTests.cs
+++ b/test/Kestrel.FunctionalTests/HttpProtocolSelectionTests.cs
@@ -25,9 +25,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Fact]
-        public Task Server_Http1AndHttp2_Cleartext_Error()
+        public Task Server_Http1AndHttp2_Cleartext_Http1Default()
         {
-            return TestError<InvalidOperationException>(HttpProtocols.Http1AndHttp2, CoreStrings.EndPointRequiresTlsForHttp1AndHttp2);
+            return TestSuccess(HttpProtocols.Http1AndHttp2, "GET / HTTP/1.1\r\nHost:\r\n\r\n", "HTTP/1.1 200 OK");
         }
 
         [Fact]


### PR DESCRIPTION
 #2720 Making the default protocols Http1 and Http2. We want this for the previews to gather feedback. If it doesn't work out we can disable it again for RTM.

With these defaults:
For TLS it will rely on ALPN to select Http2 or else fall back to Http1.
For non-TLS it will pick Http1 (I removed one error check to enable this).

Once we get stephen's flow control [PR](#2740) in then we should be ready for this.