### PR TITLE
Use logical 'or' instead of bitwise in IsConnectionReset method.

### DIFF
--- a/src/Kestrel.Transport.Libuv/Internal/LibuvConstants.cs
+++ b/src/Kestrel.Transport.Libuv/Internal/LibuvConstants.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsConnectionReset(int errno)
         {
-            return errno == ECONNRESET || errno == EPIPE || errno == ENOTCONN | errno == EINVAL;
+            return errno == ECONNRESET || errno == EPIPE || errno == ENOTCONN || errno == EINVAL;
         }
 
         private static int? GetECONNRESET()


### PR DESCRIPTION
Now in method **IsConnectionReset** used:
`return errno == ECONNRESET || errno == EPIPE || errno == ENOTCONN | errno == EINVAL;`

I think need use logical '**or**' for the last comparison too like this:
`return errno == ECONNRESET || errno == EPIPE || errno == ENOTCONN || errno == EINVAL;`