### PR TITLE
HTTP/2 Test stabalization

### DIFF
--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -1218,7 +1218,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StartStreamAsync(1, headers, endStream: false);
             await SendDataAsync(1, new byte[6], endStream: false);
             await SendDataAsync(1, new byte[6], endStream: false);
-            await SendDataAsync(1, new byte[6], endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 59,
@@ -1228,6 +1227,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withLength: 0,
                 withFlags: (byte)Http2DataFrameFlags.END_STREAM,
                 withStreamId: 1);
+
+            await WaitForStreamErrorAsync(1, Http2ErrorCode.NO_ERROR, null);
+            // Logged without an exception.
+            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -1277,7 +1280,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StartStreamAsync(1, headers, endStream: false);
             await SendDataAsync(1, new byte[6], endStream: false);
             await SendDataAsync(1, new byte[6], endStream: false);
-            await SendDataAsync(1, new byte[6], endStream: true);
+            await SendDataAsync(1, new byte[6], endStream: false);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
                 withLength: 59,
@@ -1287,6 +1290,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withLength: 0,
                 withFlags: (byte)Http2DataFrameFlags.END_STREAM,
                 withStreamId: 1);
+            await WaitForStreamErrorAsync(1, Http2ErrorCode.NO_ERROR, null);
+            // Logged without an exception.
+            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -64,9 +64,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             // Send continuation frame to verify intermediate request header timeout doesn't interfere with keep-alive timeout.
-            await SendHeadersAsync(1, Http2HeadersFrameFlags.NONE, _browserRequestHeaders);
+            await SendHeadersAsync(1, Http2HeadersFrameFlags.END_STREAM, _browserRequestHeaders);
             await SendEmptyContinuationFrameAsync(1, Http2ContinuationFrameFlags.END_HEADERS);
-            await SendDataAsync(1, new Memory<byte>(), endStream: true);
 
             _mockTimeoutControl.Verify(c => c.SetTimeout(It.IsAny<long>(), TimeoutReason.RequestHeaders), Times.Once);
 
@@ -110,7 +109,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await InitializeConnectionAsync(_noopApplication);
 
-            await SendHeadersAsync(1, Http2HeadersFrameFlags.NONE, _browserRequestHeaders);
+            await SendHeadersAsync(1, Http2HeadersFrameFlags.END_STREAM, _browserRequestHeaders);
 
             await SendEmptyContinuationFrameAsync(1, Http2ContinuationFrameFlags.NONE);
 


### PR DESCRIPTION
#3009 These tests were flaky after we added resets for incomplete request bodies. There's a race between processing the data in the last frame, reacting to the error, and setting the end-of-stream flag. The simplest solution is to force the race by not sending the end-of-stream flag when where testing error conditions.