### PR TITLE
Limit concurrent HTTP/2 Streams per connection

### DIFF
--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -566,4 +566,10 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http2StreamErrorAfterHeaders" xml:space="preserve">
     <value>An error occured after the response headers were sent, a reset is being sent.</value>
   </data>
+  <data name="Http2ErrorMaxStreams" xml:space="preserve">
+    <value>A new stream was refused because this connection has reached its stream limit.</value>
+  </data>
+  <data name="GreaterThanZeroRequired" xml:space="preserve">
+    <value>A value greater than zero is required.</value>
+  </data>
 </root>

--- a/src/Kestrel.Core/Http2Limits.cs
+++ b/src/Kestrel.Core/Http2Limits.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core
+{
+    /// <summary>
+    /// Limits only applicable to HTTP/2 connections.
+    /// </summary>
+    public class Http2Limits
+    {
+        private int _maxStreamsPerConnection = 100;
+
+        /// <summary>
+        /// Limits the number of concurrent request streams per HTTP/2 connection. Excess streams will be refused.
+        /// <para>
+        /// Defaults to 100
+        /// </para>
+        /// </summary>
+        public int MaxStreamsPerConnection
+        {
+            get => _maxStreamsPerConnection;
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, CoreStrings.GreaterThanZeroRequired);
+                }
+                _maxStreamsPerConnection = value;
+            }
+        }
+    }
+}

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Settings.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Settings.cs
@@ -1,42 +1,67 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     public partial class Http2Frame
     {
+        private const int SettingSize = 6; // 2 bytes for the id, 4 bytes for the value.
+
         public Http2SettingsFrameFlags SettingsFlags
         {
             get => (Http2SettingsFrameFlags)Flags;
             set => Flags = (byte)value;
         }
 
-        public void PrepareSettings(Http2SettingsFrameFlags flags, Http2PeerSettings settings = null)
+        public int SettingsCount
         {
-            var settingCount = settings?.Count() ?? 0;
+            get => Length / SettingSize;
+            set => Length = value * SettingSize;
+        }
 
-            Length = 6 * settingCount;
+        public IList<Http2PeerSetting> GetSettings()
+        {
+            var settings = new Http2PeerSetting[SettingsCount];
+            for (int i = 0; i < settings.Length; i++)
+            {
+                settings[i] = GetSetting(i);
+            }
+            return settings;
+        }
+
+        private Http2PeerSetting GetSetting(int index)
+        {
+            var offset = index * SettingSize;
+            var payload = Payload.Slice(offset);
+            var id = (Http2SettingsParameter)BinaryPrimitives.ReadUInt16BigEndian(payload);
+            var value = BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(2));
+
+            return new Http2PeerSetting(id, value);
+        }
+
+        public void PrepareSettings(Http2SettingsFrameFlags flags, IList<Http2PeerSetting> settings = null)
+        {
+            var settingCount = settings?.Count ?? 0;
+            SettingsCount = settingCount;
             Type = Http2FrameType.SETTINGS;
             SettingsFlags = flags;
             StreamId = 0;
-
-            if (settings != null)
+            for (int i = 0; i < settingCount; i++)
             {
-                Span<byte> payload = Payload;
-                foreach (var setting in settings)
-                {
-                    payload[0] = (byte)((ushort)setting.Parameter >> 8);
-                    payload[1] = (byte)(ushort)setting.Parameter;
-                    payload[2] = (byte)(setting.Value >> 24);
-                    payload[3] = (byte)(setting.Value >> 16);
-                    payload[4] = (byte)(setting.Value >> 8);
-                    payload[5] = (byte)setting.Value;
-                    payload = payload.Slice(6);
-                }
+                SetSetting(i, settings[i]);
             }
+        }
+
+        private void SetSetting(int index, Http2PeerSetting setting)
+        {
+            var offset = index * SettingSize;
+            var payload = Payload.Slice(offset);
+            BinaryPrimitives.WriteUInt16BigEndian(payload, (ushort)setting.Parameter);
+            BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(2), setting.Value);
         }
     }
 }

--- a/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
@@ -270,12 +270,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        public Task WriteSettingsAsync(Http2PeerSettings settings)
+        public Task WriteSettingsAsync(IList<Http2PeerSetting> settings)
         {
             lock (_writeLock)
             {
-                // TODO: actually send settings
-                _outgoingFrame.PrepareSettings(Http2SettingsFrameFlags.NONE);
+                _outgoingFrame.PrepareSettings(Http2SettingsFrameFlags.NONE, settings);
                 return WriteFrameUnsynchronizedAsync();
             }
         }

--- a/src/Kestrel.Core/KestrelServerLimits.cs
+++ b/src/Kestrel.Core/KestrelServerLimits.cs
@@ -252,6 +252,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         }
 
         /// <summary>
+        /// Limits only applicable to HTTP/2 connections.
+        /// </summary>
+        public Http2Limits Http2 { get; } = new Http2Limits();
+
+        /// <summary>
         /// Gets or sets the request body minimum data rate in bytes/second.
         /// Setting this property to null indicates no minimum data rate should be enforced.
         /// This limit has no effect on upgraded connections which are always unlimited.

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -2100,6 +2100,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal static string FormatHttp2StreamErrorAfterHeaders()
             => GetString("Http2StreamErrorAfterHeaders");
 
+        /// <summary>
+        /// A new stream was refused because this connection has reached its stream limit.
+        /// </summary>
+        internal static string Http2ErrorMaxStreams
+        {
+            get => GetString("Http2ErrorMaxStreams");
+        }
+
+        /// <summary>
+        /// A new stream was refused because this connection has reached its stream limit.
+        /// </summary>
+        internal static string FormatHttp2ErrorMaxStreams()
+            => GetString("Http2ErrorMaxStreams");
+
+        /// <summary>
+        /// A value greater than zero is required.
+        /// </summary>
+        internal static string GreaterThanZeroRequired
+        {
+            get => GetString("GreaterThanZeroRequired");
+        }
+
+        /// <summary>
+        /// A value greater than zero is required.
+        /// </summary>
+        internal static string FormatGreaterThanZeroRequired()
+            => GetString("GreaterThanZeroRequired");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/test/Kestrel.Core.Tests/Http2StreamTests.cs
+++ b/test/Kestrel.Core.Tests/Http2StreamTests.cs
@@ -1868,7 +1868,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await SendSettingsAsync();
 
             await ExpectAsync(Http2FrameType.SETTINGS,
-                withLength: 0,
+                withLength: 6,
                 withFlags: 0,
                 withStreamId: 0);
 
@@ -1937,7 +1937,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         private Task SendSettingsAsync()
         {
             var frame = new Http2Frame();
-            frame.PrepareSettings(Http2SettingsFrameFlags.NONE, _clientSettings);
+            frame.PrepareSettings(Http2SettingsFrameFlags.NONE, _clientSettings.GetNonProtocolDefaults());
             return SendAsync(frame.Raw);
         }
 

--- a/test/Kestrel.InMemory.FunctionalTests/HttpProtocolSelectionTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/HttpProtocolSelectionTests.cs
@@ -37,8 +37,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Fact]
         public Task Server_Http2Only_Cleartext_Success()
         {
-            // Expect a SETTINGS frame (type 0x4) with no payload and no flags
-            return TestSuccess(HttpProtocols.Http2, Encoding.ASCII.GetString(Http2Connection.ClientPreface), "\x00\x00\x00\x04\x00\x00\x00\x00\x00");
+            // Expect a SETTINGS frame (type 0x4) with default settings
+            return TestSuccess(HttpProtocols.Http2, Encoding.ASCII.GetString(Http2Connection.ClientPreface),
+                "\x00\x00\x06\x04\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x64");
         }
 
         private async Task TestSuccess(HttpProtocols serverProtocols, string request, string expectedResponse)


### PR DESCRIPTION
 #2815 Defaults to 100 which is similar to Nginx, Apache, and IIS/Http.Sys.

I needed to finish implementing the infrastructure for sending settings to the client.

I also experimented with the BinaryConverter APIs for #2773, they worked great.

