### PR TITLE
Improve exception handling in Http2Connection.ProcessRequestsAsync

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.IO;
 using System.IO.Pipelines;
 using System.Security.Authentication;
 using System.Text;
@@ -14,8 +15,8 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
@@ -218,6 +219,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
                 error = ex;
             }
+            catch (IOException ex)
+            {
+                Log.RequestProcessingError(ConnectionId, ex);
+                error = ex;
+            }
             catch (Http2ConnectionErrorException ex)
             {
                 Log.Http2ConnectionError(ConnectionId, ex);
@@ -232,9 +238,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
             catch (Exception ex)
             {
+                Log.LogWarning(0, ex, CoreStrings.RequestProcessingEndError);
                 error = ex;
                 errorCode = Http2ErrorCode.INTERNAL_ERROR;
-                throw;
             }
             finally
             {

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
@@ -3418,6 +3419,36 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StartStreamAsync(3, _browserRequestHeaders, endStream: false);
 
             await WaitForConnectionStopAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
+        public void IOExceptionDuringFrameProcessingLoggedAsInfo()
+        {
+            var ioException = new IOException();
+            _pair.Application.Output.Complete(ioException);
+
+            Assert.Equal(TaskStatus.RanToCompletion, _connection.ProcessRequestsAsync(new DummyApplication(_noopApplication)).Status);
+
+            var logMessage = _logger.Messages.Single();
+
+            Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+            Assert.Equal("Connection id \"(null)\" request processing ended abnormally.", logMessage.Message);
+            Assert.Same(ioException, logMessage.Exception);
+        }
+
+        [Fact]
+        public void UnexpectedExceptionDuringFrameProcessingLoggedAWarning()
+        {
+            var exception = new Exception();
+            _pair.Application.Output.Complete(exception);
+
+            Assert.Equal(TaskStatus.RanToCompletion, _connection.ProcessRequestsAsync(new DummyApplication(_noopApplication)).Status);
+
+            var logMessage = _logger.Messages.Single();
+
+            Assert.Equal(LogLevel.Warning, logMessage.LogLevel);
+            Assert.Equal(CoreStrings.RequestProcessingEndError, logMessage.Message);
+            Assert.Same(exception, logMessage.Exception);
         }
 
         private async Task InitializeConnectionAsync(RequestDelegate application)


### PR DESCRIPTION
This change basically copies the exception handling behavior of HttpProtocol.ProcessRequestsAsync into Http2Connection.ProcessRequestsAsync.

Prior to this change some functional tests were triggering critical logs like the following:

```
  Log Critical[0]: Unexpected exception in HttpConnection.ProcessRequestsAsync. System.IO.IOException: The read operation failed, see inner exception. ---> Microsoft.AspNetCore.Connections.ConnectionAbortedException: The connection was aborted
     at System.IO.Pipelines.PipeCompletion.ThrowLatchedException()
     at System.IO.Pipelines.Pipe.GetReadResult(ReadResult& result)
     at System.IO.Pipelines.Pipe.GetReadAsyncResult()
     at Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal.RawStream.ReadAsyncInternal(Memory`1 destination) in G:\dev\aspnet\KestrelHttpServer\src\Kestrel.Core\Adapter\Internal\RawStream.cs:line 122
     at System.Net.Security.SslStreamInternal.<FillBufferAsync>g__InternalFillBufferAsync|38_0[TReadAdapter](TReadAdapter adap, ValueTask`1 task, Int32 min, Int32 initial)
     at System.Net.Security.SslStreamInternal.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)
     --- End of inner exception stack trace ---
     at System.Net.Security.SslStreamInternal.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)
     at Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal.AdaptedPipeline.ReadInputAsync(Stream stream) in G:\dev\aspnet\KestrelHttpServer\src\Kestrel.Core\Adapter\Internal\AdaptedPipeline.cs:line 135
     at System.IO.Pipelines.PipeCompletion.ThrowLatchedException()
     at System.IO.Pipelines.Pipe.GetReadResult(ReadResult& result)
     at System.IO.Pipelines.Pipe.GetReadAsyncResult()
     at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2Connection.ProcessRequestsAsync[TContext](IHttpApplication`1 application) in G:\dev\aspnet\KestrelHttpServer\src\Kestrel.Core\Internal\Http2\Http2Connection.cs:line 178
     at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.HttpConnection.ProcessRequestsAsync[TContext](IHttpApplication`1 httpApplication) in G:\dev\
```

I haven't worked out exactly which test(s) are triggering these logs, but I suspect the H2Spec tests. Either way, IOExceptions should be handled more gracefully than they were.