### PR TITLE
Implement #2230 - Consume BindingAddress instead of ServerAddress

### DIFF
--- a/benchmarkapps/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
+++ b/benchmarkapps/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 
@@ -22,7 +23,7 @@ namespace PlatformBenchmarks
             var threadCountRaw = builder.GetSetting("threadCount");
             int? theadCount = null;
 
-            if (!string.IsNullOrEmpty(threadCountRaw) && 
+            if (!string.IsNullOrEmpty(threadCountRaw) &&
                 Int32.TryParse(threadCountRaw, out var value))
             {
                 theadCount = value;
@@ -51,7 +52,7 @@ namespace PlatformBenchmarks
 
             return builder;
         }
-        
+
         public static IPEndPoint CreateIPEndPoint(this IConfiguration config)
         {
             var url = config["server.urls"] ?? config["urls"];
@@ -61,7 +62,7 @@ namespace PlatformBenchmarks
                 return new IPEndPoint(IPAddress.Loopback, 8080);
             }
 
-            var address = ServerAddress.FromUrl(url);
+            var address = BindingAddress.Parse(url);
 
             IPAddress ip;
 

--- a/src/Kestrel.Core/Internal/AddressBinder.cs
+++ b/src/Kestrel.Core/Internal/AddressBinder.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
@@ -85,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         /// Returns an <see cref="IPEndPoint"/> for the given host an port.
         /// If the host parameter isn't "localhost" or an IP address, use IPAddress.Any.
         /// </summary>
-        protected internal static bool TryCreateIPEndPoint(ServerAddress address, out IPEndPoint endpoint)
+        protected internal static bool TryCreateIPEndPoint(BindingAddress address, out IPEndPoint endpoint)
         {
             if (!IPAddress.TryParse(address.Host, out var ip))
             {
@@ -113,7 +114,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         internal static ListenOptions ParseAddress(string address, out bool https)
         {
-            var parsedAddress = ServerAddress.FromUrl(address);
+            var parsedAddress = BindingAddress.Parse(address);
             https = false;
 
             if (parsedAddress.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))

--- a/src/Kestrel.Core/Kestrel.Core.csproj
+++ b/src/Kestrel.Core/Kestrel.Core.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Certificates.Generation.Sources" PrivateAssets="All" Version="$(MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftAspNetCoreHostingAbstractionsPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="$(MicrosoftAspNetCoreWebUtilitiesPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="$(MicrosoftNetHttpHeadersPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />

--- a/src/Kestrel.Core/ServerAddress.cs
+++ b/src/Kestrel.Core/ServerAddress.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core
 {
+    [Obsolete("This is obsolete and will be removed in a future version. See https://github.com/aspnet/KestrelHttpServer/issues/2230")]
     public class ServerAddress
     {
         public string Host { get; private set; }

--- a/test/Kestrel.Core.Tests/AddressBinderTests.cs
+++ b/test/Kestrel.Core.Tests/AddressBinderTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 using Microsoft.AspNetCore.Testing;
@@ -25,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void CorrectIPEndpointsAreCreated(string address, string expectedAddress, int expectedPort)
         {
             Assert.True(AddressBinder.TryCreateIPEndPoint(
-                ServerAddress.FromUrl(address), out var endpoint));
+                BindingAddress.Parse(address), out var endpoint));
             Assert.NotNull(endpoint);
             Assert.Equal(IPAddress.Parse(expectedAddress), endpoint.Address);
             Assert.Equal(expectedPort, endpoint.Port);
@@ -42,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void DoesNotCreateIPEndPointOnInvalidIPAddress(string address)
         {
             Assert.False(AddressBinder.TryCreateIPEndPoint(
-                ServerAddress.FromUrl(address), out var endpoint));
+                BindingAddress.Parse(address), out var endpoint));
         }
 
         [Theory]

--- a/test/Kestrel.Core.Tests/KestrelServerTests.cs
+++ b/test/Kestrel.Core.Tests/KestrelServerTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 var exception = Assert.Throws<FormatException>(() => StartDummyApplication(server));
 
-                Assert.Contains("Invalid URL", exception.Message);
+                Assert.Contains("Invalid url", exception.Message);
                 Assert.Equal(1, testLogger.CriticalErrorsLogged);
             }
         }

--- a/test/Kestrel.Core.Tests/ServerAddressTests.cs
+++ b/test/Kestrel.Core.Tests/ServerAddressTests.cs
@@ -14,7 +14,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData("//noscheme")]
         public void FromUriThrowsForUrlsWithoutSchemeDelimiter(string url)
         {
+            #pragma warning disable CS0618 // Type or member is obsolete
             Assert.Throws<FormatException>(() => ServerAddress.FromUrl(url));
+            #pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Theory]
@@ -28,7 +30,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData("http:////:5000")]
         public void FromUriThrowsForUrlsWithoutHost(string url)
         {
+            #pragma warning disable CS0618 // Type or member is obsolete
             Assert.Throws<FormatException>(() => ServerAddress.FromUrl(url));
+            #pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Theory]
@@ -56,7 +60,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData("http://unix:/tmp/kestrel-test.sock:5000/doesn't/matter", "http", "unix:/tmp/kestrel-test.sock", 0, "5000/doesn't/matter", "http://unix:/tmp/kestrel-test.sock")]
         public void UrlsAreParsedCorrectly(string url, string scheme, string host, int port, string pathBase, string toString)
         {
+            #pragma warning disable CS0618 // Type or member is obsolete
             var serverAddress = ServerAddress.FromUrl(url);
+            #pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.Equal(scheme, serverAddress.Scheme);
             Assert.Equal(host, serverAddress.Host);


### PR DESCRIPTION
Hello. I've tried to implement changes for #2230. I've done this:

1. Marked ServerAddress obsolete and suppress CS0618 errors in ServerAddressTests
2. Added reference to Microsoft.AspNetCore.Http in Kestrel.Core.csproj
3. Replaced usage of ServerAddress.FromUrl with BindingAddress.Parse
4. Update tests

I hope nothing is wrong =)