### PR TITLE
Add diagnostic messages to show hanging tests in the output

### DIFF
--- a/test/xunit.runner.json
+++ b/test/xunit.runner.json
@@ -3,5 +3,6 @@
   "appDomain": "denied",
   "methodDisplay": "method",
   "longRunningTestSeconds": 60,
+  "diagnosticMessages": true,
   "maxParallelThreads": -1
 }


### PR DESCRIPTION
Now test hangs will show up.