### PR TITLE
Map ListenOptions.Protocols from IConfiguration

### DIFF
--- a/src/Kestrel.Core/Internal/ConfigurationReader.cs
+++ b/src/Kestrel.Core/Internal/ConfigurationReader.cs
@@ -9,9 +9,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
     internal class ConfigurationReader
     {
+        private const string ProtocolsKey = "Protocols";
+        private const string CertificatesKey = "Certificates";
+        private const string CertificateKey = "Certificate";
+        private const string EndpointDefaultsKey = "EndpointDefaults";
+        private const string EndpointsKey = "Endpoints";
+        private const string UrlKey = "Url";
+
         private IConfiguration _configuration;
         private IDictionary<string, CertificateConfig> _certificates;
         private IList<EndpointConfig> _endpoints;
+        private EndpointDefaults _endpointDefaults;
 
         public ConfigurationReader(IConfiguration configuration)
         {
@@ -28,6 +36,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 }
 
                 return _certificates;
+            }
+        }
+
+        public EndpointDefaults EndpointDefaults
+        {
+            get
+            {
+                if (_endpointDefaults == null)
+                {
+                    ReadEndpointDefaults();
+                }
+
+                return _endpointDefaults;
             }
         }
 
@@ -48,29 +69,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         {
             _certificates = new Dictionary<string, CertificateConfig>(0);
 
-            var certificatesConfig = _configuration.GetSection("Certificates").GetChildren();
+            var certificatesConfig = _configuration.GetSection(CertificatesKey).GetChildren();
             foreach (var certificateConfig in certificatesConfig)
             {
                 _certificates.Add(certificateConfig.Key, new CertificateConfig(certificateConfig));
             }
         }
 
+        // "EndpointDefaults": {
+        //    "Protocols": "Http1AndHttp2",
+        // }
+        private void ReadEndpointDefaults()
+        {
+            var configSection = _configuration.GetSection(EndpointDefaultsKey);
+            _endpointDefaults = new EndpointDefaults()
+            {
+                Protocols = ParseProtocols(configSection[ProtocolsKey])
+            };
+        }
+
         private void ReadEndpoints()
         {
             _endpoints = new List<EndpointConfig>();
 
-            var endpointsConfig = _configuration.GetSection("Endpoints").GetChildren();
+            var endpointsConfig = _configuration.GetSection(EndpointsKey).GetChildren();
             foreach (var endpointConfig in endpointsConfig)
             {
                 // "EndpointName": {
-                //    "Url": "https://*:5463",
-                //    "Certificate": {
-                //        "Path": "testCert.pfx",
-                //        "Password": "testPassword"
-                //    }
+                //    "Url": "https://*:5463",
+                //    "Protocols": "Http1AndHttp2",
+                //    "Certificate": {
+                //        "Path": "testCert.pfx",
+                //        "Password": "testPassword"
+                //    }
                 // }
-                
-                var url = endpointConfig["Url"];
+
+                var url = endpointConfig[UrlKey];
                 if (string.IsNullOrEmpty(url))
                 {
                     throw new InvalidOperationException(CoreStrings.FormatEndpointMissingUrl(endpointConfig.Key));
@@ -80,16 +114,37 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 {
                     Name = endpointConfig.Key,
                     Url = url,
+                    Protocols = ParseProtocols(endpointConfig[ProtocolsKey]),
                     ConfigSection = endpointConfig,
-                    Certificate = new CertificateConfig(endpointConfig.GetSection("Certificate")),
+                    Certificate = new CertificateConfig(endpointConfig.GetSection(CertificateKey)),
                 };
                 _endpoints.Add(endpoint);
             }
         }
+
+        private static HttpProtocols? ParseProtocols(string protocols)
+        {
+            if (Enum.TryParse<HttpProtocols>(protocols, ignoreCase: true, out var result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+    }
+
+    // "EndpointDefaults": {
+    //    "Protocols": "Http1AndHttp2",
+    // }
+    internal class EndpointDefaults
+    {
+        public HttpProtocols? Protocols { get; set; }
+        public IConfigurationSection ConfigSection { get; set; }
     }
 
     // "EndpointName": {
     //    "Url": "https://*:5463",
+    //    "Protocols": "Http1AndHttp2",
     //    "Certificate": {
     //        "Path": "testCert.pfx",
     //        "Password": "testPassword"
@@ -99,6 +154,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
     {
         public string Name { get; set; }
         public string Url { get; set; }
+        public HttpProtocols? Protocols { get; set; }
         public IConfigurationSection ConfigSection { get; set; }
         public CertificateConfig Certificate { get; set; }
     }

--- a/src/Kestrel.Core/KestrelServerOptions.cs
+++ b/src/Kestrel.Core/KestrelServerOptions.cs
@@ -103,6 +103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal void ApplyEndpointDefaults(ListenOptions listenOptions)
         {
             listenOptions.KestrelServerOptions = this;
+            ConfigurationLoader?.ApplyConfigurationDefaults(listenOptions);
             EndpointDefaults(listenOptions);
         }
 


### PR DESCRIPTION
#2903 @shirhatti @DamianEdwards requested this after a high level design review. This allows you to turn HTTP/2 (and HTTP/1.x) on/off server wide or per endpoint using only config.

New schemas:

Per endpoint there is a new `Protocols` field:
```
{
"Kestrel": {
  "EndPoints": {
    "Endpoint0": {
      "Url": "http://localhost:5000",
      "Protocols": "Http1AndHttp2"
    },
```

Globally there is a new `EndPointDefaults` section with a `Protocols` field:
```
{
"Kestrel": {
  "EndPointDefaults": {
      "Protocols": "Http1AndHttp2"
```
As an alternative we could collapse this to:
```
{
"Kestrel": {
      "DefaultProtocols": "Http1AndHttp2"
```

The value is any acceptable value of the HttpProtocols enum: Http1, Http2, or Http1AndHttp2.

The global default really is global, it will affect endpoints defined via any of the currently acceptable mechanics: The default http://localhost:5000, UseUrls, ASPNETCORE_URLS, Listen, Config, etc.).

Protocols specified in code will override the config values, including in ConfigureEndpointDefaults.
