### PR TITLE
Handle SocketError.ProtocolType as a connection reset on macOS

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketConnection.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     {
         private static readonly int MinAllocBufferSize = KestrelMemoryPool.MinimumSegmentSize / 2;
         private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        private static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
         private readonly Socket _socket;
         private readonly PipeScheduler _scheduler;
@@ -307,9 +308,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         private static bool IsConnectionResetError(SocketError errorCode)
         {
+            // ProtocolType can be removed once https://github.com/dotnet/corefx/issues/31927 is fixed.
             return errorCode == SocketError.ConnectionReset ||
                    errorCode == SocketError.ConnectionAborted ||
-                   errorCode == SocketError.Shutdown;
+                   errorCode == SocketError.Shutdown ||
+                   (errorCode == SocketError.ProtocolType && IsMacOS);
         }
 
         private static bool IsConnectionAbortError(SocketError errorCode)


### PR DESCRIPTION
Backport of #2845

Addresses #2885