### PR TITLE
Expose status code of BadHttpRequestException

### DIFF
--- a/src/Kestrel.Core/BadHttpRequestException.cs
+++ b/src/Kestrel.Core/BadHttpRequestException.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
         }
 
-        internal int StatusCode { get; }
+        public int StatusCode { get; }
 
         internal StringValues AllowedHeader { get; }
 


### PR DESCRIPTION
Addresses #2909. We should probably avoid exposing `Reason` since that level of granularity is not likely needed. 