### PR TITLE
Logging and settings ack

### DIFF
--- a/benchmarks/Kestrel.Performance/Mocks/MockTrace.cs
+++ b/benchmarks/Kestrel.Performance/Mocks/MockTrace.cs
@@ -52,5 +52,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         public void Http2StreamResetAbort(string traceIdentifier, Http2ErrorCode error, ConnectionAbortedException abortReason) { }
         public void Http2ConnectionClosing(string connectionId) { }
         public void Http2ConnectionClosed(string connectionId, int highestOpenedStreamId) { }
+        public void Http2FrameReceived(string connectionId, Http2Frame frame) { }
+        public void Http2FrameSending(string connectionId, Http2Frame frame) { }
     }
 }

--- a/samples/Http2SampleApp/Program.cs
+++ b/samples/Http2SampleApp/Program.cs
@@ -44,7 +44,7 @@ namespace Http2SampleApp
                     {
                         listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
                         listenOptions.UseHttps("testCert.pfx", "testPassword");
-                        listenOptions.UseConnectionLogging();
+                        // listenOptions.UseConnectionLogging();
                         listenOptions.ConnectionAdapters.Add(new TlsFilterAdapter());
                     });
 
@@ -53,7 +53,7 @@ namespace Http2SampleApp
                     options.Listen(IPAddress.Any, basePort + 5, listenOptions =>
                     {
                         listenOptions.Protocols = HttpProtocols.Http2;
-                        listenOptions.UseConnectionLogging();
+                        // listenOptions.UseConnectionLogging();
                     });
                 })
                 .UseContentRoot(Directory.GetCurrentDirectory())

--- a/samples/Http2SampleApp/Program.cs
+++ b/samples/Http2SampleApp/Program.cs
@@ -36,7 +36,6 @@ namespace Http2SampleApp
                     options.Listen(IPAddress.Any, basePort, listenOptions =>
                     {
                         listenOptions.Protocols = HttpProtocols.Http1;
-                        listenOptions.UseConnectionLogging();
                     });
 
                     // TLS Http/1.1 or HTTP/2 endpoint negotiated via ALPN
@@ -44,7 +43,6 @@ namespace Http2SampleApp
                     {
                         listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
                         listenOptions.UseHttps("testCert.pfx", "testPassword");
-                        // listenOptions.UseConnectionLogging();
                         listenOptions.ConnectionAdapters.Add(new TlsFilterAdapter());
                     });
 
@@ -53,7 +51,6 @@ namespace Http2SampleApp
                     options.Listen(IPAddress.Any, basePort + 5, listenOptions =>
                     {
                         listenOptions.Protocols = HttpProtocols.Http2;
-                        // listenOptions.UseConnectionLogging();
                     });
                 })
                 .UseContentRoot(Directory.GetCurrentDirectory())

--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -608,6 +608,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
                 _clientSettings.ParseFrame(_incomingFrame);
 
+                var ackTask = _frameWriter.WriteSettingsAckAsync(); // Ack before we update the windows, they could send data immediately.
+
                 // This difference can be negative.
                 var windowSizeDifference = (int)_clientSettings.InitialWindowSize - previousInitialWindowSize;
 
@@ -625,7 +627,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     }
                 }
 
-                return _frameWriter.WriteSettingsAckAsync();
+                return ackTask;
             }
             catch (Http2SettingsParameterOutOfRangeException ex)
             {

--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         public Http2Connection(Http2ConnectionContext context)
         {
             _context = context;
-            _frameWriter = new Http2FrameWriter(context.Transport.Output, context.Application.Input, _outputFlowControl, this);
+            _frameWriter = new Http2FrameWriter(context.Transport.Output, context.Application.Input, _outputFlowControl, this, context.ConnectionId, context.ServiceContext.Log);
             _hpackDecoder = new HPackDecoder((int)_serverSettings.HeaderTableSize);
         }
 
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                         {
                             if (Http2FrameReader.ReadFrame(readableBuffer, _incomingFrame, _serverSettings.MaxFrameSize, out consumed, out examined))
                             {
-                                Log.LogTrace($"Connection id {ConnectionId} received {_incomingFrame.Type} frame with flags 0x{_incomingFrame.Flags:x} and length {_incomingFrame.Length} for stream ID {_incomingFrame.StreamId}");
+                                Log.Http2FrameReceived(ConnectionId, _incomingFrame);
                                 await ProcessFrameAsync(application);
                             }
                         }

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Data.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Data.cs
@@ -46,5 +46,33 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             logger.LogTrace("'DATA' Frame. Flags = {DataFlags}, PadLength = {PadLength}, PayloadLength = {PayloadLength}", DataFlags, DataPadLength, DataPayload.Count);
         }
+
+        internal object ShowFlags()
+        {
+            switch (Type)
+            {
+                case Http2FrameType.CONTINUATION:
+                    return ContinuationFlags;
+                case Http2FrameType.DATA:
+                    return DataFlags;
+                case Http2FrameType.HEADERS:
+                    return HeadersFlags;
+                case Http2FrameType.SETTINGS:
+                    return SettingsFlags;
+                case Http2FrameType.PING:
+                    return PingFlags;
+
+                // Not Implemented
+                case Http2FrameType.PUSH_PROMISE:
+
+                // No flags defined
+                case Http2FrameType.PRIORITY:
+                case Http2FrameType.RST_STREAM:
+                case Http2FrameType.GOAWAY:
+                case Http2FrameType.WINDOW_UPDATE:
+                default:
+                    return $"0x{Flags:x}";
+            }
+        }
     }
 }

--- a/src/Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
@@ -66,5 +66,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         void Http2StreamResetAbort(string traceIdentifier, Http2ErrorCode error, ConnectionAbortedException abortReason);
 
         void HPackDecodingError(string connectionId, int streamId, HPackDecodingException ex);
+
+        void Http2FrameReceived(string connectionId, Http2Frame frame);
+
+        void Http2FrameSending(string connectionId, Http2Frame frame);
     }
 }

--- a/src/Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
@@ -99,6 +99,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             LoggerMessage.Define<string, int>(LogLevel.Debug, new EventId(36, nameof(Http2ConnectionClosed)),
                 @"Connection id ""{ConnectionId}"" is closed. The last processed stream ID was {HighestOpenedStreamId}.");
 
+        private static readonly Action<ILogger, string, Http2FrameType, int, int, object, Exception> _http2FrameReceived =
+            LoggerMessage.Define<string, Http2FrameType, int, int, object>(LogLevel.Trace, new EventId(37, nameof(Http2FrameReceived)),
+                @"Connection id ""{ConnectionId}"" received {type} frame for stream ID {id} with length {length} and flags {flags}");
+
+        private static readonly Action<ILogger, string, Http2FrameType, int, int, object, Exception> _http2FrameSending =
+            LoggerMessage.Define<string, Http2FrameType, int, int, object>(LogLevel.Trace, new EventId(37, nameof(Http2FrameReceived)),
+                @"Connection id ""{ConnectionId}"" sending {type} frame for stream ID {id} with length {length} and flags {flags}");
+
         protected readonly ILogger _logger;
 
         public KestrelTrace(ILogger logger)
@@ -244,6 +252,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         public virtual void HPackDecodingError(string connectionId, int streamId, HPackDecodingException ex)
         {
             _hpackDecodingError(_logger, connectionId, streamId, ex);
+        }
+
+        public void Http2FrameReceived(string connectionId, Http2Frame frame)
+        {
+            _http2FrameReceived(_logger, connectionId, frame.Type, frame.StreamId, frame.Length, frame.ShowFlags(), null);
+        }
+
+        public void Http2FrameSending(string connectionId, Http2Frame frame)
+        {
+            _http2FrameSending(_logger, connectionId, frame.Type, frame.StreamId, frame.Length, frame.ShowFlags(), null);
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)

--- a/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
+++ b/test/Kestrel.Core.Tests/Http2ConnectionTests.cs
@@ -2328,6 +2328,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _clientSettings.InitialWindowSize += 1;
             await SendSettingsAsync();
 
+            await ExpectAsync(Http2FrameType.SETTINGS,
+                withLength: 0,
+                withFlags: (byte)Http2SettingsFrameFlags.ACK,
+                withStreamId: 0);
+
             await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
                 ignoreNonGoAwayFrames: false,
                 expectedLastStreamId: 1,

--- a/test/shared/CompositeKestrelTrace.cs
+++ b/test/shared/CompositeKestrelTrace.cs
@@ -206,5 +206,17 @@ namespace Microsoft.AspNetCore.Testing
             _trace1.Http2ConnectionClosed(connectionId, highestOpenedStreamId);
             _trace2.Http2ConnectionClosed(connectionId, highestOpenedStreamId);
         }
+
+        public void Http2FrameReceived(string connectionId, Http2Frame frame)
+        {
+            _trace1.Http2FrameReceived(connectionId, frame);
+            _trace2.Http2FrameReceived(connectionId, frame);
+        }
+
+        public void Http2FrameSending(string connectionId, Http2Frame frame)
+        {
+            _trace1.Http2FrameSending(connectionId, frame);
+            _trace2.Http2FrameSending(connectionId, frame);
+        }
     }
 }


### PR DESCRIPTION
I Improved request frame logging and added response frame logging to help debug #2772. Here's a sample of the new logs:

```
      Connection id "0HLFT9VMIK352" started.
trce: Microsoft.AspNetCore.Server.Kestrel[37]
      Connection id "0HLFT9VMIK352" sending SETTINGS frame for stream ID 0 with length 0 and flags NONE
trce: Microsoft.AspNetCore.Server.Kestrel[37]
      Connection id "0HLFT9VMIK352" received SETTINGS frame for stream ID 0 with length 18 and flags NONE
trce: Microsoft.AspNetCore.Server.Kestrel[37]
      Connection id "0HLFT9VMIK352" sending SETTINGS frame for stream ID 0 with length 0 and flags ACK
trce: Microsoft.AspNetCore.Server.Kestrel[37]
      Connection id "0HLFT9VMIK352" received WINDOW_UPDATE frame for stream ID 0 with length 4 and flags 0x0
trce: Microsoft.AspNetCore.Server.Kestrel[37]
      Connection id "0HLFT9VMIK352" received HEADERS frame for stream ID 1 with length 235 and flags END_STREAM, END_HEADERS, PRIORITY
trce: Microsoft.AspNetCore.Server.Kestrel[37]
      Connection id "0HLFT9VMIK352" received SETTINGS frame for stream ID 0 with length 0 and flags ACK
info: Microsoft.AspNetCore.Hosting.Internal.WebHost[1]
      Request starting HTTP/2 GET https://localhost:5001/
trce: Microsoft.AspNetCore.Server.Kestrel[37]
      Connection id "0HLFT9VMIK352" sending HEADERS frame for stream ID 1 with length 53 and flags END_HEADERS
trce: Microsoft.AspNetCore.Server.Kestrel[37]
      Connection id "0HLFT9VMIK352" sending DATA frame for stream ID 1 with length 19 and flags NONE
trce: Microsoft.AspNetCore.Server.Kestrel[37]
      Connection id "0HLFT9VMIK352" sending DATA frame for stream ID 1 with length 0 and flags END_STREAM
info: Microsoft.AspNetCore.Hosting.Internal.WebHost[2]
      Request finished in 41.2045ms 200
```

As for #2772... This test was previously no-opping but we changed the test app in a prior PR so it started running flaky. The test sets the stream window size to 0, starts a request, and then sets it 1. It's expecting a settings ack and then a data frame. There's a race where sometimes it gets the data frame before the ack and the test times out. I've fixed it by sending the ack before we update any stream windows.