### PR TITLE
Fix flaky test by ignoring indeterminant response

### DIFF
--- a/test/Kestrel.FunctionalTests/ChunkedRequestTests.cs
+++ b/test/Kestrel.FunctionalTests/ChunkedRequestTests.cs
@@ -678,7 +678,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                     connection.Socket.Shutdown(SocketShutdown.Send);
 
-                    await connection.ReceiveEnd();
+                    await connection.ReceiveEnd(ignoreResponse: true);
 
                     var badReqEx = await exTcs.Task.TimeoutAfter(TestConstants.DefaultTimeout);
                     Assert.Equal(RequestRejectionReason.UnexpectedEndOfRequestContent, badReqEx.Reason);

--- a/test/shared/TestConnection.cs
+++ b/test/shared/TestConnection.cs
@@ -149,14 +149,20 @@ namespace Microsoft.AspNetCore.Testing
             Assert.Equal(expected, new string(actual, 0, offset));
         }
 
-        public async Task ReceiveEnd(params string[] lines)
+        public Task ReceiveEnd(params string[] lines)
+            => ReceiveEnd(false, lines);
+
+        public async Task ReceiveEnd(bool ignoreResponse, params string[] lines)
         {
             await Receive(lines).ConfigureAwait(false);
             _socket.Shutdown(SocketShutdown.Send);
             var ch = new char[128];
             var count = await _reader.ReadAsync(ch, 0, 128).TimeoutAfter(Timeout).ConfigureAwait(false);
-            var text = new string(ch, 0, count);
-            Assert.Equal("", text);
+            if (!ignoreResponse)
+            {
+                var text = new string(ch, 0, count);
+                Assert.Equal("", text);
+            }
         }
 
         public async Task ReceiveForcedEnd(params string[] lines)


### PR DESCRIPTION
Addresses: https://github.com/aspnet/KestrelHttpServer/issues/2883.

Instead of removing the `await ReceiveEnd()` call, I'm just ignoring the response.