### PR TITLE
Http/2 response trailers

### DIFF
--- a/benchmarks/Kestrel.Performance/Mocks/MockTrace.cs
+++ b/benchmarks/Kestrel.Performance/Mocks/MockTrace.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         public void Http2ConnectionError(string connectionId, Http2ConnectionErrorException ex) { }
         public void Http2StreamError(string connectionId, Http2StreamErrorException ex) { }
         public void HPackDecodingError(string connectionId, int streamId, HPackDecodingException ex) { }
+        public void HPackEncodingError(string connectionId, int streamId, HPackEncodingException ex) { }
         public void Http2StreamResetAbort(string traceIdentifier, Http2ErrorCode error, ConnectionAbortedException abortReason) { }
         public void Http2ConnectionClosing(string connectionId) { }
         public void Http2ConnectionClosed(string connectionId, int highestOpenedStreamId) { }

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -11,13 +11,13 @@
     <MicrosoftAspNetCoreAllPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreAllPackageVersion>
     <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
     <MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>
-    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHostingPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreHostingPackageVersion>
-    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHttpFeaturesPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreHttpFeaturesPackageVersion>
-    <MicrosoftAspNetCoreHttpPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreHttpPackageVersion>
+    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.2.0-a-preview3-tratcher-trailers-17154</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreHostingPackageVersion>2.2.0-a-preview3-tratcher-trailers-17154</MicrosoftAspNetCoreHostingPackageVersion>
+    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.2.0-a-preview3-tratcher-trailers-16760</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreHttpFeaturesPackageVersion>2.2.0-a-preview3-tratcher-trailers-16760</MicrosoftAspNetCoreHttpFeaturesPackageVersion>
+    <MicrosoftAspNetCoreHttpPackageVersion>2.2.0-a-preview3-tratcher-trailers-16760</MicrosoftAspNetCoreHttpPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftAspNetCoreWebUtilitiesPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreWebUtilitiesPackageVersion>
+    <MicrosoftAspNetCoreWebUtilitiesPackageVersion>2.2.0-a-preview3-tratcher-trailers-16760</MicrosoftAspNetCoreWebUtilitiesPackageVersion>
     <MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>2.2.0-preview3-35359</MicrosoftExtensionsActivatorUtilitiesSourcesPackageVersion>
     <MicrosoftExtensionsConfigurationBinderPackageVersion>2.2.0-preview3-35359</MicrosoftExtensionsConfigurationBinderPackageVersion>
     <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.2.0-preview3-35359</MicrosoftExtensionsConfigurationCommandLinePackageVersion>

--- a/samples/Http2SampleApp/Startup.cs
+++ b/samples/Http2SampleApp/Startup.cs
@@ -14,6 +14,7 @@ namespace Http2SampleApp
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            app.UseTimingMiddleware();
             app.Run(context =>
             {
                 return context.Response.WriteAsync("Hello World! " + context.Request.Protocol);

--- a/samples/Http2SampleApp/TimingMiddleware.cs
+++ b/samples/Http2SampleApp/TimingMiddleware.cs
@@ -1,0 +1,50 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Http2SampleApp
+{
+    // You may need to install the Microsoft.AspNetCore.Http.Abstractions package into your project
+    public class TimingMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public TimingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            if (httpContext.Response.SupportsTrailers())
+            {
+                httpContext.Response.DeclareTrailer("Server-Timing");
+
+                var stopWatch = new Stopwatch();
+                stopWatch.Start();
+
+                await _next(httpContext);
+
+                stopWatch.Stop();
+                // Not yet supported in any browser dev tools
+                httpContext.Response.AppendTrailer("Server-Timing", $"app;dur={stopWatch.ElapsedMilliseconds}.0");
+            }
+            else
+            {
+                // Works in chrome
+                // httpContext.Response.Headers.Append("Server-Timing", $"app;dur=25.0");
+                await _next(httpContext);
+            }
+        }
+    }
+
+    // Extension method used to add the middleware to the HTTP request pipeline.
+    public static class TimingMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseTimingMiddleware(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<TimingMiddleware>();
+        }
+    }
+}

--- a/src/Kestrel.Core/Internal/Http/HttpHeaders.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpHeaders.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             throw new ArgumentException(CoreStrings.KeyAlreadyExists);
         }
 
-        int ICollection<KeyValuePair<string, StringValues>>.Count => GetCountFast();
+        public int Count => GetCountFast();
 
         bool ICollection<KeyValuePair<string, StringValues>>.IsReadOnly => _isReadOnly;
 

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -209,9 +209,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _currentIHttpUpgradeFeature = this;
         }
 
-        protected void ResetIHttp2StreamIdFeature()
+        protected void ResetHttp2Features()
         {
             _currentIHttp2StreamIdFeature = this;
+            _currentIHttpResponseTrailersFeature = this;
         }
 
         void IHttpResponseFeature.OnStarting(Func<object, Task> callback, object state)

--- a/src/Kestrel.Core/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpProtocol.Generated.cs
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private static readonly Type IFormFeatureType = typeof(IFormFeature);
         private static readonly Type IHttpUpgradeFeatureType = typeof(IHttpUpgradeFeature);
         private static readonly Type IHttp2StreamIdFeatureType = typeof(IHttp2StreamIdFeature);
+        private static readonly Type IHttpResponseTrailersFeatureType = typeof(IHttpResponseTrailersFeature);
         private static readonly Type IResponseCookiesFeatureType = typeof(IResponseCookiesFeature);
         private static readonly Type IItemsFeatureType = typeof(IItemsFeature);
         private static readonly Type ITlsConnectionFeatureType = typeof(ITlsConnectionFeature);
@@ -46,6 +47,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private object _currentIFormFeature;
         private object _currentIHttpUpgradeFeature;
         private object _currentIHttp2StreamIdFeature;
+        private object _currentIHttpResponseTrailersFeature;
         private object _currentIResponseCookiesFeature;
         private object _currentIItemsFeature;
         private object _currentITlsConnectionFeature;
@@ -79,6 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _currentIFormFeature = null;
             _currentIHttpUpgradeFeature = null;
             _currentIHttp2StreamIdFeature = null;
+            _currentIHttpResponseTrailersFeature = null;
             _currentIResponseCookiesFeature = null;
             _currentIItemsFeature = null;
             _currentITlsConnectionFeature = null;
@@ -183,6 +186,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     feature = _currentIHttp2StreamIdFeature;
                 }
+                else if (key == IHttpResponseTrailersFeatureType)
+                {
+                    feature = _currentIHttpResponseTrailersFeature;
+                }
                 else if (key == IResponseCookiesFeatureType)
                 {
                     feature = _currentIResponseCookiesFeature;
@@ -279,6 +286,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _currentIHttp2StreamIdFeature = value;
                 }
+                else if (key == IHttpResponseTrailersFeatureType)
+                {
+                    _currentIHttpResponseTrailersFeature = value;
+                }
                 else if (key == IResponseCookiesFeatureType)
                 {
                     _currentIResponseCookiesFeature = value;
@@ -372,6 +383,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
             {
                 feature = (TFeature)_currentIHttp2StreamIdFeature;
+            }
+            else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
+            {
+                feature = (TFeature)_currentIHttpResponseTrailersFeature;
             }
             else if (typeof(TFeature) == typeof(IResponseCookiesFeature))
             {
@@ -473,6 +488,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIHttp2StreamIdFeature = feature;
             }
+            else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
+            {
+                _currentIHttpResponseTrailersFeature = feature;
+            }
             else if (typeof(TFeature) == typeof(IResponseCookiesFeature))
             {
                 _currentIResponseCookiesFeature = feature;
@@ -564,6 +583,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (_currentIHttp2StreamIdFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(IHttp2StreamIdFeatureType, _currentIHttp2StreamIdFeature);
+            }
+            if (_currentIHttpResponseTrailersFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(IHttpResponseTrailersFeatureType, _currentIHttpResponseTrailersFeature);
             }
             if (_currentIResponseCookiesFeature != null)
             {

--- a/src/Kestrel.Core/Internal/Http/HttpResponseTrailers.cs
+++ b/src/Kestrel.Core/Internal/Http/HttpResponseTrailers.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
+{
+    public partial class HttpResponseTrailers : HttpHeaders
+    {
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        protected override IEnumerator<KeyValuePair<string, StringValues>> GetEnumeratorFast()
+        {
+            return GetEnumerator();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void SetValueUnknown(string key, in StringValues value)
+        {
+            ValidateHeaderNameCharacters(key);
+            Unknown[key] = value;
+        }
+
+        public partial struct Enumerator : IEnumerator<KeyValuePair<string, StringValues>>
+        {
+            private readonly HttpResponseTrailers _collection;
+            private readonly long _bits;
+            private int _state;
+            private KeyValuePair<string, StringValues> _current;
+            private readonly bool _hasUnknown;
+            private Dictionary<string, StringValues>.Enumerator _unknownEnumerator;
+
+            internal Enumerator(HttpResponseTrailers collection)
+            {
+                _collection = collection;
+                _bits = collection._bits;
+                _state = 0;
+                _current = default;
+                _hasUnknown = collection.MaybeUnknown != null;
+                _unknownEnumerator = _hasUnknown
+                    ? collection.MaybeUnknown.GetEnumerator()
+                    : default;
+            }
+
+            public KeyValuePair<string, StringValues> Current => _current;
+
+            object IEnumerator.Current => _current;
+
+            public void Dispose()
+            {
+            }
+
+            public void Reset()
+            {
+                _state = 0;
+            }
+        }
+    }
+}

--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             var http2Limits = httpLimits.Http2;
 
             _context = context;
-            _frameWriter = new Http2FrameWriter(context.Transport.Output, context.ConnectionContext, _outputFlowControl, context.TimeoutControl, context.ConnectionId, context.ServiceContext.Log);
+            _frameWriter = new Http2FrameWriter(context.Transport.Output, context.ConnectionContext, this, _outputFlowControl, context.TimeoutControl, context.ConnectionId, context.ServiceContext.Log);
             _serverSettings.MaxConcurrentStreams = (uint)http2Limits.MaxStreamsPerConnection;
             _serverSettings.MaxFrameSize = (uint)http2Limits.MaxFrameSize;
             _serverSettings.HeaderTableSize = (uint)http2Limits.HeaderTableSize;

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.FeatureCollection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.FeatureCollection.cs
@@ -1,12 +1,34 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
-    public partial class Http2Stream : IHttp2StreamIdFeature
+    public partial class Http2Stream : IHttp2StreamIdFeature, IHttpResponseTrailersFeature
     {
+        internal HttpResponseTrailers Trailers { get; set; }
+        private IHeaderDictionary _userTrailers;
+
+        IHeaderDictionary IHttpResponseTrailersFeature.Trailers
+        {
+            get
+            {
+                if (Trailers == null)
+                {
+                    Trailers = new HttpResponseTrailers();
+                }
+                return _userTrailers ?? Trailers;
+            }
+            set
+            {
+                _userTrailers = value;
+            }
+        }
+
         int IHttp2StreamIdFeature.StreamId => _context.StreamId;
     }
 }

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 _context.ServerPeerSettings.InitialWindowSize / 2);
 
             _outputFlowControl = new StreamOutputFlowControl(context.ConnectionOutputFlowControl, context.ClientPeerSettings.InitialWindowSize);
-            _http2Output = new Http2OutputProducer(context.StreamId, context.FrameWriter, _outputFlowControl, context.TimeoutControl, context.MemoryPool);
+            _http2Output = new Http2OutputProducer(context.StreamId, context.FrameWriter, _outputFlowControl, context.TimeoutControl, context.MemoryPool, this);
 
             RequestBodyPipe = CreateRequestBodyPipe(_context.ServerPeerSettings.InitialWindowSize);
             Output = _http2Output;
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         protected override void OnReset()
         {
-            ResetIHttp2StreamIdFeature();
+            ResetHttp2Features();
         }
 
         protected override void OnRequestProcessingEnded()

--- a/src/Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/IKestrelTrace.cs
@@ -67,6 +67,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         void HPackDecodingError(string connectionId, int streamId, HPackDecodingException ex);
 
+        void HPackEncodingError(string connectionId, int streamId, HPackEncodingException ex);
+
         void Http2FrameReceived(string connectionId, Http2Frame frame);
 
         void Http2FrameSending(string connectionId, Http2Frame frame);

--- a/src/Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Kestrel.Core/Internal/Infrastructure/KestrelTrace.cs
@@ -107,6 +107,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             LoggerMessage.Define<string, Http2FrameType, int, int, object>(LogLevel.Trace, new EventId(37, nameof(Http2FrameReceived)),
                 @"Connection id ""{ConnectionId}"" sending {type} frame for stream ID {id} with length {length} and flags {flags}");
 
+        private static readonly Action<ILogger, string, int, Exception> _hpackEncodingError =
+            LoggerMessage.Define<string, int>(LogLevel.Information, new EventId(38, nameof(HPackEncodingError)),
+                @"Connection id ""{ConnectionId}"": HPACK encoding error while encoding headers for stream ID {StreamId}.");
+
         protected readonly ILogger _logger;
 
         public KestrelTrace(ILogger logger)
@@ -252,6 +256,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         public virtual void HPackDecodingError(string connectionId, int streamId, HPackDecodingException ex)
         {
             _hpackDecodingError(_logger, connectionId, streamId, ex);
+        }
+
+        public virtual void HPackEncodingError(string connectionId, int streamId, HPackEncodingException ex)
+        {
+            _hpackEncodingError(_logger, connectionId, streamId, ex);
         }
 
         public void Http2FrameReceived(string connectionId, Http2Frame frame)

--- a/test/shared/CompositeKestrelTrace.cs
+++ b/test/shared/CompositeKestrelTrace.cs
@@ -189,6 +189,12 @@ namespace Microsoft.AspNetCore.Testing
             _trace2.HPackDecodingError(connectionId, streamId, ex);
         }
 
+        public void HPackEncodingError(string connectionId, int streamId, HPackEncodingException ex)
+        {
+            _trace1.HPackEncodingError(connectionId, streamId, ex);
+            _trace2.HPackEncodingError(connectionId, streamId, ex);
+        }
+
         public void Http2StreamResetAbort(string traceIdentifier, Http2ErrorCode error, ConnectionAbortedException abortReason)
         {
             _trace1.Http2StreamResetAbort(traceIdentifier, error, abortReason);

--- a/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -30,6 +30,7 @@ namespace CodeGenerator
             {
                 "IHttpUpgradeFeature",
                 "IHttp2StreamIdFeature",
+                "IHttpResponseTrailersFeature",
                 "IResponseCookiesFeature",
                 "IItemsFeature",
                 "ITlsConnectionFeature",


### PR DESCRIPTION
 #622, Depends on https://github.com/aspnet/HttpAbstractions/pull/1043.

If any headers have been added to the trailer collection then they will be sent at the end of the request where we would normally send an empty data frame with END_STREAM.