### PR TITLE
Handle SocketError.ProtocolType as a connection reset on macOS

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -329,8 +329,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             // A connection reset can be reported as SocketError.ConnectionAborted on Windows.
             // ProtocolType can be removed once https://github.com/dotnet/corefx/issues/31927 is fixed.
             return errorCode == SocketError.ConnectionReset ||
-                   errorCode == SocketError.ConnectionAborted ||
                    errorCode == SocketError.Shutdown ||
+                   (errorCode == SocketError.ConnectionAborted && IsWindows) ||
                    (errorCode == SocketError.ProtocolType && IsMacOS);
         }
 
@@ -339,7 +339,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             // Calling Dispose after ReceiveAsync can cause an "InvalidArgument" error on *nix.
             return errorCode == SocketError.OperationAborted ||
                    errorCode == SocketError.Interrupted ||
-                   errorCode == SocketError.InvalidArgument;
+                   (errorCode == SocketError.InvalidArgument && !IsWindows);
         }
     }
 }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -327,9 +327,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         private static bool IsConnectionResetError(SocketError errorCode)
         {
             // A connection reset can be reported as SocketError.ConnectionAborted on Windows.
+            // ProtocolType can be removed once https://github.com/dotnet/corefx/issues/31927 is fixed.
             return errorCode == SocketError.ConnectionReset ||
                    errorCode == SocketError.ConnectionAborted ||
-                   errorCode == SocketError.Shutdown;
+                   errorCode == SocketError.Shutdown ||
+                   (errorCode == SocketError.ProtocolType && IsMacOS);
         }
 
         private static bool IsConnectionAbortError(SocketError errorCode)


### PR DESCRIPTION
Addresses #2764 
See dotnet/corefx#31927