### PR TITLE
Remove calls to MemoryMarshal.GetReference

### DIFF
--- a/benchmarkapps/PlatformBenchmarks/BufferExtensions.cs
+++ b/benchmarkapps/PlatformBenchmarks/BufferExtensions.cs
@@ -31,7 +31,7 @@ namespace PlatformBenchmarks
 
             // Fast path, try copying to the available memory directly
             var advanceBy = 0;
-            fixed (byte* output = &MemoryMarshal.GetReference(span))
+            fixed (byte* output = span)
             {
                 var start = output;
                 if (number < 10 && bytesLeftInBlock >= 1)

--- a/src/Kestrel.Core/Internal/Http/HttpParser.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpParser.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             // Fix and parse the span
-            fixed (byte* data = &MemoryMarshal.GetReference(span))
+            fixed (byte* data = span)
             {
                 ParseRequestLine(handler, data, span.Length);
             }
@@ -206,7 +206,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var span = reader.CurrentSegment;
                     var remaining = span.Length - reader.CurrentSegmentIndex;
 
-                    fixed (byte* pBuffer = &MemoryMarshal.GetReference(span))
+                    fixed (byte* pBuffer = span)
                     {
                         while (remaining > 0)
                         {
@@ -298,7 +298,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                                 var headerSpan = buffer.Slice(current, lineEnd).ToSpan();
                                 length = headerSpan.Length;
 
-                                fixed (byte* pHeader = &MemoryMarshal.GetReference(headerSpan))
+                                fixed (byte* pHeader = headerSpan)
                                 {
                                     TakeSingleHeader(pHeader, length, handler);
                                 }

--- a/src/Kestrel.Core/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpRequestHeaders.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public unsafe void Append(Span<byte> name, string value)
         {
-            fixed (byte* namePtr = &MemoryMarshal.GetReference(name))
+            fixed (byte* namePtr = name)
             {
                 Append(namePtr, name.Length, value);
             }

--- a/src/Kestrel.Core/Internal/Http/PathNormalizer.cs
+++ b/src/Kestrel.Core/Internal/Http/PathNormalizer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             // .NET 451 doesn't have pointer overloads for Encoding.GetString so we
             // copy to an array
-            fixed (byte* pointer = &MemoryMarshal.GetReference(path))
+            fixed (byte* pointer = path)
             {
                 return Encoding.UTF8.GetString(pointer, path.Length);
             }
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         // In-place implementation of the algorithm from https://tools.ietf.org/html/rfc3986#section-5.2.4
         public static unsafe int RemoveDotSegments(Span<byte> input)
         {
-            fixed (byte* start = &MemoryMarshal.GetReference(input))
+            fixed (byte* start = input)
             {
                 var end = start + input.Length;
                 return RemoveDotSegments(start, end);

--- a/src/Kestrel.Core/Internal/Http/PipelineExtensions.cs
+++ b/src/Kestrel.Core/Internal/Http/PipelineExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (sourceLength <= destLength)
             {
                 fixed (char* input = data)
-                fixed (byte* output = &MemoryMarshal.GetReference(dest))
+                fixed (byte* output = dest)
                 {
                     EncodeAsciiCharsToBytes(input, output, sourceLength);
                 }
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
             // Fast path, try copying to the available memory directly
             var simpleWrite = true;
-            fixed (byte* output = &MemoryMarshal.GetReference(span))
+            fixed (byte* output = span)
             {
                 var start = output;
                 if (number < 10 && bytesLeftInBlock >= 1)
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         continue;
                     }
 
-                    fixed (byte* output = &MemoryMarshal.GetReference(buffer.Span))
+                    fixed (byte* output = buffer.Span)
                     {
                         EncodeAsciiCharsToBytes(inputSlice, output, writable);
                     }

--- a/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/HttpUtilities.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             var asciiString = new string('\0', span.Length);
 
             fixed (char* output = asciiString)
-            fixed (byte* buffer = &MemoryMarshal.GetReference(span))
+            fixed (byte* buffer = span)
             {
                 // This version if AsciiUtilities returns null if there are any null (0 byte) characters
                 // in the string
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             var resultString = new string('\0', span.Length);
 
             fixed (char* output = resultString)
-            fixed (byte* buffer = &MemoryMarshal.GetReference(span))
+            fixed (byte* buffer = span)
             {
                 // This version if AsciiUtilities returns null if there are any null (0 byte) characters
                 // in the string
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool GetKnownMethod(this Span<byte> span, out HttpMethod method, out int length)
         {
-            fixed (byte* data = &MemoryMarshal.GetReference(span))
+            fixed (byte* data = span)
             {
                 method = GetKnownMethod(data, span.Length, out length);
                 return method != HttpMethod.Custom;
@@ -310,7 +310,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool GetKnownVersion(this Span<byte> span, out HttpVersion knownVersion, out byte length)
         {
-            fixed (byte* data = &MemoryMarshal.GetReference(span))
+            fixed (byte* data = span)
             {
                 knownVersion = GetKnownVersion(data, span.Length);
                 if (knownVersion != HttpVersion.Unknown)
@@ -369,7 +369,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool GetKnownHttpScheme(this Span<byte> span, out HttpScheme knownScheme)
         {
-            fixed (byte* data = &MemoryMarshal.GetReference(span))
+            fixed (byte* data = span)
             {
                 return GetKnownHttpScheme(data, span.Length, out knownScheme);
             }


### PR DESCRIPTION
- Spans can be pinned natively in C# 7.3

cc @jkotas @jaredpar (This is the moral equivalent right?)