### PR TITLE
Disallow any frames after a reset is received

### DIFF
--- a/src/Kestrel.Core/CoreStrings.resx
+++ b/src/Kestrel.Core/CoreStrings.resx
@@ -587,4 +587,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="ConnectionAbortedByClient" xml:space="preserve">
     <value>The client closed the connection.</value>
   </data>
+  <data name="Http2ErrorStreamAborted" xml:space="preserve">
+    <value>A frame of type {frameType} was received after stream {streamId} was reset or aborted.</value>
+  </data>
 </root>

--- a/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
+++ b/src/Kestrel.Core/Properties/CoreStrings.Designer.cs
@@ -2198,6 +2198,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         internal static string FormatConnectionAbortedByClient()
             => GetString("ConnectionAbortedByClient");
 
+        /// <summary>
+        /// A frame of type {frameType} was received after stream {streamId} was reset or aborted.
+        /// </summary>
+        internal static string Http2ErrorStreamAborted
+        {
+            get => GetString("Http2ErrorStreamAborted");
+        }
+
+        /// <summary>
+        /// A frame of type {frameType} was received after stream {streamId} was reset or aborted.
+        /// </summary>
+        internal static string FormatHttp2ErrorStreamAborted(object frameType, object streamId)
+            => string.Format(CultureInfo.CurrentCulture, GetString("Http2ErrorStreamAborted", "frameType", "streamId"), frameType, streamId);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/test/Kestrel.Transport.FunctionalTests/Http2/H2SpecTests.cs
+++ b/test/Kestrel.Transport.FunctionalTests/Http2/H2SpecTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
             get
             {
                 var dataset = new TheoryData<H2SpecTestCase>();
-                var toSkip = new[] { "http2/5.1/8" };
+                var toSkip = new string[] { /*"http2/5.1/8"*/ };
 
                 foreach (var testcase in H2SpecCommands.EnumerateTestCases())
                 {


### PR DESCRIPTION
#2154 This covers the last H2spec test. The spec says that the client must not send additional header or data frames on a stream after sending a reset. There was a race where additional frames would be accepted up until the request processing ended and the stream was removed from the active streams list. I added a new flag to prevent this. This is similar to the EndOfStream flag but with a different error message and it does not cause the request body to appear complete but rather aborted. Technically this could be treated as a stream error but I've opted to leave it as a connection error for now, we handle those better.

#2832 (not included) is related but covers an opposite scenario where the request is aborted from the server side but the client is still allowed to send frames for a given period. The current race there is that the frames are only accepted until the request processing ends and the stream is removed from the active streams list. The client may need more time to react so we'll want to do additional work there. I've not included any changes for that in this PR because there's no functional overlap, only conceptual.