### PR TITLE
Don't preserve the ExecutionContext when dispatching callbacks

### DIFF
--- a/src/Connections.Abstractions/DefaultConnectionContext.cs
+++ b/src/Connections.Abstractions/DefaultConnectionContext.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Connections
 
         public override void Abort(ConnectionAbortedException abortReason)
         {
-            ThreadPool.QueueUserWorkItem(cts => ((CancellationTokenSource)cts).Cancel(), _connectionClosedTokenSource);
+            ThreadPool.UnsafeQueueUserWorkItem(cts => ((CancellationTokenSource)cts).Cancel(), _connectionClosedTokenSource);
         }
 
         public void Dispose()

--- a/src/Kestrel.Core/Internal/Infrastructure/ThreadPoolAwaitable.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/ThreadPoolAwaitable.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public void OnCompleted(Action continuation)
         {
-            ThreadPool.QueueUserWorkItem(state => ((Action)state)(), continuation);
+            ThreadPool.UnsafeQueueUserWorkItem(state => ((Action)state)(), continuation);
         }
 
         public void UnsafeOnCompleted(Action continuation)

--- a/src/Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/LibuvConnection.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
                     // We're done with the socket now
                     _socket.Dispose();
-                    ThreadPool.QueueUserWorkItem(state => ((LibuvConnection)state).CancelConnectionClosedToken(), this);
+                    ThreadPool.UnsafeQueueUserWorkItem(state => ((LibuvConnection)state).CancelConnectionClosedToken(), this);
                 }
             }
             catch (Exception e)

--- a/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             {
                 if (!_doingWork)
                 {
-                    System.Threading.ThreadPool.QueueUserWorkItem(_doWorkCallback, this);
+                    System.Threading.ThreadPool.UnsafeQueueUserWorkItem(_doWorkCallback, this);
                     _doingWork = true;
                 }
             }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
                 _receiver.Dispose();
                 _sender.Dispose();
-                ThreadPool.QueueUserWorkItem(state => ((SocketConnection)state).CancelConnectionClosedToken(), this);
+                ThreadPool.UnsafeQueueUserWorkItem(state => ((SocketConnection)state).CancelConnectionClosedToken(), this);
             }
             catch (Exception ex)
             {

--- a/test/Kestrel.InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTrans
 
             _isClosed = true;
 
-            ThreadPool.QueueUserWorkItem(state =>
+            ThreadPool.UnsafeQueueUserWorkItem(state =>
             {
                 var self = (InMemoryTransportConnection)state;
                 self._connectionClosedTokenSource.Cancel();


### PR DESCRIPTION
- The layers up stack already preserve and restore the ExecutionContext, there's no need to capture and run for the scheduler callback and cancellation token callback