### PR TITLE
Use ValueTask instead of custom awaiter for SocketAwaitableEventArgs

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketAwaitableEventArgs.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketAwaitableEventArgs.cs
@@ -106,19 +106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 return new ValueTask<int>(this, 0);
             }
 
-            int bytesTransferred = BytesTransferred;
-            SocketError error = SocketError;
-
-            Reset();
-
-            return error == SocketError.Success ?
-                new ValueTask<int>(bytesTransferred) :
-                new ValueTask<int>(Task.FromException<int>(new SocketException((int)error)));
-        }
-
-        private void Reset()
-        {
-            Volatile.Write(ref _completion, null);
+            return CompleteSocketOperation();
         }
 
         /// <summary>Initiates a send operation on the associated socket.</summary>
@@ -130,6 +118,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 return new ValueTask<int>(this, 0);
             }
 
+            return CompleteSocketOperation();
+        }
+
+        private void Reset()
+        {
+            Volatile.Write(ref _completion, null);
+        }
+
+        private ValueTask<int> CompleteSocketOperation()
+        {
             int bytesTransferred = BytesTransferred;
             SocketError error = SocketError;
 

--- a/src/Kestrel.Transport.Sockets/Internal/SocketAwaitableEventArgs.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketAwaitableEventArgs.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 Task.Factory.StartNew(continuation, state);
 #endif
             }
-            else
+            else if (awaitableState != null)
             {
                 Debug.Fail("Multiple continuations registered!");
             }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketAwaitableEventArgs.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketAwaitableEventArgs.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             }
             else if (awaitableState != null)
             {
-                Debug.Fail("Multiple continuations registered!");
+                throw new InvalidOperationException("Multiple continuations registered!");
             }
 
         }

--- a/src/Kestrel.Transport.Sockets/Internal/SocketAwaitableEventArgs.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketAwaitableEventArgs.cs
@@ -81,6 +81,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             SocketError error = SocketError;
             int bytes = BytesTransferred;
 
+            Volatile.Write(ref _callback, null);
+
             if (error != SocketError.Success)
             {
                 ThrowSocketException(error);
@@ -120,8 +122,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
             int bytesTransferred = BytesTransferred;
             SocketError error = SocketError;
-
-            Volatile.Write(ref _callback, null);
 
             return error == SocketError.Success ?
                 new ValueTask<int>(bytesTransferred) :

--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO.Pipelines;
 using System.Net.Sockets;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
@@ -13,19 +14,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
         }
 
-        public SocketAwaitableEventArgs WaitForDataAsync()
+        public ValueTask<int> WaitForDataAsync()
         {
             _awaitableEventArgs.SetBuffer(Array.Empty<byte>(), 0, 0);
 
-            if (!_socket.ReceiveAsync(_awaitableEventArgs))
-            {
-                _awaitableEventArgs.Complete();
-            }
-
-            return _awaitableEventArgs;
+            return _awaitableEventArgs.ReceiveAsync(_socket);
         }
 
-        public SocketAwaitableEventArgs ReceiveAsync(Memory<byte> buffer)
+        public ValueTask<int> ReceiveAsync(Memory<byte> buffer)
         {
 #if NETCOREAPP2_1
             _awaitableEventArgs.SetBuffer(buffer);
@@ -36,12 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 #else
 #error TFMs need to be updated
 #endif
-            if (!_socket.ReceiveAsync(_awaitableEventArgs))
-            {
-                _awaitableEventArgs.Complete();
-            }
-
-            return _awaitableEventArgs;
+            return _awaitableEventArgs.ReceiveAsync(_socket);
         }
     }
 }


### PR DESCRIPTION
- This could improve the performance of async operations (reduce the number of allocations)

TODO: Measure performance, I may combine this with #2974 