### PR TITLE
Disable memory pool late return validation in H2SpecTests

### DIFF
--- a/test/Kestrel.FunctionalTests/Http2/H2SpecTests.cs
+++ b/test/Kestrel.FunctionalTests/Http2/H2SpecTests.cs
@@ -26,7 +26,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
         [MemberData(nameof(H2SpecTestCases))]
         public async Task RunIndividualTestCase(H2SpecTestCase testCase)
         {
-            var hostBuilder = TransportSelector.GetWebHostBuilder()
+            var memoryPoolFactory = new DiagnosticMemoryPoolFactory(allowLateReturn: true);
+
+            var hostBuilder = TransportSelector.GetWebHostBuilder(memoryPoolFactory.Create)
                 .UseKestrel(options =>
                 {
                     options.Listen(IPAddress.Loopback, 0, listenOptions =>


### PR DESCRIPTION
See https://ci3.dot.net/job/aspnet_KestrelHttpServer/job/release_2.2/job/linux-Configuration_Debug_prtest/42/console for the test failure this prevents.

@JunTaoLuo We'll want to reenable this validation once graceful shutdown is implemented for HTTP/2.