### PR TITLE
Make usage of TestConnection.Receive vs ReceiveEnd consistent

### DIFF
--- a/test/Kestrel.InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "GET /\x0D\0x0ALocation:http://www.contoso.com/ HTTP/1.1",
                         "Host:\r\n\r\n");
 
-                    await client.ReceiveStartsWith("HTTP/1.1 400");
+                    await client.Receive("HTTP/1.1 400");
                 }
             }
         }
@@ -225,7 +225,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 ""
             };
 
-            await connection.ReceiveForcedEnd(lines.Where(f => f != null).ToArray());
+            await connection.ReceiveEnd(lines.Where(f => f != null).ToArray());
         }
 
         public static TheoryData<string, string> InvalidRequestLineData

--- a/test/Kestrel.InMemory.FunctionalTests/ChunkedRequestTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/ChunkedRequestTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "0",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Content-Length: 11",
                         "",
                         "Hello World");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Content-Length: 7",
                         "",
                         "Goodbye");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 11",
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 using (var connection = server.CreateConnection())
                 {
                     await connection.Send(fullRequest);
-                    await connection.ReceiveEnd(expectedFullResponse);
+                    await connection.Receive(expectedFullResponse);
                 }
             }
         }
@@ -289,7 +289,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         $"{trailingHeaderLine}",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 431 Request Header Fields Too Large",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         $"{trailingHeaderLine}",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 431 Request Header Fields Too Large",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -422,7 +422,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 using (var connection = server.CreateConnection())
                 {
                     await connection.Send(fullRequest);
-                    await connection.ReceiveEnd(expectedFullResponse);
+                    await connection.Receive(expectedFullResponse);
                 }
             }
         }
@@ -461,7 +461,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "HTTP/1.1 400 Bad Request",
                         "Connection: close",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 0",
                         "",
@@ -505,7 +505,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "HTTP/1.1 400 Bad Request",
                         "Connection: close",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 0",
                         "",
@@ -537,7 +537,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 400 Bad Request",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -561,7 +561,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 400 Bad Request",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -583,7 +583,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 400 Bad Request",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -607,7 +607,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 400 Bad Request",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",

--- a/test/Kestrel.InMemory.FunctionalTests/ChunkedResponseTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/ChunkedResponseTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Transfer-Encoding: chunked",
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host: ",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Transfer-Encoding: chunked",
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                     flushed.Release();
 
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "c",
                         "Hello World!",
                         "0",
@@ -248,7 +248,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host: ",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Transfer-Encoding: chunked",
@@ -281,7 +281,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host: ",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Transfer-Encoding: chunked",
@@ -315,7 +315,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "");
 
                     // Headers are sent before connection is closed, but chunked body terminator isn't sent
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Transfer-Encoding: chunked",
@@ -361,7 +361,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                     flushWh.SetResult(null);
 
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "6",
                         "World!",
                         "0",
@@ -393,7 +393,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host: ",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Transfer-Encoding: chunked",

--- a/test/Kestrel.InMemory.FunctionalTests/DefaultHeaderTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/DefaultHeaderTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Server: Kestrel",

--- a/test/Kestrel.InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Content-Length: " + (globalMaxRequestBodySize + 1),
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 413 Payload Too Large",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Content-Length: " + (perRequestMaxRequestBodySize + 1),
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 413 Payload Too Large",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Content-Length: 1",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         "Content-Length: 0",
@@ -246,7 +246,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         $"Date: {server.Context.DateHeaderValue}",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd();
+                    await connection.ReceiveEnd();
                 }
             }
 
@@ -279,7 +279,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Content-Length: " + (new KestrelServerLimits().MaxRequestBodySize + 1),
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 413 Payload Too Large",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -326,7 +326,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Transfer-Encoding: chunked",
                         "",
                         chunkedPayload);
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 413 Payload Too Large",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -435,7 +435,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Transfer-Encoding: chunked",
                         "",
                         chunkedPayload);
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         "Content-Length: 0",
@@ -478,7 +478,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Transfer-Encoding: chunked",
                         "",
                         "1\r\n");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 413 Payload Too Large",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",

--- a/test/Kestrel.InMemory.FunctionalTests/MaxRequestLineSizeTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/MaxRequestLineSizeTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 using (var connection = server.CreateConnection())
                 {
                     await connection.Send(request);
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         "Transfer-Encoding: chunked",
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 using (var connection = server.CreateConnection())
                 {
                     await connection.SendAll(requestLine);
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 414 URI Too Long",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",

--- a/test/Kestrel.InMemory.FunctionalTests/RequestHeaderLimitsTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/RequestHeaderLimitsTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 using (var connection = server.CreateConnection())
                 {
                     await connection.Send($"GET / HTTP/1.1\r\n{headers}\r\n");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         "Transfer-Encoding: chunked",
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 using (var connection = server.CreateConnection())
                 {
                     await connection.Send($"GET / HTTP/1.1\r\n{headers}\r\n");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         "Transfer-Encoding: chunked",
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 using (var connection = server.CreateConnection())
                 {
                     await connection.SendAll($"GET / HTTP/1.1\r\n{headers}\r\n");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 431 Request Header Fields Too Large",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 using (var connection = server.CreateConnection())
                 {
                     await connection.SendAll($"GET / HTTP/1.1\r\n{headers}\r\n");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 431 Request Header Fields Too Large",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",

--- a/test/Kestrel.InMemory.FunctionalTests/RequestTargetProcessingTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/RequestTargetProcessingTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 11",
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 11",
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         $"Host: {host}",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 11",

--- a/test/Kestrel.InMemory.FunctionalTests/RequestTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/RequestTests.cs
@@ -342,7 +342,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "GET / HTTP/1.0",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -358,7 +358,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Content-Length: 11",
                         "",
                         "Hello World");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -391,7 +391,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 0",
                         "\r\n");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -431,7 +431,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "Goodbye");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -486,7 +486,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "Goodbye");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -518,7 +518,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "");
                     await connection.Send("Hello World");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -551,7 +551,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Connection: close",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -567,7 +567,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -592,7 +592,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     await connection.Send(
                         "POST / HTTP/1.1");
                     connection.ShutdownSend();
-                    await connection.ReceiveForcedEnd();
+                    await connection.ReceiveEnd();
                 }
 
                 using (var connection = server.CreateConnection())
@@ -602,7 +602,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "Content-Length: 7");
                     connection.ShutdownSend();
-                    await connection.ReceiveForcedEnd();
+                    await connection.ReceiveEnd();
                 }
             }
         }
@@ -643,7 +643,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 0",
@@ -687,7 +687,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Connection: Upgrade",
                         "",
                         message);
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 101 Switching Protocols",
                         "Connection: Upgrade",
                         $"Date: {testContext.DateHeaderValue}",
@@ -895,7 +895,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "hello");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -928,7 +928,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "hello");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 101 Switching Protocols",
                         "Connection: Upgrade",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -988,13 +988,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                     await connection.Send("b");
 
-                    await connection.Receive(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 101 Switching Protocols",
                         "Connection: Upgrade",
-                        "");
-                    await connection.ReceiveStartsWith(
-                        $"Date: ");
-                    await connection.ReceiveForcedEnd(
+                        $"Date: {server.Context.DateHeaderValue}",
                         "",
                         "hello");
                 }

--- a/test/Kestrel.InMemory.FunctionalTests/ResponseTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/ResponseTests.cs
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "",
                         "gg");
 
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         "Content-Length: 0",
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Transfer-Encoding: chunked",
                         "",
                         "gg");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         "Content-Length: 0",
@@ -573,7 +573,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         $"HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         "Content-Length: 11",
@@ -611,7 +611,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         $"HTTP/1.1 500 Internal Server Error",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -646,7 +646,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         $"HTTP/1.1 500 Internal Server Error",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -1029,7 +1029,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                     flushed.SetResult(null);
 
-                    await connection.ReceiveEnd("hello, world");
+                    await connection.Receive("hello, world");
                 }
             }
         }
@@ -1093,7 +1093,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -1109,7 +1109,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Connection: keep-alive",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -1139,7 +1139,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: keep-alive",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -1155,7 +1155,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Connection: keep-alive",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: keep-alive",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -1199,7 +1199,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         $"Transfer-Encoding: {responseTransferEncoding}",
@@ -1436,7 +1436,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     // This will receive a success response because the server flushed the response
                     // before reading the malformed chunk header in the request, but then it will close
                     // the connection.
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {server.Context.DateHeaderValue}",
                         "Content-Length: 0",
@@ -1548,7 +1548,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     // If 100 Continue sets HttpProtocol.HasResponseStarted to true,
                     // a success response will be produced before the server sees the
                     // bad chunk header above, making this test fail.
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 400 Bad Request",
                         "Connection: close",
                         $"Date: {server.Context.DateHeaderValue}",
@@ -1650,7 +1650,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Connection: keep-alive",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 0",
@@ -1723,7 +1723,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "",
@@ -1769,7 +1769,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Content-Length: 3",
                         "",
                         "200");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 204 No Content",
                         $"Date: {testContext.DateHeaderValue}",
                         "",
@@ -1809,7 +1809,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Connection: Upgrade",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 101 Switching Protocols",
                         "Connection: Upgrade",
                         $"Date: {testContext.DateHeaderValue}",
@@ -1824,7 +1824,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Connection: keep-alive, Upgrade",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 101 Switching Protocols",
                         "Connection: Upgrade",
                         $"Date: {testContext.DateHeaderValue}",
@@ -1866,7 +1866,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Connection: close",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 500 Internal Server Error",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 0",
@@ -1923,7 +1923,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 500 Internal Server Error",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 0",
@@ -1977,7 +1977,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 11",
@@ -2020,7 +2020,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 11",
@@ -2061,7 +2061,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 11",
@@ -2093,7 +2093,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "GET / HTTP/1.0",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd(
+                    await connection.ReceiveEnd(
                         "HTTP/1.1 200 OK",
                         "Connection: close",
                         $"Date: {testContext.DateHeaderValue}",
@@ -2124,7 +2124,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Content-Length: 1",
                         "",
                         "");
-                    await connection.ReceiveForcedEnd();
+                    await connection.ReceiveEnd();
                 }
             }
         }
@@ -2165,7 +2165,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         "Content-Length: 0",
@@ -2214,7 +2214,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         $"Content-Length: {response.Length}",
@@ -2265,7 +2265,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-                    await connection.ReceiveEnd(
+                    await connection.Receive(
                         "HTTP/1.1 200 OK",
                         $"Date: {testContext.DateHeaderValue}",
                         $"Content-Length: {response.Length}",
@@ -2461,7 +2461,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
                         if (expectedClientStatusCode == HttpStatusCode.OK)
                         {
-                            await connection.ReceiveForcedEnd(
+                            await connection.ReceiveEnd(
                                 "HTTP/1.1 200 OK",
                                 $"Date: {server.Context.DateHeaderValue}",
                                 "Content-Length: 0",
@@ -2470,7 +2470,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         }
                         else
                         {
-                            await connection.ReceiveForcedEnd(
+                            await connection.ReceiveEnd(
                                 "HTTP/1.1 400 Bad Request",
                                 "Connection: close",
                                 $"Date: {server.Context.DateHeaderValue}",

--- a/test/Kestrel.InMemory.FunctionalTests/UpgradeTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/UpgradeTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     "",
                     "");
 
-                await connection.ReceiveForcedEnd(
+                await connection.ReceiveEnd(
                     "HTTP/1.1 400 Bad Request",
                     "Connection: close",
                     $"Date: {server.Context.DateHeaderValue}",
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     "Connection: Upgrade",
                     "",
                     "");
-                await connection.ReceiveForcedEnd(
+                await connection.ReceiveEnd(
                     "HTTP/1.1 400 Bad Request",
                     "Connection: close",
                     $"Date: {server.Context.DateHeaderValue}",


### PR DESCRIPTION
- Add a transport test verifying that concurrent requests/connections work.

The new test helps resolve #2776