### PR TITLE
Extract bitshift helper code, Frame cleanup

### DIFF
--- a/benchmarks/Kestrel.Performance/BinaryPrimitivesBenchmark.cs
+++ b/benchmarks/Kestrel.Performance/BinaryPrimitivesBenchmark.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers.Binary;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    public class BinaryPrimitivesBenchmark
+    {
+        private const int Iterations = 100;
+
+        private byte[] _data;
+        
+        [GlobalSetup]
+        public void Setup()
+        {
+            _data = new byte[4];
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Iterations)]
+        public uint GetUInt32AsBitwise()
+        {
+            var v = 0u;
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                v = (uint)((_data[0] << 24) | (_data[1] << 16) | (_data[2] << 8) | _data[3]);
+            }
+            return v;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public unsafe uint GetUInt32AsBinary()
+        {
+            var v = 0u;
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                v = BinaryPrimitives.ReadUInt32BigEndian(_data.AsSpan());
+            }
+            return v;
+        }
+    }
+}

--- a/benchmarks/Kestrel.Performance/README.md
+++ b/benchmarks/Kestrel.Performance/README.md
@@ -1,5 +1,7 @@
 ﻿Compile the solution in Release mode (so Kestrel is available in release)
-
+```
+build /t:compile /p:Configuration=Release
+```
 To run a specific benchmark add it as parameter
 ```
 dotnet run -f netcoreapp2.0 -c Release RequestParsing

--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -564,12 +564,15 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
     <value>More data received than specified in the Content-Length header.</value>
   </data>
   <data name="Http2StreamErrorAfterHeaders" xml:space="preserve">
-    <value>An error occured after the response headers were sent, a reset is being sent.</value>
+    <value>An error occurred after the response headers were sent, a reset is being sent.</value>
   </data>
   <data name="Http2ErrorMaxStreams" xml:space="preserve">
     <value>A new stream was refused because this connection has reached its stream limit.</value>
   </data>
   <data name="GreaterThanZeroRequired" xml:space="preserve">
     <value>A value greater than zero is required.</value>
+  </data>
+  <data name="Http2FrameMissingFields" xml:space="preserve">
+    <value>The frame is too short to contain the fields indicated by the given flags.</value>
   </data>
 </root>

--- a/src/Kestrel.Core/Internal/Http2/Bitshifter.cs
+++ b/src/Kestrel.Core/Internal/Http2/Bitshifter.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
+{
+    // Mimics BinaryPrimities with oddly sized units
+    internal class Bitshifter
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint ReadUInt24BigEndian(ReadOnlySpan<byte> source)
+        {
+            return (uint)((source[0] << 16) | (source[1] << 8) | source[2]);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteUInt24BigEndian(Span<byte> destination, uint value)
+        {
+            Debug.Assert(value <= 0xFF_FF_FF, value.ToString());
+            destination[0] = (byte)((value & 0xFF_00_00) >> 16);
+            destination[1] = (byte)((value & 0x00_FF_00) >> 8);
+            destination[2] = (byte)(value & 0x00_00_FF);
+        }
+
+        // Drops the highest order bit
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint ReadUInt31BigEndian(ReadOnlySpan<byte> source)
+        {
+            return BinaryPrimitives.ReadUInt32BigEndian(source) & 0x7F_FF_FF_FF;
+        }
+
+        // Does not overwrite the highest order bit
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteUInt31BigEndian(Span<byte> destination, uint value)
+        {
+            Debug.Assert(value <= 0x7F_FF_FF_FF, value.ToString());
+            // Keep the highest bit
+            var reserved = (destination[0] & 0x80u) << 24;
+            BinaryPrimitives.WriteUInt32BigEndian(destination, value | reserved);
+        }
+    }
+}

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Continuation.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Continuation.cs
@@ -4,6 +4,11 @@
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
+    /* https://tools.ietf.org/html/rfc7540#section-6.10
+        +---------------------------------------------------------------+
+        |                   Header Block Fragment (*)                 ...
+        +---------------------------------------------------------------+
+    */
     public partial class Http2Frame
     {
         public Http2ContinuationFrameFlags ContinuationFlags
@@ -12,9 +17,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             set => Flags = (byte)value;
         }
 
+        public bool ContinuationEndHeaders => (ContinuationFlags & Http2ContinuationFrameFlags.END_HEADERS) == Http2ContinuationFrameFlags.END_HEADERS;
+
         public void PrepareContinuation(Http2ContinuationFrameFlags flags, int streamId)
         {
-            Length = MinAllowedMaxFrameSize - HeaderLength;
+            PayloadLength = MinAllowedMaxFrameSize - HeaderLength;
             Type = Http2FrameType.CONTINUATION;
             ContinuationFlags = flags;
             StreamId = streamId;

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Data.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Data.cs
@@ -2,10 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
+    /*
+        +---------------+
+        |Pad Length? (8)|
+        +---------------+-----------------------------------------------+
+        |                            Data (*)                         ...
+        +---------------------------------------------------------------+
+        |                           Padding (*)                       ...
+        +---------------------------------------------------------------+
+    */
     public partial class Http2Frame
     {
         public Http2DataFrameFlags DataFlags
@@ -14,23 +22,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             set => Flags = (byte)value;
         }
 
+        public bool DataEndStream => (DataFlags & Http2DataFrameFlags.END_STREAM) == Http2DataFrameFlags.END_STREAM;
+
         public bool DataHasPadding => (DataFlags & Http2DataFrameFlags.PADDED) == Http2DataFrameFlags.PADDED;
 
         public byte DataPadLength
         {
-            get => DataHasPadding ? _data[PayloadOffset] : (byte)0;
-            set => _data[PayloadOffset] = value;
+            get => DataHasPadding ? Payload[0] : (byte)0;
+            set => Payload[0] = value;
         }
 
-        public ArraySegment<byte> DataPayload => DataHasPadding
-            ? new ArraySegment<byte>(_data, PayloadOffset + 1, Length - DataPadLength - 1)
-            : new ArraySegment<byte>(_data, PayloadOffset, Length);
+        public int DataPayloadOffset => DataHasPadding ? 1 : 0;
+
+        private int DataPayloadLength => PayloadLength - DataPayloadOffset - DataPadLength;
+
+        public Span<byte> DataPayload => Payload.Slice(DataPayloadOffset, DataPayloadLength);
 
         public void PrepareData(int streamId, byte? padLength = null)
         {
             var padded = padLength != null;
 
-            Length = MinAllowedMaxFrameSize;
+            PayloadLength = MinAllowedMaxFrameSize;
             Type = Http2FrameType.DATA;
             DataFlags = padded ? Http2DataFrameFlags.PADDED : Http2DataFrameFlags.NONE;
             StreamId = streamId;
@@ -38,40 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             if (padded)
             {
                 DataPadLength = padLength.Value;
-                Payload.Slice(Length - padLength.Value).Fill(0);
-            }
-        }
-
-        private void DataTraceFrame(ILogger logger)
-        {
-            logger.LogTrace("'DATA' Frame. Flags = {DataFlags}, PadLength = {PadLength}, PayloadLength = {PayloadLength}", DataFlags, DataPadLength, DataPayload.Count);
-        }
-
-        internal object ShowFlags()
-        {
-            switch (Type)
-            {
-                case Http2FrameType.CONTINUATION:
-                    return ContinuationFlags;
-                case Http2FrameType.DATA:
-                    return DataFlags;
-                case Http2FrameType.HEADERS:
-                    return HeadersFlags;
-                case Http2FrameType.SETTINGS:
-                    return SettingsFlags;
-                case Http2FrameType.PING:
-                    return PingFlags;
-
-                // Not Implemented
-                case Http2FrameType.PUSH_PROMISE:
-
-                // No flags defined
-                case Http2FrameType.PRIORITY:
-                case Http2FrameType.RST_STREAM:
-                case Http2FrameType.GOAWAY:
-                case Http2FrameType.WINDOW_UPDATE:
-                default:
-                    return $"0x{Flags:x}";
+                Payload.Slice(PayloadLength - padLength.Value).Fill(0);
             }
         }
     }

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.GoAway.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.GoAway.cs
@@ -1,37 +1,38 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers.Binary;
+
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
+    /* https://tools.ietf.org/html/rfc7540#section-6.8
+        +-+-------------------------------------------------------------+
+        |R|                  Last-Stream-ID (31)                        |
+        +-+-------------------------------------------------------------+
+        |                      Error Code (32)                          |
+        +---------------------------------------------------------------+
+        |                  Additional Debug Data (*)                    |
+        +---------------------------------------------------------------+
+    */
     public partial class Http2Frame
     {
+        private const int ErrorCodeOffset = 4;
+
         public int GoAwayLastStreamId
         {
-            get => (Payload[0] << 24) | (Payload[1] << 16) | (Payload[2] << 8) | Payload[3];
-            set
-            {
-                Payload[0] = (byte)((value >> 24) & 0xff);
-                Payload[1] = (byte)((value >> 16) & 0xff);
-                Payload[2] = (byte)((value >> 8) & 0xff);
-                Payload[3] = (byte)(value & 0xff);
-            }
+            get => (int)Bitshifter.ReadUInt31BigEndian(Payload);
+            set => Bitshifter.WriteUInt31BigEndian(Payload, (uint)value);
         }
 
         public Http2ErrorCode GoAwayErrorCode
         {
-            get => (Http2ErrorCode)((Payload[4] << 24) | (Payload[5] << 16) | (Payload[6] << 8) | Payload[7]);
-            set
-            {
-                Payload[4] = (byte)(((uint)value >> 24) & 0xff);
-                Payload[5] = (byte)(((uint)value >> 16) & 0xff);
-                Payload[6] = (byte)(((uint)value >> 8) & 0xff);
-                Payload[7] = (byte)((uint)value & 0xff);
-            }
+            get => (Http2ErrorCode)BinaryPrimitives.ReadUInt32BigEndian(Payload.Slice(ErrorCodeOffset));
+            set => BinaryPrimitives.WriteUInt32BigEndian(Payload.Slice(ErrorCodeOffset), (uint)value);
         }
 
         public void PrepareGoAway(int lastStreamId, Http2ErrorCode errorCode)
         {
-            Length = 8;
+            PayloadLength = 8;
             Type = Http2FrameType.GOAWAY;
             Flags = 0;
             StreamId = 0;

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Ping.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Ping.cs
@@ -4,6 +4,13 @@
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
+    /* https://tools.ietf.org/html/rfc7540#section-6.7
+        +---------------------------------------------------------------+
+        |                                                               |
+        |                      Opaque Data (64)                         |
+        |                                                               |
+        +---------------------------------------------------------------+
+    */
     public partial class Http2Frame
     {
         public Http2PingFrameFlags PingFlags
@@ -12,9 +19,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             set => Flags = (byte)value;
         }
 
+        public bool PingAck => (PingFlags & Http2PingFrameFlags.ACK) == Http2PingFrameFlags.ACK;
+
         public void PreparePing(Http2PingFrameFlags flags)
         {
-            Length = 8;
+            PayloadLength = 8;
             Type = Http2FrameType.PING;
             PingFlags = flags;
             StreamId = 0;

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.RstStream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.RstStream.cs
@@ -1,25 +1,26 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Buffers.Binary;
+
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
+    /* https://tools.ietf.org/html/rfc7540#section-6.4
+        +---------------------------------------------------------------+
+        |                        Error Code (32)                        |
+        +---------------------------------------------------------------+
+    */
     public partial class Http2Frame
     {
         public Http2ErrorCode RstStreamErrorCode
         {
-            get => (Http2ErrorCode)((Payload[0] << 24) | (Payload[1] << 16) | (Payload[2] << 8) | Payload[3]);
-            set
-            {
-                Payload[0] = (byte)(((uint)value >> 24) & 0xff);
-                Payload[1] = (byte)(((uint)value >> 16) & 0xff);
-                Payload[2] = (byte)(((uint)value >> 8) & 0xff);
-                Payload[3] = (byte)((uint)value & 0xff);
-            }
+            get => (Http2ErrorCode)BinaryPrimitives.ReadUInt32BigEndian(Payload);
+            set => BinaryPrimitives.WriteUInt32BigEndian(Payload, (uint)value);
         }
 
         public void PrepareRstStream(int streamId, Http2ErrorCode errorCode)
         {
-            Length = 4;
+            PayloadLength = 4;
             Type = Http2FrameType.RST_STREAM;
             Flags = 0;
             StreamId = streamId;

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Settings.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Settings.cs
@@ -3,10 +3,17 @@
 
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
+    /* https://tools.ietf.org/html/rfc7540#section-6.5.1
+        List of:
+        +-------------------------------+
+        |       Identifier (16)         |
+        +-------------------------------+-------------------------------+
+        |                        Value (32)                             |
+        +---------------------------------------------------------------+
+    */
     public partial class Http2Frame
     {
         private const int SettingSize = 6; // 2 bytes for the id, 4 bytes for the value.
@@ -17,10 +24,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             set => Flags = (byte)value;
         }
 
+        public bool SettingsAck => (SettingsFlags & Http2SettingsFrameFlags.ACK) == Http2SettingsFrameFlags.ACK;
+
         public int SettingsCount
         {
-            get => Length / SettingSize;
-            set => Length = value * SettingSize;
+            get => PayloadLength / SettingSize;
+            set => PayloadLength = value * SettingSize;
         }
 
         public IList<Http2PeerSetting> GetSettings()

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.WindowUpdate.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.WindowUpdate.cs
@@ -3,23 +3,22 @@
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
+    /* https://tools.ietf.org/html/rfc7540#section-6.9
+        +-+-------------------------------------------------------------+
+        |R|              Window Size Increment (31)                     |
+        +-+-------------------------------------------------------------+
+    */
     public partial class Http2Frame
     {
         public int WindowUpdateSizeIncrement
         {
-            get => ((Payload[0] << 24) | (Payload[1] << 16) | (Payload[2] << 8) | Payload[3]) & 0x7fffffff;
-            set
-            {
-                Payload[0] = (byte)(((uint)value >> 24) & 0x7f);
-                Payload[1] = (byte)(((uint)value >> 16) & 0xff);
-                Payload[2] = (byte)(((uint)value >> 8) & 0xff);
-                Payload[3] = (byte)((uint)value & 0xff);
-            }
+            get => (int)Bitshifter.ReadUInt31BigEndian(Payload);
+            set => Bitshifter.WriteUInt31BigEndian(Payload, (uint)value);
         }
 
         public void PrepareWindowUpdate(int streamId, int sizeIncrement)
         {
-            Length = 4;
+            PayloadLength = 4;
             Type = Http2FrameType.WINDOW_UPDATE;
             Flags = 0;
             StreamId = streamId;

--- a/src/Kestrel.Core/Internal/Http2/Http2FrameReader.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2FrameReader.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Collections;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
@@ -22,18 +21,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             var headerSlice = readableBuffer.Slice(0, Http2Frame.HeaderLength);
             headerSlice.CopyTo(frame.Raw);
 
-            if (frame.Length > maxFrameSize)
+            var payloadLength = frame.PayloadLength;
+            if (payloadLength > maxFrameSize)
             {
-                throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorFrameOverLimit(frame.Length, maxFrameSize), Http2ErrorCode.FRAME_SIZE_ERROR);
+                throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorFrameOverLimit(payloadLength, maxFrameSize), Http2ErrorCode.FRAME_SIZE_ERROR);
             }
 
-            if (readableBuffer.Length < Http2Frame.HeaderLength + frame.Length)
+            var frameLength = Http2Frame.HeaderLength + payloadLength;
+            if (readableBuffer.Length < frameLength)
             {
                 return false;
             }
 
-            readableBuffer.Slice(Http2Frame.HeaderLength, frame.Length).CopyTo(frame.Payload);
-            consumed = examined = readableBuffer.GetPosition(Http2Frame.HeaderLength + frame.Length);
+            readableBuffer.Slice(Http2Frame.HeaderLength, payloadLength).CopyTo(frame.Payload);
+            consumed = examined = readableBuffer.GetPosition(frameLength);
 
             return true;
         }

--- a/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             lock (_writeLock)
             {
                 _outgoingFrame.PrepareHeaders(Http2HeadersFrameFlags.END_HEADERS, streamId);
-                _outgoingFrame.Length = _continueBytes.Length;
+                _outgoingFrame.PayloadLength = _continueBytes.Length;
                 _continueBytes.CopyTo(_outgoingFrame.HeadersPayload);
 
                 return WriteFrameUnsynchronizedAsync();
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 _outgoingFrame.PrepareHeaders(Http2HeadersFrameFlags.NONE, streamId);
 
                 var done = _hpackEncoder.BeginEncode(statusCode, EnumerateHeaders(headers), _outgoingFrame.Payload, out var payloadLength);
-                _outgoingFrame.Length = payloadLength;
+                _outgoingFrame.PayloadLength = payloadLength;
 
                 if (done)
                 {
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     _outgoingFrame.PrepareContinuation(Http2ContinuationFrameFlags.NONE, streamId);
 
                     done = _hpackEncoder.Encode(_outgoingFrame.Payload, out var length);
-                    _outgoingFrame.Length = length;
+                    _outgoingFrame.PayloadLength = length;
 
                     if (done)
                     {
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 _outgoingFrame.DataFlags = Http2DataFrameFlags.END_STREAM;
             }
 
-            _outgoingFrame.Length = unwrittenPayloadLength;
+            _outgoingFrame.PayloadLength = unwrittenPayloadLength;
 
             _log.Http2FrameSending(_connectionId, _outgoingFrame);
             _outputWriter.Write(_outgoingFrame.Raw);

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -274,9 +274,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
 
             var payload = dataFrame.DataPayload;
-            var endStream = (dataFrame.DataFlags & Http2DataFrameFlags.END_STREAM) == Http2DataFrameFlags.END_STREAM;
+            var endStream = dataFrame.DataEndStream;
 
-            if (payload.Count > 0)
+            if (payload.Length > 0)
             {
                 RequestBodyStarted = true;
 
@@ -287,7 +287,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     _inputFlowControl.StopWindowUpdates();
                 }
 
-                _inputFlowControl.Advance(payload.Count);
+                _inputFlowControl.Advance(payload.Length);
 
                 if (IsAborted)
                 {
@@ -300,12 +300,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 if (InputRemaining.HasValue)
                 {
                     // https://tools.ietf.org/html/rfc7540#section-8.1.2.6
-                    if (payload.Count > InputRemaining.Value)
+                    if (payload.Length > InputRemaining.Value)
                     {
                         throw new Http2StreamErrorException(StreamId, CoreStrings.Http2StreamErrorMoreDataThanLength, Http2ErrorCode.PROTOCOL_ERROR);
                     }
 
-                    InputRemaining -= payload.Count;
+                    InputRemaining -= payload.Length;
                 }
 
                 RequestBodyPipe.Writer.Write(payload);

--- a/src/Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
@@ -256,12 +256,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         public void Http2FrameReceived(string connectionId, Http2Frame frame)
         {
-            _http2FrameReceived(_logger, connectionId, frame.Type, frame.StreamId, frame.Length, frame.ShowFlags(), null);
+            _http2FrameReceived(_logger, connectionId, frame.Type, frame.StreamId, frame.PayloadLength, frame.ShowFlags(), null);
         }
 
         public void Http2FrameSending(string connectionId, Http2Frame frame)
         {
-            _http2FrameSending(_logger, connectionId, frame.Type, frame.StreamId, frame.Length, frame.ShowFlags(), null);
+            _http2FrameSending(_logger, connectionId, frame.Type, frame.StreamId, frame.PayloadLength, frame.ShowFlags(), null);
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -2087,7 +2087,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             => GetString("Http2StreamErrorMoreDataThanLength");
 
         /// <summary>
-        /// An error occured after the response headers were sent, a reset is being sent.
+        /// An error occurred after the response headers were sent, a reset is being sent.
         /// </summary>
         internal static string Http2StreamErrorAfterHeaders
         {
@@ -2095,7 +2095,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         }
 
         /// <summary>
-        /// An error occured after the response headers were sent, a reset is being sent.
+        /// An error occurred after the response headers were sent, a reset is being sent.
         /// </summary>
         internal static string FormatHttp2StreamErrorAfterHeaders()
             => GetString("Http2StreamErrorAfterHeaders");
@@ -2127,6 +2127,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// </summary>
         internal static string FormatGreaterThanZeroRequired()
             => GetString("GreaterThanZeroRequired");
+
+        /// <summary>
+        /// The frame is too short to contain the fields indicated by the given flags.
+        /// </summary>
+        internal static string Http2FrameMissingFields
+        {
+            get => GetString("Http2FrameMissingFields");
+        }
+
+        /// <summary>
+        /// The frame is too short to contain the fields indicated by the given flags.
+        /// </summary>
+        internal static string FormatHttp2FrameMissingFields()
+            => GetString("Http2FrameMissingFields");
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/TlsTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/TlsTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.Http2
             }
 
             Assert.Equal(Http2FrameType.GOAWAY, frame.Type);
-            Assert.Equal(8, frame.Length);
+            Assert.Equal(8, frame.PayloadLength);
             Assert.Equal(0, frame.Flags);
             Assert.Equal(0, frame.StreamId);
             Assert.Equal(expectedLastStreamId, frame.GoAwayLastStreamId);


### PR DESCRIPTION
 #2773 

Extracted all non-trivial bitwise operations from the Http2Frame classes. I also fixed several issues where it was reading 31 bits but writing 32 bits and stomping on adjacent (rarely used) fields.

There was an error in Data and Headers where reading the padding length or priority weight fields could read off the end of an invalid frame. I normalized everything to read from the restricted Payload Span so everything stays in bounds.

BinaryPrimitives are modestly faster and more consistent than the old code. Not to mention a lot cleaner.
```
             Method |     Mean |     Error |   StdDev |     Op/s | Scaled | ScaledSD | Allocated |
------------------- |---------:|----------:|---------:|---------:|-------:|---------:|----------:|
 GetUInt32AsBitwise | 21.80 us | 1.1883 us | 3.466 us | 45,861.5 |   1.00 |     0.00 |       0 B |
  GetUInt32AsBinary | 19.98 us | 0.6416 us | 1.656 us | 50,061.2 |   0.94 |     0.17 |       0 B |
```