### PR TITLE
Fixed a memory leak and flaky test

### DIFF
--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.cs
@@ -607,7 +607,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 application.DisposeContext(httpContext, _applicationException);
 
                 // Even for non-keep-alive requests, try to consume the entire body to avoid RSTs.
-                if (_ioCompleted == 0 && _requestRejectedException == null && !messageBody.IsEmpty)
+                if (_requestRejectedException == null && !messageBody.IsEmpty)
                 {
                     await messageBody.ConsumeAsync();
                 }


### PR DESCRIPTION
- The memory leak was caused by not properly cleaning up the RequestBodyPipe for Http2Streams. Removing the _ioCompleted check before consuming the message body seems to work well.
- The flaky test didn't handle the fact that writing to the connection after a stream has been RSTed that it'll cause the entire connection to close.