### PR TITLE
Change how HTTP/2 frames are parsed and generated

### DIFF
--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -572,13 +572,13 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="GreaterThanZeroRequired" xml:space="preserve">
     <value>A value greater than zero is required.</value>
   </data>
-  <data name="Http2FrameMissingFields" xml:space="preserve">
-    <value>The frame is too short to contain the fields indicated by the given flags.</value>
-  </data>
   <data name="ArgumentOutOfRange" xml:space="preserve">
     <value>A value between {min} and {max} is required.</value>
   </data>
   <data name="HPackErrorDynamicTableSizeUpdateNotAtBeginningOfHeaderBlock" xml:space="preserve">
     <value>Dynamic tables size update did not occur at the beginning of the first header block.</value>
+  </data>
+  <data name="HPackErrorNotEnoughBuffer" xml:space="preserve">
+    <value>The given buffer was too small to encode any headers.</value>
   </data>
 </root>

--- a/src/Kestrel.Core/Internal/Http2/HPack/HPackDecoder.cs
+++ b/src/Kestrel.Core/Internal/Http2/HPack/HPackDecoder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack
@@ -109,11 +110,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack
             _dynamicTable = dynamicTable;
         }
 
-        public void Decode(Span<byte> data, bool endHeaders, IHttpHeadersHandler handler)
+        public void Decode(ReadOnlySequence<byte> data, bool endHeaders, IHttpHeadersHandler handler)
         {
-            for (var i = 0; i < data.Length; i++)
+            foreach (var segment in data)
             {
-                OnByte(data[i], handler);
+                var span = segment.Span;
+                for (var i = 0; i < span.Length; i++)
+                {
+                    OnByte(span[i], handler);
+                }
             }
 
             if (endHeaders)

--- a/src/Kestrel.Core/Internal/Http2/HPack/HPackEncodingException.cs
+++ b/src/Kestrel.Core/Internal/Http2/HPack/HPackEncodingException.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.HPack
+{
+    public class HPackEncodingException : Exception
+    {
+        public HPackEncodingException(string message)
+            : base(message)
+        {
+        }
+        public HPackEncodingException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Continuation.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Continuation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     /* https://tools.ietf.org/html/rfc7540#section-6.10
@@ -21,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public void PrepareContinuation(Http2ContinuationFrameFlags flags, int streamId)
         {
-            PayloadLength = (int)_maxFrameSize;
+            PayloadLength = 0;
             Type = Http2FrameType.CONTINUATION;
             ContinuationFlags = flags;
             StreamId = streamId;

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Data.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Data.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     /*
@@ -26,32 +24,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public bool DataHasPadding => (DataFlags & Http2DataFrameFlags.PADDED) == Http2DataFrameFlags.PADDED;
 
-        public byte DataPadLength
-        {
-            get => DataHasPadding ? Payload[0] : (byte)0;
-            set => Payload[0] = value;
-        }
+        public byte DataPadLength { get; set; }
 
-        public int DataPayloadOffset => DataHasPadding ? 1 : 0;
+        private int DataPayloadOffset => DataHasPadding ? 1 : 0;
 
-        private int DataPayloadLength => PayloadLength - DataPayloadOffset - DataPadLength;
-
-        public Span<byte> DataPayload => Payload.Slice(DataPayloadOffset, DataPayloadLength);
+        public int DataPayloadLength => PayloadLength - DataPayloadOffset - DataPadLength;
 
         public void PrepareData(int streamId, byte? padLength = null)
         {
-            var padded = padLength != null;
-
-            PayloadLength = (int)_maxFrameSize;
+            PayloadLength = 0;
             Type = Http2FrameType.DATA;
-            DataFlags = padded ? Http2DataFrameFlags.PADDED : Http2DataFrameFlags.NONE;
+            DataFlags = padLength.HasValue ? Http2DataFrameFlags.PADDED : Http2DataFrameFlags.NONE;
             StreamId = streamId;
-
-            if (padded)
-            {
-                DataPadLength = padLength.Value;
-                Payload.Slice(PayloadLength - padLength.Value).Fill(0);
-            }
+            DataPadLength = padLength ?? 0;
         }
     }
 }

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.GoAway.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.GoAway.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Buffers.Binary;
-
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     /* https://tools.ietf.org/html/rfc7540#section-6.8
@@ -16,19 +14,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     */
     public partial class Http2Frame
     {
-        private const int ErrorCodeOffset = 4;
+        public int GoAwayLastStreamId { get; set; }
 
-        public int GoAwayLastStreamId
-        {
-            get => (int)Bitshifter.ReadUInt31BigEndian(Payload);
-            set => Bitshifter.WriteUInt31BigEndian(Payload, (uint)value);
-        }
-
-        public Http2ErrorCode GoAwayErrorCode
-        {
-            get => (Http2ErrorCode)BinaryPrimitives.ReadUInt32BigEndian(Payload.Slice(ErrorCodeOffset));
-            set => BinaryPrimitives.WriteUInt32BigEndian(Payload.Slice(ErrorCodeOffset), (uint)value);
-        }
+        public Http2ErrorCode GoAwayErrorCode { get; set; }
 
         public void PrepareGoAway(int lastStreamId, Http2ErrorCode errorCode)
         {

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Ping.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Ping.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     /* https://tools.ietf.org/html/rfc7540#section-6.7

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Priority.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Priority.cs
@@ -12,36 +12,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     */
     public partial class Http2Frame
     {
-        private const int PriorityWeightOffset = 4;
+        public int PriorityStreamDependency { get; set; }
 
-        public int PriorityStreamDependency
-        {
-            get => (int)Bitshifter.ReadUInt31BigEndian(Payload);
-            set => Bitshifter.WriteUInt31BigEndian(Payload, (uint)value);
-        }
+        public bool PriorityIsExclusive { get; set; }
 
-        public bool PriorityIsExclusive
-        {
-            get => (Payload[0] & 0x80) != 0;
-            set
-            {
-                if (value)
-                {
-                    Payload[0] |= 0x80;
-                }
-                else
-                {
-                    Payload[0] &= 0x7f;
-                }
-            }
-        }
-
-        public byte PriorityWeight
-        {
-            get => Payload[PriorityWeightOffset];
-            set => Payload[PriorityWeightOffset] = value;
-        }
-
+        public byte PriorityWeight { get; set; }
 
         public void PreparePriority(int streamId, int streamDependency, bool exclusive, byte weight)
         {

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.RstStream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.RstStream.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Buffers.Binary;
-
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     /* https://tools.ietf.org/html/rfc7540#section-6.4
@@ -12,11 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     */
     public partial class Http2Frame
     {
-        public Http2ErrorCode RstStreamErrorCode
-        {
-            get => (Http2ErrorCode)BinaryPrimitives.ReadUInt32BigEndian(Payload);
-            set => BinaryPrimitives.WriteUInt32BigEndian(Payload, (uint)value);
-        }
+        public Http2ErrorCode RstStreamErrorCode { get; set; }
 
         public void PrepareRstStream(int streamId, Http2ErrorCode errorCode)
         {

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.Settings.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.Settings.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Buffers.Binary;
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     /* https://tools.ietf.org/html/rfc7540#section-6.5.1
@@ -16,8 +13,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     */
     public partial class Http2Frame
     {
-        internal const int SettingSize = 6; // 2 bytes for the id, 4 bytes for the value.
-
         public Http2SettingsFrameFlags SettingsFlags
         {
             get => (Http2SettingsFrameFlags)Flags;
@@ -26,51 +21,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public bool SettingsAck => (SettingsFlags & Http2SettingsFrameFlags.ACK) == Http2SettingsFrameFlags.ACK;
 
-        public int SettingsCount
+        public void PrepareSettings(Http2SettingsFrameFlags flags)
         {
-            get => PayloadLength / SettingSize;
-            set => PayloadLength = value * SettingSize;
-        }
-
-        public IList<Http2PeerSetting> GetSettings()
-        {
-            var settings = new Http2PeerSetting[SettingsCount];
-            for (int i = 0; i < settings.Length; i++)
-            {
-                settings[i] = GetSetting(i);
-            }
-            return settings;
-        }
-
-        private Http2PeerSetting GetSetting(int index)
-        {
-            var offset = index * SettingSize;
-            var payload = Payload.Slice(offset);
-            var id = (Http2SettingsParameter)BinaryPrimitives.ReadUInt16BigEndian(payload);
-            var value = BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(2));
-
-            return new Http2PeerSetting(id, value);
-        }
-
-        public void PrepareSettings(Http2SettingsFrameFlags flags, IList<Http2PeerSetting> settings = null)
-        {
-            var settingCount = settings?.Count ?? 0;
-            SettingsCount = settingCount;
+            PayloadLength = 0;
             Type = Http2FrameType.SETTINGS;
             SettingsFlags = flags;
             StreamId = 0;
-            for (int i = 0; i < settingCount; i++)
-            {
-                SetSetting(i, settings[i]);
-            }
-        }
-
-        private void SetSetting(int index, Http2PeerSetting setting)
-        {
-            var offset = index * SettingSize;
-            var payload = Payload.Slice(offset);
-            BinaryPrimitives.WriteUInt16BigEndian(payload, (ushort)setting.Parameter);
-            BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(2), setting.Value);
         }
     }
 }

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.WindowUpdate.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.WindowUpdate.cs
@@ -10,11 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     */
     public partial class Http2Frame
     {
-        public int WindowUpdateSizeIncrement
-        {
-            get => (int)Bitshifter.ReadUInt31BigEndian(Payload);
-            set => Bitshifter.WriteUInt31BigEndian(Payload, (uint)value);
-        }
+        public int WindowUpdateSizeIncrement { get; set; }
 
         public void PrepareWindowUpdate(int streamId, int sizeIncrement)
         {

--- a/src/Kestrel.Core/Internal/Http2/Http2Frame.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Frame.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     /* https://tools.ietf.org/html/rfc7540#section-4.1
@@ -18,51 +16,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
     */
     public partial class Http2Frame
     {
-        public const int HeaderLength = 9;
+        public int PayloadLength { get; set; }
 
-        private const int LengthOffset = 0;
-        private const int TypeOffset = 3;
-        private const int FlagsOffset = 4;
-        private const int StreamIdOffset = 5;
-        private const int PayloadOffset = 9;
+        public Http2FrameType Type { get; set; }
 
-        private uint _maxFrameSize;
+        public byte Flags { get; set; }
 
-        private readonly byte[] _data;
-
-        public Http2Frame(uint maxFrameSize)
-        {
-            _maxFrameSize = maxFrameSize;
-            _data = new byte[HeaderLength + _maxFrameSize];
-        }
-
-        public Span<byte> Raw => new Span<byte>(_data, 0, HeaderLength + PayloadLength);
-
-        public int PayloadLength
-        {
-            get => (int)Bitshifter.ReadUInt24BigEndian(_data.AsSpan(LengthOffset));
-            set => Bitshifter.WriteUInt24BigEndian(_data.AsSpan(LengthOffset), (uint)value);
-        }
-
-        public Http2FrameType Type
-        {
-            get => (Http2FrameType)_data[TypeOffset];
-            set => _data[TypeOffset] = (byte)value;
-        }
-
-        public byte Flags
-        {
-            get => _data[FlagsOffset];
-            set => _data[FlagsOffset] = value;
-        }
-
-        public int StreamId
-        {
-            get => (int)Bitshifter.ReadUInt31BigEndian(_data.AsSpan(StreamIdOffset));
-            set => Bitshifter.WriteUInt31BigEndian(_data.AsSpan(StreamIdOffset), (uint)value);
-        }
-
-        public Span<byte> Payload => new Span<byte>(_data, PayloadOffset, PayloadLength);
+        public int StreamId { get; set; }
 
         internal object ShowFlags()
         {
@@ -90,6 +50,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 default:
                     return $"0x{Flags:x}";
             }
+        }
+
+        public override string ToString()
+        {
+            return $"{Type} Stream: {StreamId} Length: {PayloadLength} Flags: {ShowFlags()}";
         }
     }
 }

--- a/src/Kestrel.Core/Internal/Http2/Http2FrameReader.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2FrameReader.cs
@@ -3,40 +3,241 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     public static class Http2FrameReader
     {
-        public static bool ReadFrame(ReadOnlySequence<byte> readableBuffer, Http2Frame frame, uint maxFrameSize, out SequencePosition consumed, out SequencePosition examined)
-        {
-            consumed = readableBuffer.Start;
-            examined = readableBuffer.End;
+        /* https://tools.ietf.org/html/rfc7540#section-4.1
+            +-----------------------------------------------+
+            |                 Length (24)                   |
+            +---------------+---------------+---------------+
+            |   Type (8)    |   Flags (8)   |
+            +-+-------------+---------------+-------------------------------+
+            |R|                 Stream Identifier (31)                      |
+            +=+=============================================================+
+            |                   Frame Payload (0...)                      ...
+            +---------------------------------------------------------------+
+        */
+        public const int HeaderLength = 9;
 
-            if (readableBuffer.Length < Http2Frame.HeaderLength)
+        private const int TypeOffset = 3;
+        private const int FlagsOffset = 4;
+        private const int StreamIdOffset = 5;
+
+        public const int SettingSize = 6; // 2 bytes for the id, 4 bytes for the value.
+
+        public static bool ReadFrame(ReadOnlySequence<byte> readableBuffer, Http2Frame frame, uint maxFrameSize, out ReadOnlySequence<byte> framePayload)
+        {
+            framePayload = ReadOnlySequence<byte>.Empty;
+
+            if (readableBuffer.Length < HeaderLength)
             {
                 return false;
             }
 
-            var headerSlice = readableBuffer.Slice(0, Http2Frame.HeaderLength);
-            headerSlice.CopyTo(frame.Raw);
+            var headerSlice = readableBuffer.Slice(0, HeaderLength);
+            var header = headerSlice.ToSpan();
 
-            var payloadLength = frame.PayloadLength;
+            var payloadLength = (int)Bitshifter.ReadUInt24BigEndian(header);
             if (payloadLength > maxFrameSize)
             {
                 throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorFrameOverLimit(payloadLength, maxFrameSize), Http2ErrorCode.FRAME_SIZE_ERROR);
             }
 
-            var frameLength = Http2Frame.HeaderLength + payloadLength;
+            // Make sure the whole frame is buffered
+            var frameLength = HeaderLength + payloadLength;
             if (readableBuffer.Length < frameLength)
             {
                 return false;
             }
 
-            readableBuffer.Slice(Http2Frame.HeaderLength, payloadLength).CopyTo(frame.Payload);
-            consumed = examined = readableBuffer.GetPosition(frameLength);
+            frame.PayloadLength = payloadLength;
+            frame.Type = (Http2FrameType)header[TypeOffset];
+            frame.Flags = header[FlagsOffset];
+            frame.StreamId = (int)Bitshifter.ReadUInt31BigEndian(header.Slice(StreamIdOffset));
+
+            var extendedHeaderLength = ReadExtendedFields(frame, readableBuffer);
+
+            // The remaining payload minus the extra fields
+            framePayload = readableBuffer.Slice(HeaderLength + extendedHeaderLength, payloadLength - extendedHeaderLength);
 
             return true;
+        }
+
+        private static int ReadExtendedFields(Http2Frame frame, ReadOnlySequence<byte> readableBuffer)
+        {
+            // Copy in any extra fields for the given frame type
+            var extendedHeaderLength = GetPayloadFieldsLength(frame);
+
+            if (extendedHeaderLength > frame.PayloadLength)
+            {
+                throw new Http2ConnectionErrorException(
+                    CoreStrings.FormatHttp2ErrorUnexpectedFrameLength(frame.Type, expectedLength: extendedHeaderLength), Http2ErrorCode.FRAME_SIZE_ERROR);
+            }
+
+            var extendedHeaders = readableBuffer.Slice(HeaderLength, extendedHeaderLength).ToSpan();
+
+            // Parse frame type specific fields
+            switch (frame.Type)
+            {
+                /*
+                    +---------------+
+                    |Pad Length? (8)|
+                    +---------------+-----------------------------------------------+
+                    |                            Data (*)                         ...
+                    +---------------------------------------------------------------+
+                    |                           Padding (*)                       ...
+                    +---------------------------------------------------------------+
+                */
+                case Http2FrameType.DATA: // Variable 0 or 1
+                    frame.DataPadLength = frame.DataHasPadding ? extendedHeaders[0] : (byte)0;
+                    break;
+
+                /* https://tools.ietf.org/html/rfc7540#section-6.2
+                    +---------------+
+                    |Pad Length? (8)|
+                    +-+-------------+-----------------------------------------------+
+                    |E|                 Stream Dependency? (31)                     |
+                    +-+-------------+-----------------------------------------------+
+                    |  Weight? (8)  |
+                    +-+-------------+-----------------------------------------------+
+                    |                   Header Block Fragment (*)                 ...
+                    +---------------------------------------------------------------+
+                    |                           Padding (*)                       ...
+                    +---------------------------------------------------------------+
+                */
+                case Http2FrameType.HEADERS:
+                    if (frame.HeadersHasPadding)
+                    {
+                        frame.HeadersPadLength = extendedHeaders[0];
+                        extendedHeaders = extendedHeaders.Slice(1);
+                    }
+                    else
+                    {
+                        frame.HeadersPadLength = 0;
+                    }
+
+                    if (frame.HeadersHasPriority)
+                    {
+                        frame.HeadersStreamDependency = (int)Bitshifter.ReadUInt31BigEndian(extendedHeaders);
+                        frame.HeadersPriorityWeight = extendedHeaders.Slice(4)[0];
+                    }
+                    else
+                    {
+                        frame.HeadersStreamDependency = 0;
+                        frame.HeadersPriorityWeight = 0;
+                    }
+                    break;
+
+                /* https://tools.ietf.org/html/rfc7540#section-6.8
+                    +-+-------------------------------------------------------------+
+                    |R|                  Last-Stream-ID (31)                        |
+                    +-+-------------------------------------------------------------+
+                    |                      Error Code (32)                          |
+                    +---------------------------------------------------------------+
+                    |                  Additional Debug Data (*)                    |
+                    +---------------------------------------------------------------+
+                */
+                case Http2FrameType.GOAWAY:
+                    frame.GoAwayLastStreamId = (int)Bitshifter.ReadUInt31BigEndian(extendedHeaders);
+                    frame.GoAwayErrorCode = (Http2ErrorCode)BinaryPrimitives.ReadUInt32BigEndian(extendedHeaders.Slice(4));
+                    break;
+
+                /* https://tools.ietf.org/html/rfc7540#section-6.3
+                    +-+-------------------------------------------------------------+
+                    |E|                  Stream Dependency (31)                     |
+                    +-+-------------+-----------------------------------------------+
+                    |   Weight (8)  |
+                    +-+-------------+
+                */
+                case Http2FrameType.PRIORITY:
+                    frame.PriorityStreamDependency = (int)Bitshifter.ReadUInt31BigEndian(extendedHeaders);
+                    frame.PriorityWeight = extendedHeaders.Slice(4)[0];
+                    break;
+
+                /* https://tools.ietf.org/html/rfc7540#section-6.4
+                    +---------------------------------------------------------------+
+                    |                        Error Code (32)                        |
+                    +---------------------------------------------------------------+
+                */
+                case Http2FrameType.RST_STREAM:
+                    frame.RstStreamErrorCode = (Http2ErrorCode)BinaryPrimitives.ReadUInt32BigEndian(extendedHeaders);
+                    break;
+
+                /* https://tools.ietf.org/html/rfc7540#section-6.9
+                    +-+-------------------------------------------------------------+
+                    |R|              Window Size Increment (31)                     |
+                    +-+-------------------------------------------------------------+
+                */
+                case Http2FrameType.WINDOW_UPDATE:
+                    frame.WindowUpdateSizeIncrement = (int)Bitshifter.ReadUInt31BigEndian(extendedHeaders);
+                    break;
+
+                case Http2FrameType.PING: // Opaque payload 8 bytes long
+                case Http2FrameType.SETTINGS: // Settings are general payload
+                case Http2FrameType.CONTINUATION: // None
+                case Http2FrameType.PUSH_PROMISE: // Not implemented frames are ignored at this phase
+                default:
+                    return 0;
+            }
+
+            return extendedHeaderLength;
+        }
+
+        // The length in bytes of additional fields stored in the payload section.
+        // This may be variable based on flags, but should be no more than 8 bytes.
+        public static int GetPayloadFieldsLength(Http2Frame frame)
+        {
+            switch (frame.Type)
+            {
+                // TODO: Extract constants
+                case Http2FrameType.DATA: // Variable 0 or 1
+                    return frame.DataHasPadding ? 1 : 0;
+                case Http2FrameType.HEADERS:
+                    return (frame.HeadersHasPadding ? 1 : 0) + (frame.HeadersHasPriority ? 5 : 0); // Variable 0 to 6
+                case Http2FrameType.GOAWAY:
+                    return 8; // Last stream id and error code.
+                case Http2FrameType.PRIORITY:
+                    return 5; // Stream dependency and weight
+                case Http2FrameType.RST_STREAM:
+                    return 4; // Error code
+                case Http2FrameType.WINDOW_UPDATE:
+                    return 4; // Update size
+                case Http2FrameType.PING: // 8 bytes of opaque data
+                case Http2FrameType.SETTINGS: // Settings are general payload
+                case Http2FrameType.CONTINUATION: // None
+                case Http2FrameType.PUSH_PROMISE: // Not implemented frames are ignored at this phase
+                default:
+                    return 0;
+            }
+        }
+
+        public static IList<Http2PeerSetting> ReadSettings(ReadOnlySequence<byte> payload)
+        {
+            var data = payload.ToSpan();
+            Debug.Assert(data.Length % SettingSize == 0, "Invalid settings payload length");
+            var settingsCount = data.Length / SettingSize;
+
+            var settings = new Http2PeerSetting[settingsCount];
+            for (int i = 0; i < settings.Length; i++)
+            {
+                settings[i] = ReadSetting(data);
+                data = data.Slice(SettingSize);
+            }
+            return settings;
+        }
+
+        private static Http2PeerSetting ReadSetting(ReadOnlySpan<byte> payload)
+        {
+            var id = (Http2SettingsParameter)BinaryPrimitives.ReadUInt16BigEndian(payload);
+            var value = BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(2));
+
+            return new Http2PeerSetting(id, value);
         }
     }
 }

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -2129,20 +2129,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             => GetString("GreaterThanZeroRequired");
 
         /// <summary>
-        /// The frame is too short to contain the fields indicated by the given flags.
-        /// </summary>
-        internal static string Http2FrameMissingFields
-        {
-            get => GetString("Http2FrameMissingFields");
-        }
-
-        /// <summary>
-        /// The frame is too short to contain the fields indicated by the given flags.
-        /// </summary>
-        internal static string FormatHttp2FrameMissingFields()
-            => GetString("Http2FrameMissingFields");
-
-        /// <summary>
         /// A value between {min} and {max} is required.
         /// </summary>
         internal static string ArgumentOutOfRange
@@ -2169,6 +2155,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// </summary>
         internal static string FormatHPackErrorDynamicTableSizeUpdateNotAtBeginningOfHeaderBlock()
             => GetString("HPackErrorDynamicTableSizeUpdateNotAtBeginningOfHeaderBlock");
+
+        /// <summary>
+        /// The given buffer was too small to encode any headers.
+        /// </summary>
+        internal static string HPackErrorNotEnoughBuffer
+        {
+            get => GetString("HPackErrorNotEnoughBuffer");
+        }
+
+        /// <summary>
+        /// The given buffer was too small to encode any headers.
+        /// </summary>
+        internal static string FormatHPackErrorNotEnoughBuffer()
+            => GetString("HPackErrorNotEnoughBuffer");
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -84,8 +84,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await InitializeConnectionAsync(_echoApplication);
 
             await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
+
             uint length = Http2PeerSettings.MinAllowedMaxFrameSize + 1;
-            await SendDataAsync(1, new byte[length].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[length], endStream: true);
 
             await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
                 ignoreNonGoAwayFrames: true,
@@ -104,7 +105,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await InitializeConnectionAsync(_echoApplication, expectedSettingsCount: 3);
 
             await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
-            await SendDataAsync(1, new byte[length].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[length], endStream: true);
 
             await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 37,
@@ -150,7 +151,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.DataPayload));
+            Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
         [Fact]
@@ -177,7 +178,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame.DataPayload));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
         [Fact]
@@ -249,10 +250,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame1.DataPayload));
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame2.DataPayload));
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame3.DataPayload));
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame4.DataPayload));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame1.PayloadSequence.ToArray()));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame2.PayloadSequence.ToArray()));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame3.PayloadSequence.ToArray()));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame4.PayloadSequence.ToArray()));
             Assert.Equal(_maxData.Length * 2, streamWindowUpdateFrame1.WindowUpdateSizeIncrement);
             Assert.Equal(_maxData.Length * 2, connectionWindowUpdateFrame1.WindowUpdateSizeIncrement);
             Assert.Equal(_maxData.Length * 2, connectionWindowUpdateFrame2.WindowUpdateSizeIncrement);
@@ -287,7 +288,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.DataPayload));
+            Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
         [Fact]
@@ -350,10 +351,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
 
-            Assert.True(_helloBytes.AsSpan().SequenceEqual(stream1DataFrame1.DataPayload));
-            Assert.True(_worldBytes.AsSpan().SequenceEqual(stream1DataFrame2.DataPayload));
-            Assert.True(_helloBytes.AsSpan().SequenceEqual(stream3DataFrame1.DataPayload));
-            Assert.True(_worldBytes.AsSpan().SequenceEqual(stream3DataFrame2.DataPayload));
+            Assert.True(_helloBytes.AsSpan().SequenceEqual(stream1DataFrame1.PayloadSequence.ToArray()));
+            Assert.True(_worldBytes.AsSpan().SequenceEqual(stream1DataFrame2.PayloadSequence.ToArray()));
+            Assert.True(_helloBytes.AsSpan().SequenceEqual(stream3DataFrame1.PayloadSequence.ToArray()));
+            Assert.True(_worldBytes.AsSpan().SequenceEqual(stream3DataFrame2.PayloadSequence.ToArray()));
         }
 
         [Fact]
@@ -443,16 +444,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
 
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame1.DataPayload));
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame2.DataPayload));
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame3.DataPayload));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame1.PayloadSequence.ToArray()));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame2.PayloadSequence.ToArray()));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame3.PayloadSequence.ToArray()));
             Assert.Equal(_maxData.Length * 2, streamWindowUpdateFrame.WindowUpdateSizeIncrement);
             Assert.Equal(_maxData.Length * 2, connectionWindowUpdateFrame1.WindowUpdateSizeIncrement);
 
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame4.DataPayload));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame4.PayloadSequence.ToArray()));
             Assert.Equal(_maxData.Length * 2, connectionWindowUpdateFrame2.WindowUpdateSizeIncrement);
 
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame5.DataPayload));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame5.PayloadSequence.ToArray()));
         }
 
         [Fact]
@@ -547,7 +548,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.DataPayload));
+            Assert.True(_helloWorldBytes.AsSpan().SequenceEqual(dataFrame.PayloadSequence.ToArray()));
         }
 
         [Theory]
@@ -564,7 +565,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await InitializeConnectionAsync(_echoApplication);
 
             await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
-            await SendDataWithPaddingAsync(1, maxDataMinusPadding.Span, padLength, endStream: false);
+            await SendDataWithPaddingAsync(1, maxDataMinusPadding, padLength, endStream: false);
 
             await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 37,
@@ -595,8 +596,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            Assert.True(maxDataMinusPadding.Span.SequenceEqual(dataFrame1.DataPayload));
-            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame2.DataPayload));
+            Assert.True(maxDataMinusPadding.Span.SequenceEqual(dataFrame1.PayloadSequence.ToArray()));
+            Assert.True(_maxData.AsSpan().SequenceEqual(dataFrame2.PayloadSequence.ToArray()));
 
             Assert.Equal(_maxData.Length * 2, connectionWindowUpdateFrame.WindowUpdateSizeIncrement);
         }
@@ -703,8 +704,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
                 ignoreNonGoAwayFrames: true,
                 expectedLastStreamId: 1,
-                expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR,
-                expectedErrorMessage: CoreStrings.Http2FrameMissingFields);
+                expectedErrorCode: Http2ErrorCode.FRAME_SIZE_ERROR,
+                expectedErrorMessage: CoreStrings.FormatHttp2ErrorUnexpectedFrameLength(Http2FrameType.DATA, expectedLength: 1));
         }
 
         [Fact]
@@ -1127,6 +1128,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
                 withStreamId: 1);
 
+            Assert.Equal(new byte[] { 0x08, 0x03, (byte)'1', (byte)'0', (byte)'0' }, frame.PayloadSequence.ToArray());
+
             await SendDataAsync(1, _helloBytes, endStream: true);
 
             await ExpectAsync(Http2FrameType.HEADERS,
@@ -1141,8 +1144,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withLength: 0,
                 withFlags: (byte)Http2DataFrameFlags.END_STREAM,
                 withStreamId: 1);
-
-            Assert.Equal(new byte[] { 0x08, 0x03, (byte)'1', (byte)'0', (byte)'0' }, frame.HeadersPayload.ToArray());
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
@@ -1361,8 +1362,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
                 ignoreNonGoAwayFrames: true,
                 expectedLastStreamId: 0,
-                expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR,
-                expectedErrorMessage: CoreStrings.Http2FrameMissingFields);
+                expectedErrorCode: Http2ErrorCode.FRAME_SIZE_ERROR,
+                expectedErrorMessage: CoreStrings.FormatHttp2ErrorUnexpectedFrameLength(Http2FrameType.HEADERS, expectedLength: 1));
         }
 
         [Theory]
@@ -1924,7 +1925,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     withFlags: (byte)Http2DataFrameFlags.NONE,
                     withStreamId: streamId);
 
-                Assert.True(_helloWorldBytes.AsSpan(0, initialWindowSize).SequenceEqual(dataFrame.DataPayload));
+                Assert.True(_helloWorldBytes.AsSpan(0, initialWindowSize).SequenceEqual(dataFrame.PayloadSequence.ToArray()));
                 Assert.False(writeTasks[streamId].IsCompleted);
             }
 
@@ -2064,13 +2065,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await SendSettingsAsync();
 
             var frame = await ExpectAsync(Http2FrameType.SETTINGS,
-                withLength: Http2Frame.SettingSize * 2,
+                withLength: Http2FrameReader.SettingSize * 2,
                 withFlags: 0,
                 withStreamId: 0);
 
             // Only non protocol defaults are sent
-            Assert.Equal(2, frame.SettingsCount);
-            var settings = frame.GetSettings();
+            var settings = Http2FrameReader.ReadSettings(frame.PayloadSequence);
             Assert.Equal(2, settings.Count);
 
             var setting = settings[0];
@@ -2101,13 +2101,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await SendSettingsAsync();
 
             var frame = await ExpectAsync(Http2FrameType.SETTINGS,
-                withLength: 6 * 2,
+                withLength: Http2FrameReader.SettingSize * 2,
                 withFlags: 0,
                 withStreamId: 0);
 
             // Only non protocol defaults are sent
-            Assert.Equal(2, frame.SettingsCount);
-            var settings = frame.GetSettings();
+            var settings = Http2FrameReader.ReadSettings(frame.PayloadSequence);
             Assert.Equal(2, settings.Count);
 
             var setting = settings[0];
@@ -2139,9 +2138,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             await InitializeConnectionAsync(_noopApplication);
 
-            var frame = new Http2Frame(Http2PeerSettings.MinAllowedMaxFrameSize);
+            var frame = new Http2Frame();
             frame.PrepareSettings(Http2SettingsFrameFlags.ACK);
-            await SendAsync(frame.Raw);
+            Http2FrameWriter.WriteHeader(frame, _pair.Application.Output);
+            await FlushAsync(_pair.Application.Output);
 
             await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
         }
@@ -2260,6 +2260,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task SETTINGS_Received_ChangesAllowedResponseMaxFrameSize()
         {
+            _connection.ServerSettings.MaxFrameSize = Http2PeerSettings.MaxAllowedMaxFrameSize;
             // This includes the default response headers such as :status, etc
             var defaultResponseHeaderLength = 37;
             var headerValueLength = Http2PeerSettings.MinAllowedMaxFrameSize;
@@ -2276,7 +2277,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 context.Response.Headers["A"] = new string('a', headerValueLength);
                 context.Response.Headers["B"] = new string('b', headerValueLength);
                 return context.Response.Body.WriteAsync(new byte[payloadLength], 0, payloadLength);
-            });
+            }, expectedSettingsCount: 3);
 
             // Update client settings
             _clientSettings.MaxFrameSize = (uint)payloadLength;
@@ -2301,6 +2302,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withStreamId: 1);
             await ExpectAsync(Http2FrameType.DATA,
                 withLength: payloadLength,
+                withFlags: (byte)Http2DataFrameFlags.NONE,
+                withStreamId: 1);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 0,
+                withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+                withStreamId: 1);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
+        public async Task SETTINGS_Received_ClientMaxFrameSizeCannotExceedServerMaxFrameSize()
+        {
+            var serverMaxFrame = Http2PeerSettings.MinAllowedMaxFrameSize + 1024;
+            _connection.ServerSettings.MaxFrameSize = Http2PeerSettings.MinAllowedMaxFrameSize + 1024;
+            var clientMaxFrame = serverMaxFrame + 1024 * 5;
+            _clientSettings.MaxFrameSize = (uint)clientMaxFrame;
+
+            await InitializeConnectionAsync(context =>
+            {
+                return context.Response.Body.WriteAsync(new byte[clientMaxFrame], 0, clientMaxFrame);
+            }, expectedSettingsCount: 3);
+
+            // Start request
+            await StartStreamAsync(1, _browserRequestHeaders, endStream: true);
+
+            await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+                withStreamId: 1);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: serverMaxFrame,
+                withFlags: (byte)Http2DataFrameFlags.NONE,
+                withStreamId: 1);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: clientMaxFrame - serverMaxFrame,
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 1);
             await ExpectAsync(Http2FrameType.DATA,
@@ -2627,7 +2664,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     withFlags: (byte)Http2DataFrameFlags.NONE,
                     withStreamId: streamId);
 
-                Assert.True(_helloWorldBytes.AsSpan(0, initialWindowSize).SequenceEqual(dataFrame.DataPayload));
+                Assert.True(_helloWorldBytes.AsSpan(0, initialWindowSize).SequenceEqual(dataFrame.PayloadSequence.ToArray()));
                 Assert.False(writeTasks[streamId].IsCompleted);
             }
 
@@ -2931,8 +2968,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            Assert.True(_helloWorldBytes.AsSpan(0, initialWindowSize).SequenceEqual(dataFrame1.DataPayload));
-            Assert.True(_helloWorldBytes.AsSpan(initialWindowSize, initialWindowSize).SequenceEqual(dataFrame2.DataPayload));
+            Assert.True(_helloWorldBytes.AsSpan(0, initialWindowSize).SequenceEqual(dataFrame1.PayloadSequence.ToArray()));
+            Assert.True(_helloWorldBytes.AsSpan(initialWindowSize, initialWindowSize).SequenceEqual(dataFrame2.PayloadSequence.ToArray()));
         }
 
         [Fact]
@@ -2986,9 +3023,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            Assert.True(_helloWorldBytes.AsSpan(0, 6).SequenceEqual(dataFrame1.DataPayload));
-            Assert.True(_helloWorldBytes.AsSpan(6, 3).SequenceEqual(dataFrame2.DataPayload));
-            Assert.True(_helloWorldBytes.AsSpan(9, 3).SequenceEqual(dataFrame3.DataPayload));
+            Assert.True(_helloWorldBytes.AsSpan(0, 6).SequenceEqual(dataFrame1.PayloadSequence.ToArray()));
+            Assert.True(_helloWorldBytes.AsSpan(6, 3).SequenceEqual(dataFrame2.PayloadSequence.ToArray()));
+            Assert.True(_helloWorldBytes.AsSpan(9, 3).SequenceEqual(dataFrame3.PayloadSequence.ToArray()));
         }
 
         [Fact]
@@ -3190,9 +3227,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
-            _hpackDecoder.Decode(continuationFrame1.HeadersPayload, endHeaders: false, handler: this);
-            _hpackDecoder.Decode(continuationFrame2.HeadersPayload, endHeaders: true, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(continuationFrame1.PayloadSequence, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(continuationFrame2.PayloadSequence, endHeaders: true, handler: this);
 
             Assert.Equal(11, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(4, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(4, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(5, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(5, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(6, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -262,7 +262,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -328,7 +328,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -361,7 +361,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -394,7 +394,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(4, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -429,7 +429,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(4, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -464,7 +464,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(4, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -499,7 +499,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(4, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -610,7 +610,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[12].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[12], endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 55,
@@ -623,7 +623,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -653,7 +653,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 new KeyValuePair<string, string>(HeaderNames.ContentLength, "12"),
             };
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[12].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[12], endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 55,
@@ -666,7 +666,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -699,9 +699,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[1].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[3].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[8].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[1], endStream: false);
+            await SendDataAsync(1, new byte[3], endStream: false);
+            await SendDataAsync(1, new byte[8], endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 55,
@@ -714,7 +714,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -786,7 +786,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[13].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[13], endStream: true);
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.PROTOCOL_ERROR, CoreStrings.Http2StreamErrorMoreDataThanLength);
 
@@ -821,7 +821,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[11].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[11], endStream: true);
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.PROTOCOL_ERROR, CoreStrings.Http2StreamErrorLessDataThanLength);
 
@@ -856,10 +856,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[1].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[2].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[10].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[2].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[1], endStream: false);
+            await SendDataAsync(1, new byte[2], endStream: false);
+            await SendDataAsync(1, new byte[10], endStream: false);
+            await SendDataAsync(1, new byte[2], endStream: true);
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.PROTOCOL_ERROR, CoreStrings.Http2StreamErrorMoreDataThanLength);
 
@@ -894,8 +894,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[1].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[2].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[1], endStream: false);
+            await SendDataAsync(1, new byte[2], endStream: true);
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.PROTOCOL_ERROR, CoreStrings.Http2StreamErrorLessDataThanLength);
 
@@ -938,7 +938,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -977,7 +977,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1015,7 +1015,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1053,7 +1053,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1080,7 +1080,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[12].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[12], endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 55,
@@ -1093,7 +1093,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1136,7 +1136,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1164,7 +1164,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[12].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[12], endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 55,
@@ -1177,7 +1177,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1207,9 +1207,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[6].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[6].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[6].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[6], endStream: false);
+            await SendDataAsync(1, new byte[6], endStream: false);
+            await SendDataAsync(1, new byte[6], endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 59,
@@ -1222,7 +1222,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1266,9 +1266,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[6].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[6].AsSpan(), endStream: false);
-            await SendDataAsync(1, new byte[6].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[6], endStream: false);
+            await SendDataAsync(1, new byte[6], endStream: false);
+            await SendDataAsync(1, new byte[6], endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 59,
@@ -1281,7 +1281,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1321,7 +1321,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             await StartStreamAsync(1, headers, endStream: false);
-            await SendDataAsync(1, new byte[12].AsSpan(), endStream: true);
+            await SendDataAsync(1, new byte[12], endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 55,
@@ -1334,7 +1334,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1371,7 +1371,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(3, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1409,7 +1409,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
-            _hpackDecoder.Decode(headersFrame.HeadersPayload, endHeaders: false, handler: this);
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
             Assert.Equal(2, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -1734,6 +1734,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withStreamId: 1);
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
+        public async Task ResponseWithHeadersTooLarge_AbortsConnection()
+        {
+            var appFinished = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            await InitializeConnectionAsync(async context =>
+            {
+                context.Response.Headers["too_long"] = new string('a', (int)Http2PeerSettings.DefaultMaxFrameSize);
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.WriteAsync("Hello World")).DefaultTimeout();
+                appFinished.TrySetResult(ex.InnerException.Message);
+            });
+
+            await StartStreamAsync(1, _browserRequestHeaders, endStream: true);
+
+            var message = await appFinished.Task.DefaultTimeout();
+            Assert.Equal(CoreStrings.HPackErrorNotEnoughBuffer, message);
         }
     }
 }

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/TlsTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/TlsTests.cs
@@ -92,20 +92,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.Http2
 
         private async Task<Http2Frame> ReceiveFrameAsync(PipeReader reader)
         {
-            var frame = new Http2Frame(Http2PeerSettings.MinAllowedMaxFrameSize);
+            var frame = new Http2Frame();
 
             while (true)
             {
                 var result = await reader.ReadAsync();
                 var buffer = result.Buffer;
                 var consumed = buffer.Start;
-                var examined = buffer.End;
+                var examined = buffer.Start;
 
                 try
                 {
-                    if (Http2FrameReader.ReadFrame(buffer, frame, 16_384, out consumed, out examined))
+                    if (Http2FrameReader.ReadFrame(buffer, frame, 16_384, out var framePayload))
                     {
+                        consumed = examined = framePayload.End;
                         return frame;
+                    }
+                    else
+                    {
+                        examined = buffer.End;
                     }
 
                     if (result.IsCompleted)


### PR DESCRIPTION
 #2858 I was able to reduce the request buffer from 16kb to 15 bytes. The response buffer is still needed for compressing headers.

This helped eliminate several data copies for request headers, request and response data, and settings frames.

Converting Http2Frame to a POCO helped eliminate a lot of redundant de/serialization of properties that were accessed multiple times.

Measurements needed.