### PR TITLE
Suppress the execution context per operation

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO.Pipelines;
 using System.Net.Sockets;
+using System.Threading;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
@@ -17,9 +18,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
             _awaitableEventArgs.SetBuffer(Array.Empty<byte>(), 0, 0);
 
-            if (!_socket.ReceiveAsync(_awaitableEventArgs))
+            using (ExecutionContext.SuppressFlow())
             {
-                _awaitableEventArgs.Complete();
+                if (!_socket.ReceiveAsync(_awaitableEventArgs))
+                {
+                    _awaitableEventArgs.Complete();
+                }
             }
 
             return _awaitableEventArgs;
@@ -36,9 +40,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 #else
 #error TFMs need to be updated
 #endif
-            if (!_socket.ReceiveAsync(_awaitableEventArgs))
+            using (ExecutionContext.SuppressFlow())
             {
-                _awaitableEventArgs.Complete();
+                if (!_socket.ReceiveAsync(_awaitableEventArgs))
+                {
+                    _awaitableEventArgs.Complete();
+                }
             }
 
             return _awaitableEventArgs;

--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
             _awaitableEventArgs.SetBuffer(Array.Empty<byte>(), 0, 0);
 
-            using (ExecutionContext.SuppressFlow())
+            using (SuppressExecutionContext())
             {
                 if (!_socket.ReceiveAsync(_awaitableEventArgs))
                 {
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 #else
 #error TFMs need to be updated
 #endif
-            using (ExecutionContext.SuppressFlow())
+            using (SuppressExecutionContext())
             {
                 if (!_socket.ReceiveAsync(_awaitableEventArgs))
                 {

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
             _awaitableEventArgs.BufferList = GetBufferList(buffers);
 
-            using (ExecutionContext.SuppressFlow())
+            using (SuppressExecutionContext())
             {
                 if (!_socket.SendAsync(_awaitableEventArgs))
                 {
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 #else
 #error TFMs need to be updated
 #endif
-            using (ExecutionContext.SuppressFlow())
+            using (SuppressExecutionContext())
             {
                 if (!_socket.SendAsync(_awaitableEventArgs))
                 {

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSender.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
@@ -39,9 +40,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
             _awaitableEventArgs.BufferList = GetBufferList(buffers);
 
-            if (!_socket.SendAsync(_awaitableEventArgs))
+            using (ExecutionContext.SuppressFlow())
             {
-                _awaitableEventArgs.Complete();
+                if (!_socket.SendAsync(_awaitableEventArgs))
+                {
+                    _awaitableEventArgs.Complete();
+                }
             }
 
             return _awaitableEventArgs;
@@ -64,9 +68,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 #else
 #error TFMs need to be updated
 #endif
-            if (!_socket.SendAsync(_awaitableEventArgs))
+            using (ExecutionContext.SuppressFlow())
             {
-                _awaitableEventArgs.Complete();
+                if (!_socket.SendAsync(_awaitableEventArgs))
+                {
+                    _awaitableEventArgs.Complete();
+                }
             }
 
             return _awaitableEventArgs;

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSenderReceiverBase.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSenderReceiverBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public void Dispose() => _awaitableEventArgs.Dispose();
 
-        protected AsyncFlowControl? SuppressExecutionContext()
+        protected static AsyncFlowControl? SuppressExecutionContext()
         {
             return ExecutionContext.IsFlowSuppressed() ? (AsyncFlowControl?)null : ExecutionContext.SuppressFlow();
         }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSenderReceiverBase.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSenderReceiverBase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         protected AsyncFlowControl? SuppressExecutionContext()
         {
-            return ExecutionContext.IsFlowSuppressed() ? (AsyncFlowControl?)null : ExecutionContext.SuppressFlow()
+            return ExecutionContext.IsFlowSuppressed() ? (AsyncFlowControl?)null : ExecutionContext.SuppressFlow();
         }
     }
 }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketSenderReceiverBase.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketSenderReceiverBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO.Pipelines;
 using System.Net.Sockets;
+using System.Threading;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
@@ -19,5 +20,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         }
 
         public void Dispose() => _awaitableEventArgs.Dispose();
+
+        protected AsyncFlowControl? SuppressExecutionContext()
+        {
+            return ExecutionContext.IsFlowSuppressed() ? (AsyncFlowControl?)null : ExecutionContext.SuppressFlow()
+        }
     }
 }


### PR DESCRIPTION
Today we capture and restore the execution context per Socket operation. There's no need to do that because it already happens in the async state machine. 

I need to measure the performance since we're making an additional method call per operation to save it on the other side, it might be a wash. Ideally, we would just use https://github.com/dotnet/corefx/issues/32582

## BEFORE
![image](https://user-images.githubusercontent.com/95136/46393963-4800a600-c69c-11e8-931d-585049da089c.png)

## AFTER
![image](https://user-images.githubusercontent.com/95136/46393797-93ff1b00-c69b-11e8-8842-a8f318f6d8a2.png)

Look at that beautiful flattened frame 😄. This is the code being avoided https://github.com/dotnet/coreclr/blob/302630ed5a3730470e9ffeeebcd38c737c03963d/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs#L126-L202