### PR TITLE
Track aborted streams for a given grace period

### DIFF
--- a/src/Kestrel.Core/Internal/Http/Http1Connection.cs
+++ b/src/Kestrel.Core/Internal/Http/Http1Connection.cs
@@ -518,6 +518,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
+        void IRequestProcessor.Tick(DateTimeOffset now) { }
+
         private Pipe CreateRequestBodyPipe()
             => new Pipe(new PipeOptions
             (

--- a/src/Kestrel.Core/Internal/HttpConnection.cs
+++ b/src/Kestrel.Core/Internal/HttpConnection.cs
@@ -356,7 +356,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 return;
             }
 
-            _timeoutControl.Tick(_systemClock.UtcNow);
+            var now = _systemClock.UtcNow;
+            _timeoutControl.Tick(now);
+            _requestProcessor?.Tick(now);
         }
 
         private void CloseUninitializedConnection(ConnectionAbortedException abortReason)

--- a/src/Kestrel.Core/Internal/IRequestProcessor.cs
+++ b/src/Kestrel.Core/Internal/IRequestProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -13,6 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         void StopProcessingNextRequest();
         void HandleRequestHeadersTimeout();
         void OnInputOrOutputCompleted();
+        void Tick(DateTimeOffset now);
         void Abort(ConnectionAbortedException ex);
     }
 }


### PR DESCRIPTION
 #2832 Aborted streams are given a 5 second non-configurable grace period for the client to react to the abort and stop sending frames. Data and trailers received after the grace period will be considered a connection error as before.

I've also pulled in #2756 (Send a RST if the request body is not read) which is directly related to draining.

We were also missing a lock around the closing the request body pipe reader.

Please review by Wed EoD so we can get this in for Preview3.