### PR TITLE
Gracefully shutdown HTTP/2 connections on server shutdown

### DIFF
--- a/benchmarks/Kestrel.Performance/Mocks/MockTrace.cs
+++ b/benchmarks/Kestrel.Performance/Mocks/MockTrace.cs
@@ -50,5 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         public void Http2StreamError(string connectionId, Http2StreamErrorException ex) { }
         public void HPackDecodingError(string connectionId, int streamId, HPackDecodingException ex) { }
         public void Http2StreamResetAbort(string traceIdentifier, Http2ErrorCode error, ConnectionAbortedException abortReason) { }
+        public void Http2ConnectionClosing(string connectionId) { }
+        public void Http2ConnectionClosed(string connectionId, int highestOpenedStreamId) { }
     }
 }

--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -75,9 +75,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private PseudoHeaderFields _parsedPseudoHeaderFields;
         private Http2HeadersFrameFlags _headerFlags;
         private bool _isMethodConnect;
+        private readonly object _stateLock = new object();
         private int _highestOpenedStreamId;
-
-        private bool _stopping;
+        private Http2ConnectionState _state = Http2ConnectionState.Open;
 
         private readonly ConcurrentDictionary<int, Http2Stream> _streams = new ConcurrentDictionary<int, Http2Stream>();
 
@@ -98,20 +98,60 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public void OnInputOrOutputCompleted()
         {
-            _stopping = true;
+            lock (_stateLock)
+            {
+                if (_state != Http2ConnectionState.Closed)
+                {
+                    _frameWriter.WriteGoAwayAsync(_highestOpenedStreamId, Http2ErrorCode.NO_ERROR);
+                    UpdateState(Http2ConnectionState.Closed);
+                }
+            }
+
             _frameWriter.Complete();
         }
 
         public void Abort(ConnectionAbortedException ex)
         {
-            _stopping = true;
+            lock (_stateLock)
+            {
+                if (_state != Http2ConnectionState.Closed)
+                {
+                    _frameWriter.WriteGoAwayAsync(_highestOpenedStreamId, Http2ErrorCode.INTERNAL_ERROR);
+                    UpdateState(Http2ConnectionState.Closed);
+                }
+            }
+
             _frameWriter.Abort(ex);
         }
 
         public void StopProcessingNextRequest()
+            => StopProcessingNextRequest(true);
+
+        public void StopProcessingNextRequest(bool sendGracefulGoAway = false)
         {
-            _stopping = true;
-            Input.CancelPendingRead();
+            lock (_stateLock)
+            {
+                if (_state == Http2ConnectionState.Open)
+                {
+                    if (_streams.IsEmpty)
+                    {
+                        _frameWriter.WriteGoAwayAsync(_highestOpenedStreamId, Http2ErrorCode.NO_ERROR);
+                        UpdateState(Http2ConnectionState.Closed);
+
+                        // Wake up request processing loop so the connection can complete if there are no pending requests
+                        Input.CancelPendingRead();
+                    }
+                    else
+                    {
+                        if (sendGracefulGoAway)
+                        {
+                            _frameWriter.WriteGoAwayAsync(Int32.MaxValue, Http2ErrorCode.NO_ERROR);
+                        }
+
+                        UpdateState(Http2ConnectionState.Closing);
+                    }
+                }
+            }
         }
 
         public async Task ProcessRequestsAsync<TContext>(IHttpApplication<TContext> application)
@@ -128,12 +168,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     return;
                 }
 
-                if (!_stopping)
+                if (_state != Http2ConnectionState.Closed)
                 {
                     await _frameWriter.WriteSettingsAsync(_serverSettings);
                 }
 
-                while (!_stopping)
+                while (_state != Http2ConnectionState.Closed)
                 {
                     var result = await Input.ReadAsync();
                     var readableBuffer = result.Buffer;
@@ -198,11 +238,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
             finally
             {
-                 var connectionError = error as ConnectionAbortedException
+                var connectionError = error as ConnectionAbortedException
                     ?? new ConnectionAbortedException(CoreStrings.Http2ConnectionFaulted, error);
 
                 try
                 {
+                    lock (_stateLock)
+                    {
+                        if (_state != Http2ConnectionState.Closed)
+                        {
+                            _frameWriter.WriteGoAwayAsync(_highestOpenedStreamId, errorCode);
+                            UpdateState(Http2ConnectionState.Closed);
+                        }
+                    }
+
                     // Ensure aborting each stream doesn't result in unnecessary WINDOW_UPDATE frames being sent.
                     _inputFlowControl.StopWindowUpdates();
 
@@ -211,7 +260,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                         stream.Abort(connectionError);
                     }
 
-                    await _frameWriter.WriteGoAwayAsync(_highestOpenedStreamId, errorCode);
                     _frameWriter.Complete();
                 }
                 catch
@@ -245,7 +293,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         private async Task<bool> TryReadPrefaceAsync()
         {
-            while (!_stopping)
+            while (_state != Http2ConnectionState.Closed)
             {
                 var result = await Input.ReadAsync();
                 var readableBuffer = result.Buffer;
@@ -625,7 +673,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorStreamIdNotZero(_incomingFrame.Type), Http2ErrorCode.PROTOCOL_ERROR);
             }
 
-            StopProcessingNextRequest();
+            StopProcessingNextRequest(sendGracefulGoAway: false);
+
             return Task.CompletedTask;
         }
 
@@ -725,12 +774,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             try
             {
-                _hpackDecoder.Decode(payload, endHeaders, handler: this);
-
-                if (endHeaders)
+                lock (_stateLock)
                 {
-                    StartStream(application);
-                    ResetRequestHeaderParsingState();
+                    _highestOpenedStreamId = _currentHeadersStream.StreamId;
+                    _hpackDecoder.Decode(payload, endHeaders, handler: this);
+
+                    if (endHeaders)
+                    {
+                        if (_state != Http2ConnectionState.Closed)
+                        {
+                            StartStream(application);
+                        }
+
+                        ResetRequestHeaderParsingState();
+                    }
                 }
             }
             catch (Http2StreamErrorException)
@@ -786,11 +843,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         private void ResetRequestHeaderParsingState()
         {
-            if (_requestHeaderParsingState != RequestHeaderParsingState.Trailers)
-            {
-                _highestOpenedStreamId = _currentHeadersStream.StreamId;
-            }
-
             _currentHeadersStream = null;
             _requestHeaderParsingState = RequestHeaderParsingState.Ready;
             _parsedPseudoHeaderFields = PseudoHeaderFields.None;
@@ -827,7 +879,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         void IHttp2StreamLifetimeHandler.OnStreamCompleted(int streamId)
         {
-            _streams.TryRemove(streamId, out _);
+            lock (_stateLock)
+            {
+                _streams.TryRemove(streamId, out _);
+
+                if (_state == Http2ConnectionState.Closing && _streams.IsEmpty)
+                {
+                    _frameWriter.WriteGoAwayAsync(_highestOpenedStreamId, Http2ErrorCode.NO_ERROR);
+                    UpdateState(Http2ConnectionState.Closed);
+
+                    // Wake up request processing loop so the connection can complete if there are no pending requests
+                    Input.CancelPendingRead();
+                }
+            }
         }
 
         public void OnHeader(Span<byte> name, Span<byte> value)
@@ -953,6 +1017,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private static bool IsConnectionSpecificHeaderField(Span<byte> name, Span<byte> value)
         {
             return name.SequenceEqual(_connectionBytes) || (name.SequenceEqual(_teBytes) && !value.SequenceEqual(_trailersBytes));
+        }
+
+        private void UpdateState(Http2ConnectionState state)
+        {
+            _state = state;
+            if (state == Http2ConnectionState.Closing)
+            {
+                Log.Http2ConnectionClosing(_context.ConnectionId);
+            }
+            else if (state == Http2ConnectionState.Closed)
+            {
+                Log.Http2ConnectionClosed(_context.ConnectionId, _highestOpenedStreamId);
+            }
         }
 
         void ITimeoutControl.SetTimeout(long ticks, TimeoutAction timeoutAction)

--- a/src/Kestrel.Core/Internal/Http2/Http2ConnectionState.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2ConnectionState.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
+{
+    public enum Http2ConnectionState
+    {
+        Open = 0,
+        Closing,
+        Closed
+    }
+}

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.GoAway.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.GoAway.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     {
         public int GoAwayLastStreamId
         {
-            get => (Payload[0] << 24) | (Payload[1] << 16) | (Payload[2] << 16) | Payload[3];
+            get => (Payload[0] << 24) | (Payload[1] << 16) | (Payload[2] << 8) | Payload[3];
             set
             {
                 Payload[0] = (byte)((value >> 24) & 0xff);
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public Http2ErrorCode GoAwayErrorCode
         {
-            get => (Http2ErrorCode)((Payload[4] << 24) | (Payload[5] << 16) | (Payload[6] << 16) | Payload[7]);
+            get => (Http2ErrorCode)((Payload[4] << 24) | (Payload[5] << 16) | (Payload[6] << 8) | Payload[7]);
             set
             {
                 Payload[4] = (byte)(((uint)value >> 24) & 0xff);

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.RstStream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.RstStream.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     {
         public Http2ErrorCode RstStreamErrorCode
         {
-            get => (Http2ErrorCode)((Payload[0] << 24) | (Payload[1] << 16) | (Payload[2] << 16) | Payload[3]);
+            get => (Http2ErrorCode)((Payload[0] << 24) | (Payload[1] << 16) | (Payload[2] << 8) | Payload[3]);
             set
             {
                 Payload[0] = (byte)(((uint)value >> 24) & 0xff);

--- a/src/Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
@@ -57,6 +57,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         void Http2ConnectionError(string connectionId, Http2ConnectionErrorException ex);
 
+        void Http2ConnectionClosing(string connectionId);
+
+        void Http2ConnectionClosed(string connectionId, int highestOpenedStreamId);
+
         void Http2StreamError(string connectionId, Http2StreamErrorException ex);
 
         void Http2StreamResetAbort(string traceIdentifier, Http2ErrorCode error, ConnectionAbortedException abortReason);

--- a/src/Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
@@ -91,6 +91,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             LoggerMessage.Define<string, Http2ErrorCode>(LogLevel.Debug, new EventId(35, nameof(Http2StreamResetAbort)),
                 @"Trace id ""{TraceIdentifier}"": HTTP/2 stream error ""{error}"". A Reset is being sent to the stream.");
 
+        private static readonly Action<ILogger, string, Exception> _http2ConnectionClosing =
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(36, nameof(Http2ConnectionClosing)),
+                @"Connection id ""{ConnectionId}"" is closing.");
+
+        private static readonly Action<ILogger, string, int, Exception> _http2ConnectionClosed =
+            LoggerMessage.Define<string, int>(LogLevel.Debug, new EventId(36, nameof(Http2ConnectionClosed)),
+                @"Connection id ""{ConnectionId}"" is closed. The last processed stream ID was {HighestOpenedStreamId}.");
+
         protected readonly ILogger _logger;
 
         public KestrelTrace(ILogger logger)
@@ -211,6 +219,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         public virtual void Http2ConnectionError(string connectionId, Http2ConnectionErrorException ex)
         {
             _http2ConnectionError(_logger, connectionId, ex);
+        }
+
+        public virtual void Http2ConnectionClosing(string connectionId)
+        {
+            _http2ConnectionClosing(_logger, connectionId, null);
+        }
+
+        public virtual void Http2ConnectionClosed(string connectionId, int highestOpenedStreamId)
+        {
+            _http2ConnectionClosed(_logger, connectionId, highestOpenedStreamId, null);
         }
 
         public virtual void Http2StreamError(string connectionId, Http2StreamErrorException ex)

--- a/test/Kestrel.FunctionalTests/Http2/ShutdownTests.cs
+++ b/test/Kestrel.FunctionalTests/Http2/ShutdownTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NETCOREAPP2_2
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
+{
+    [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing SslStream ALPN support: https://github.com/dotnet/corefx/issues/30492")]
+    [OSSkipCondition(OperatingSystems.Linux, SkipReason = "Curl requires a custom install to support HTTP/2, see https://askubuntu.com/questions/884899/how-do-i-install-curl-with-http2-support")]
+    [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10)]
+    public class ShutdownTests : TestApplicationErrorLoggerLoggedTest
+    {
+        private static X509Certificate2 _x509Certificate2 = TestResources.GetTestCertificate();
+
+        private HttpClient Client { get; set; }
+        private List<Http2Frame> ReceivedFrames { get; } = new List<Http2Frame>();
+
+        public ShutdownTests()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // We don't want the default SocketsHttpHandler, it doesn't support HTTP/2 yet.
+                Client = new HttpClient(new WinHttpHandler()
+                {
+                    ServerCertificateValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                });
+            }
+        }
+
+        [ConditionalFact]
+        public async Task GracefulShutdownWaitsForRequestsToFinish()
+        {
+            var requestStarted = new TaskCompletionSource<object>();
+            var requestUnblocked = new TaskCompletionSource<object>();
+            using (var server = new TestServer(async context =>
+            {
+                requestStarted.SetResult(null);
+                await requestUnblocked.Task.DefaultTimeout();
+                await context.Response.WriteAsync("hello world " + context.Request.Protocol);
+            },
+            new TestServiceContext(LoggerFactory),
+            kestrelOptions =>
+            {
+                kestrelOptions.Listen(IPAddress.Loopback, 0, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http2;
+                    listenOptions.UseHttps(_x509Certificate2);
+                });
+            }))
+            {
+                var requestTask = Client.GetStringAsync($"https://localhost:{server.Port}/");
+                Assert.False(requestTask.IsCompleted);
+
+                await requestStarted.Task.DefaultTimeout();
+
+                var stopTask = server.StopAsync();
+
+                // Unblock the request
+                requestUnblocked.SetResult(null);
+
+                Assert.Equal("hello world HTTP/2", await requestTask);
+                await stopTask.DefaultTimeout();
+            }
+
+            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("Request finished in"));
+            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closing."));
+            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
+        }
+
+        [ConditionalFact]
+        public async Task GracefulTurnsAbortiveIfRequestsDoNotFinish()
+        {
+            var requestStarted = new TaskCompletionSource<object>();
+            var requestUnblocked = new TaskCompletionSource<object>();
+            // Abortive shutdown leaves one request hanging
+            using (var server = new TestServer(TransportSelector.GetWebHostBuilder(new DiagnosticMemoryPoolFactory(allowLateReturn: true).Create), async context =>
+            {
+                requestStarted.SetResult(null);
+                await requestUnblocked.Task.DefaultTimeout();
+                await context.Response.WriteAsync("hello world " + context.Request.Protocol);
+            }, new TestServiceContext(LoggerFactory),
+            kestrelOptions =>
+            {
+                kestrelOptions.Listen(IPAddress.Loopback, 0, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http2;
+                    listenOptions.UseHttps(_x509Certificate2);
+                });
+            },
+            _ => { }))
+            {
+                var requestTask = Client.GetStringAsync($"https://localhost:{server.Port}/");
+                Assert.False(requestTask.IsCompleted);
+                await requestStarted.Task.DefaultTimeout();
+
+                await server.StopAsync().DefaultTimeout();
+            }
+
+            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closing."));
+            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
+            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("Some connections failed to close gracefully during server shutdown."));
+            Assert.DoesNotContain(TestApplicationErrorLogger.Messages, m => m.Message.Contains("Request finished in"));
+        }
+    }
+}
+#elif NET461 // No ALPN support
+#else
+#error TFMs need updating
+#endif

--- a/test/shared/CompositeKestrelTrace.cs
+++ b/test/shared/CompositeKestrelTrace.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
@@ -195,6 +193,18 @@ namespace Microsoft.AspNetCore.Testing
         {
             _trace1.Http2StreamResetAbort(traceIdentifier, error, abortReason);
             _trace2.Http2StreamResetAbort(traceIdentifier, error, abortReason);
+        }
+
+        public void Http2ConnectionClosing(string connectionId)
+        {
+            _trace1.Http2ConnectionClosing(connectionId);
+            _trace2.Http2ConnectionClosing(connectionId);
+        }
+
+        public void Http2ConnectionClosed(string connectionId, int highestOpenedStreamId)
+        {
+            _trace1.Http2ConnectionClosed(connectionId, highestOpenedStreamId);
+            _trace2.Http2ConnectionClosed(connectionId, highestOpenedStreamId);
         }
     }
 }

--- a/test/shared/TestServiceContext.cs
+++ b/test/shared/TestServiceContext.cs
@@ -1,13 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO.Pipelines;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 


### PR DESCRIPTION
Addresses https://github.com/aspnet/KestrelHttpServer/issues/2703 and https://github.com/aspnet/KestrelHttpServer/issues/2671. 

Adding a FSM to Http2Connection:
1. Open - This is the initial state. During this state, we will process all incoming requests
2. Closing - This state is reached upon receiving a GOAWAY from the client or when the server receives the signal to shutdown (via ctrl-c for example). During this state we will still process incoming frames on streams that are open. Once all streams complete, the connection will be closed. During server initiated shutdown, we will send a GOAWAY to the client with max value for highest opened stream id as a notification to the client that shutdown is imminent but we are still processing existing requests.
3. Closed - This state is reached upon abortive shutdown, or when all remaining streams have been closed while in the Closing state. We send a final GOAWAY to the client that also include the actual highest opened stream ID we processed.