### PR TITLE
Skip falky tests caused by https://github.com/dotnet/corefx/issues/30691

### DIFF
--- a/test/Kestrel.Transport.FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/test/Kestrel.Transport.FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -22,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
     public class MaxRequestBufferSizeTests : LoggedTest
     {
         // The client is typically paused after uploading this many bytes:
-        // 
+        //
         // OS                   MaxRequestBufferSize (MB)   connectionAdapter   Transport   min pause (MB)      max pause (MB)
         // ---------------      -------------------------   -----------------   ---------   --------------      --------------
         // Windows 10 1803      1                           false               Libuv       1.7                 3.3
@@ -100,7 +101,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             }
         }
 
+        private bool LargeUploadRetryPredicate(Exception e)
+            => e is IOException && e.Message.Contains("Unable to read data from the transport connection: The I/O operation has been aborted because of either a thread exit or an application request");
+
         [Theory]
+        [RetryTest(nameof(LargeUploadRetryPredicate),
+            "Active investigation into potential corefx sockets bug: https://github.com/dotnet/corefx/issues/30691",
+            OperatingSystems.Windows)]
         [MemberData(nameof(LargeUploadData))]
         public async Task LargeUpload(long? maxRequestBufferSize, bool connectionAdapter, bool expectPause)
         {

--- a/test/Kestrel.Transport.FunctionalTests/ResponseTests.cs
+++ b/test/Kestrel.Transport.FunctionalTests/ResponseTests.cs
@@ -17,12 +17,13 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
@@ -802,7 +803,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             Assert.False(requestAborted);
         }
 
+        private bool ConnectionNotClosedWhenClientSatisfiesMinimumDataRateGivenLargeResponseHeadersRetryPredicate(Exception e)
+            => e is IOException && e.Message.Contains("Unable to read data from the transport connection: The I/O operation has been aborted because of either a thread exit or an application request");
+
         [Fact]
+        [RetryTest(nameof(ConnectionNotClosedWhenClientSatisfiesMinimumDataRateGivenLargeResponseHeadersRetryPredicate),
+            "Active investigation into potential corefx sockets bug: https://github.com/dotnet/corefx/issues/30691",
+            OperatingSystems.Windows)]
         public async Task ConnectionNotClosedWhenClientSatisfiesMinimumDataRateGivenLargeResponseHeaders()
         {
             var headerSize = 1024 * 1024; // 1 MB for each header value


### PR DESCRIPTION
Addresses most of the tests flagged by https://github.com/aspnet/KestrelHttpServer/issues/2777 and https://github.com/aspnet/KestrelHttpServer/issues/2701. We'll start retrying these tests until the corefx issue is fixed.

Side note: Originally I was planning on adding a feature to the RetryTest attribute to limit this to Win10 since that's the only version of windows these tests are failing on but I ran into implementation issues in https://github.com/aspnet/Logging/tree/johluo/match-os-version where my Win10 machine was giving me a Win8 version prefix.