### PR TITLE
Send Resets for unhandled app exceptions

### DIFF
--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -563,4 +563,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http2StreamErrorMoreDataThanLength" xml:space="preserve">
     <value>More data received than specified in the Content-Length header.</value>
   </data>
+  <data name="Http2StreamErrorAfterHeaders" xml:space="preserve">
+    <value>An error occured after the response headers were sent, a reset is being sent.</value>
+  </data>
 </root>

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
@@ -1032,8 +1032,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (HasResponseStarted)
                 {
-                    // We can no longer change the response, so we simply close the connection.
-                    _keepAlive = false;
+                    ErrorAfterResponseStarted();
                     return Task.CompletedTask;
                 }
 
@@ -1056,6 +1055,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             return WriteSuffix();
+        }
+
+        protected virtual void ErrorAfterResponseStarted()
+        {
+            // We can no longer change the response, so we simply close the connection.
+            _keepAlive = false;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -362,10 +362,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             AbortCore(abortReason);
         }
 
+        protected override void ErrorAfterResponseStarted()
+        {
+            // We can no longer change the response, send a Reset instead.
+            base.ErrorAfterResponseStarted();
+            var abortReason = new ConnectionAbortedException(CoreStrings.Http2StreamErrorAfterHeaders);
+            ResetAndAbort(abortReason, Http2ErrorCode.INTERNAL_ERROR);
+        }
+
         protected override void ApplicationAbort()
         {
             var abortReason = new ConnectionAbortedException(CoreStrings.ConnectionAbortedByApplication);
-            ResetAndAbort(abortReason, Http2ErrorCode.CANCEL);
+            ResetAndAbort(abortReason, Http2ErrorCode.INTERNAL_ERROR);
         }
 
         private void ResetAndAbort(ConnectionAbortedException abortReason, Http2ErrorCode error)

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -2086,6 +2086,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal static string FormatHttp2StreamErrorMoreDataThanLength()
             => GetString("Http2StreamErrorMoreDataThanLength");
 
+        /// <summary>
+        /// An error occured after the response headers were sent, a reset is being sent.
+        /// </summary>
+        internal static string Http2StreamErrorAfterHeaders
+        {
+            get => GetString("Http2StreamErrorAfterHeaders");
+        }
+
+        /// <summary>
+        /// An error occured after the response headers were sent, a reset is being sent.
+        /// </summary>
+        internal static string FormatHttp2StreamErrorAfterHeaders()
+            => GetString("Http2StreamErrorAfterHeaders");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);


### PR DESCRIPTION
This was all that was required to address #2733 for response content-length mismatches. The length was already being tracked and verified at the HttpProtocol layer, but the resulting exceptions were not triggering a Reset.

The broader problem was that no unhandled application exception was triggering a Reset. I've added a new override point for this.