### PR TITLE
Fix platform benchmarks TFM

### DIFF
--- a/benchmarkapps/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/benchmarkapps/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -1,19 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Prevent the SDK from validating the supported tfm. Can be removed when a new SDK supporting netcoreapp2.2 is available. -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Utf8Json" Version="$(Utf8JsonPackageVersion)" />
   </ItemGroup>
-  
+
   <!-- These references are used when running locally -->
   <ItemGroup Condition="'$(BenchmarksTargetFramework)' == ''">
     <ProjectReference Include="..\..\src\Kestrel\Kestrel.csproj" />


### PR DESCRIPTION
Remove workaround and make the TFM netcoreapp2.2 for the PlatformBenchmarks