### PR TITLE
Fix race in HTTP/2 stream abort drain timeout test

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2MessageBody.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2MessageBody.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         public static MessageBody For(Http2Stream context, MinDataRate minRequestBodyDataRate)
         {
-            if (context.EndStreamReceived && !context.RequestBodyStarted)
+            if (context.ReceivedEmptyRequestBody)
             {
                 return ZeroContentLengthClose;
             }

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -816,19 +816,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await SendDataAsync(1, _helloWorldBytes, endStream: false);
 
+            // There's a race where either of these messages could be logged, depending on if the stream cleanup has finished yet.
             await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
                 ignoreNonGoAwayFrames: false,
                 expectedLastStreamId: 1,
                 expectedErrorCode: Http2ErrorCode.STREAM_CLOSED,
-                expectedErrorMessage: null);
-
-            // There's a race where either of these messages could be logged, depending on if the stream cleanup has finished yet.
-            var closedMessage = CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.DATA, streamId: 1);
-            var halfClosedMessage = CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.DATA, streamId: 1);
-
-            var message = Assert.Single(TestApplicationErrorLogger.Messages, m => m.Exception is Http2ConnectionErrorException);
-            Assert.True(message.Exception.Message.IndexOf(closedMessage) >= 0
-                || message.Exception.Message.IndexOf(halfClosedMessage) >= 0);
+                expectedErrorMessage: new[] {
+                    CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.DATA, streamId: 1),
+                    CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.DATA, streamId: 1)
+                });
         }
 
         [Fact]
@@ -1329,19 +1325,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             // Try to re-use the stream ID (http://httpwg.org/specs/rfc7540.html#rfc.section.5.1.1)
             await StartStreamAsync(1, _browserRequestHeaders, endStream: true);
 
+            // There's a race where either of these messages could be logged, depending on if the stream cleanup has finished yet.
             await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
                 ignoreNonGoAwayFrames: false,
                 expectedLastStreamId: 1,
                 expectedErrorCode: Http2ErrorCode.STREAM_CLOSED,
-                expectedErrorMessage: null);
-
-            // There's a race where either of these messages could be logged, depending on if the stream cleanup has finished yet.
-            var closedMessage = CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.HEADERS, streamId: 1);
-            var halfClosedMessage = CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.HEADERS, streamId: 1);
-
-            var message = Assert.Single(TestApplicationErrorLogger.Messages, m => m.Exception is Http2ConnectionErrorException);
-            Assert.True(message.Exception.Message.IndexOf(closedMessage) >= 0
-                || message.Exception.Message.IndexOf(halfClosedMessage) >= 0);
+                expectedErrorMessage: new[] {
+                    CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.HEADERS, streamId: 1),
+                    CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.HEADERS, streamId: 1)
+                });
         }
 
         [Fact]
@@ -3782,12 +3774,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             // Logged without an exception.
             Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
-            // There's a race when the appfunc is exiting about how soon it unregisters the stream.
-            for (var i = 0; i < 10; i++)
-            {
-                await SendDataAsync(1, new byte[100], endStream: false);
-            }
-
             // These would be refused if the cool-down period had expired
             switch (finalFrameType)
             {
@@ -3830,12 +3816,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, "The connection was aborted by the application.");
 
-            // There's a race when the appfunc is exiting about how soon it unregisters the stream.
-            for (var i = 0; i < 10; i++)
-            {
-                await SendDataAsync(1, new byte[100], endStream: false);
-            }
-
             // These would be refused if the cool-down period had expired
             switch (finalFrameType)
             {
@@ -3877,21 +3857,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, "The connection was aborted by the application.");
 
-            // There's a race when the appfunc is exiting about how soon it unregisters the stream.
-            for (var i = 0; i < 10; i++)
-            {
-                await SendDataAsync(1, new byte[100], endStream: false);
-            }
-
             switch (finalFrameType)
             {
                 case Http2FrameType.DATA:
                     await SendDataAsync(1, new byte[100], endStream: true);
                     // An extra one to break it
                     await SendDataAsync(1, new byte[100], endStream: true);
-
-                    await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1, Http2ErrorCode.STREAM_CLOSED,
-                        CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.DATA, 1));
+                    
+                    // There's a race where either of these messages could be logged, depending on if the stream cleanup has finished yet.
+                    await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
+                        ignoreNonGoAwayFrames: false,
+                        expectedLastStreamId: 1,
+                        expectedErrorCode: Http2ErrorCode.STREAM_CLOSED,
+                        expectedErrorMessage: new[] {
+                            CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.DATA, streamId: 1),
+                            CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.DATA, streamId: 1)
+                        });
                     break;
 
                 case Http2FrameType.HEADERS:
@@ -3899,8 +3880,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     // An extra one to break it
                     await SendHeadersAsync(1, Http2HeadersFrameFlags.END_STREAM | Http2HeadersFrameFlags.END_HEADERS, _requestTrailers);
 
-                    await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1, Http2ErrorCode.STREAM_CLOSED,
-                        CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.HEADERS, 1));
+                    // There's a race where either of these messages could be logged, depending on if the stream cleanup has finished yet.
+                    await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
+                        ignoreNonGoAwayFrames: false,
+                        expectedLastStreamId: 1,
+                        expectedErrorCode: Http2ErrorCode.STREAM_CLOSED,
+                        expectedErrorMessage: new[] {
+                            CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.HEADERS, streamId: 1),
+                            CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.HEADERS, streamId: 1)
+                        });
                     break;
 
                 case Http2FrameType.CONTINUATION:
@@ -3908,8 +3896,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     await SendContinuationAsync(1, Http2ContinuationFrameFlags.END_HEADERS, _requestTrailers);
                     // An extra one to break it. It's not a Continuation because that would fail with an error that no headers were in progress.
                     await SendHeadersAsync(1, Http2HeadersFrameFlags.END_STREAM, _requestTrailers);
-                    await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1, Http2ErrorCode.STREAM_CLOSED,
-                        CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.HEADERS, 1));
+
+                    // There's a race where either of these messages could be logged, depending on if the stream cleanup has finished yet.
+                    await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
+                        ignoreNonGoAwayFrames: false,
+                        expectedLastStreamId: 1,
+                        expectedErrorCode: Http2ErrorCode.STREAM_CLOSED,
+                        expectedErrorMessage: new[] {
+                            CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.HEADERS, streamId: 1),
+                            CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.HEADERS, streamId: 1)
+                        });
                     break;
                 default:
                     throw new NotImplementedException(finalFrameType.ToString());
@@ -3933,11 +3929,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, "The connection was aborted by the application.");
 
-            // There's a race when the appfunc is exiting about how soon it unregisters the stream.
-            for (var i = 0; i < 10; i++)
-            {
-                await SendDataAsync(1, new byte[100], endStream: false);
-            }
             await SendRstStreamAsync(1);
 
             // Send an extra frame to make it fail
@@ -3955,8 +3946,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     throw new NotImplementedException(finalFrameType.ToString());
             }
 
-            await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1, Http2ErrorCode.STREAM_CLOSED,
-                CoreStrings.FormatHttp2ErrorStreamClosed(finalFrameType, 1));
+            // There's a race where either of these messages could be logged, depending on if the stream cleanup has finished yet.
+            await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
+                ignoreNonGoAwayFrames: false,
+                expectedLastStreamId: 1,
+                expectedErrorCode: Http2ErrorCode.STREAM_CLOSED,
+                expectedErrorMessage: new[] {
+                    CoreStrings.FormatHttp2ErrorStreamClosed(finalFrameType, streamId: 1),
+                    CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(finalFrameType, streamId: 1)
+                });
         }
 
         public static TheoryData<byte[]> UpperCaseHeaderNameData

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -1130,7 +1130,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 var message = Assert.Single(TestApplicationErrorLogger.Messages, m => m.Exception is TException);
 
                 Assert.Contains(expectedErrorMessage, expected => message.Exception.Message.Contains(expected));
-                //Assert.Contains(expectedErrorMessage, message.Exception.Message);
             }
 
             await _connectionTask;

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -1110,7 +1110,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(expectedErrorCode, frame.GoAwayErrorCode);
         }
 
-        protected async Task WaitForConnectionErrorAsync<TException>(bool ignoreNonGoAwayFrames, int expectedLastStreamId, Http2ErrorCode expectedErrorCode, string expectedErrorMessage)
+        protected async Task WaitForConnectionErrorAsync<TException>(bool ignoreNonGoAwayFrames, int expectedLastStreamId, Http2ErrorCode expectedErrorCode, params string[] expectedErrorMessage)
             where TException : Exception
         {
             var frame = await ReceiveFrameAsync();
@@ -1125,10 +1125,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             VerifyGoAway(frame, expectedLastStreamId, expectedErrorCode);
 
-            if (expectedErrorMessage != null)
+            if (expectedErrorMessage?.Length > 0)
             {
                 var message = Assert.Single(TestApplicationErrorLogger.Messages, m => m.Exception is TException);
-                Assert.Contains(expectedErrorMessage, message.Exception.Message);
+
+                Assert.Contains(expectedErrorMessage, expected => message.Exception.Message.Contains(expected));
+                //Assert.Contains(expectedErrorMessage, message.Exception.Message);
             }
 
             await _connectionTask;

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
@@ -208,40 +209,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, "The connection was aborted by the application.");
 
-            // There's a race when the appfunc is exiting about how soon it unregisters the stream.
-            for (var i = 0; i < 10; i++)
+            var cts = new CancellationTokenSource();
+
+            async Task AdvanceClockAndSendFrames()
             {
-                await SendDataAsync(1, new byte[100], endStream: false);
+                // There's a race when the appfunc is exiting about how soon it unregisters the stream, so retry until success.
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    // Just past the timeout
+                    mockSystemClock.UtcNow += Constants.RequestBodyDrainTimeout + TimeSpan.FromTicks(1);
+                    (_connection as IRequestProcessor).Tick(mockSystemClock.UtcNow);
+
+                    // Send an extra frame to make it fail
+                    switch (finalFrameType)
+                    {
+                        case Http2FrameType.DATA:
+                            await SendDataAsync(1, new byte[100], endStream: true);
+                            break;
+
+                        case Http2FrameType.HEADERS:
+                            await SendHeadersAsync(1, Http2HeadersFrameFlags.END_STREAM | Http2HeadersFrameFlags.END_HEADERS, _requestTrailers);
+                            break;
+
+                        default:
+                            throw new NotImplementedException(finalFrameType.ToString());
+                    }
+
+                    if (!cts.Token.IsCancellationRequested)
+                    {
+                        await Task.Delay(10);
+                    }
+                }
             }
 
-            // Just short of the timeout
-            mockSystemClock.UtcNow += Constants.RequestBodyDrainTimeout;
-            (_connection as IRequestProcessor).Tick(mockSystemClock.UtcNow);
+            var sendTask = AdvanceClockAndSendFrames();
 
-            // Still fine
-            await SendDataAsync(1, new byte[100], endStream: false);
-
-            // Just past the timeout
-            mockSystemClock.UtcNow += TimeSpan.FromTicks(1);
-            (_connection as IRequestProcessor).Tick(mockSystemClock.UtcNow);
-
-            // Send an extra frame to make it fail
-            switch (finalFrameType)
-            {
-                case Http2FrameType.DATA:
-                    await SendDataAsync(1, new byte[100], endStream: true);
-                    break;
-
-                case Http2FrameType.HEADERS:
-                    await SendHeadersAsync(1, Http2HeadersFrameFlags.END_STREAM | Http2HeadersFrameFlags.END_HEADERS, _requestTrailers);
-                    break;
-
-                default:
-                    throw new NotImplementedException(finalFrameType.ToString());
-            }
-
-            await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1, Http2ErrorCode.STREAM_CLOSED,
+            await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
+                ignoreNonGoAwayFrames: false,
+                expectedLastStreamId: 1,
+                Http2ErrorCode.STREAM_CLOSED,
                 CoreStrings.FormatHttp2ErrorStreamClosed(finalFrameType, 1));
+
+            cts.Cancel();
+
+            await sendTask.DefaultTimeout();
         }
 
         [Fact]


### PR DESCRIPTION
Fixes most recent failure reported in #2897.

```
[xUnit.net 00:00:47.13]     AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterCooldownExpires(finalFrameType: DATA) [FAIL]
2018-10-16T18:33:32.8755774Z   Failed   AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterCooldownExpires(finalFrameType: DATA)
2018-10-16T18:33:32.8813235Z   Error Message:
2018-10-16T18:33:32.8815566Z    System.TimeoutException : The operation at /_/test/shared/TaskTimeoutExtensions.cs:12 timed out after reaching the limit of 30000ms.
2018-10-16T18:33:32.8817542Z   Stack Trace:
2018-10-16T18:33:32.8820211Z      at Microsoft.AspNetCore.Testing.TaskExtensions.<TimeoutAfter>d__0`1.MoveNext()
2018-10-16T18:33:32.8822603Z   --- End of stack trace from previous location where exception was thrown ---
2018-10-16T18:33:32.8824590Z      at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
2018-10-16T18:33:32.8826444Z      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2018-10-16T18:33:32.8828404Z      at Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2TestBase.<ReceiveFrameAsync>d__92.MoveNext() in /_/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs:line 1044
2018-10-16T18:33:32.8830987Z   --- End of stack trace from previous location where exception was thrown ---
2018-10-16T18:33:32.8833656Z      at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
2018-10-16T18:33:32.8836065Z      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2018-10-16T18:33:32.8837806Z      at Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2TestBase.<WaitForConnectionErrorAsync>d__97`1.MoveNext() in /_/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs:line 1113
2018-10-16T18:33:32.8840364Z   --- End of stack trace from previous location where exception was thrown ---
2018-10-16T18:33:32.8842715Z      at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
2018-10-16T18:33:32.8844630Z      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2018-10-16T18:33:32.8846509Z      at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
2018-10-16T18:33:32.8848498Z      at Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2TimeoutTests.<AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterCooldownExpires>d__5.MoveNext() in /_/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs:line 242
2018-10-16T18:33:32.8948416Z   --- End of stack trace from previous location where exception was thrown ---
2018-10-16T18:33:32.8952714Z      at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
2018-10-16T18:33:32.8954191Z      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2018-10-16T18:33:32.8956480Z   --- End of stack trace from previous location where exception was thrown ---
2018-10-16T18:33:32.8958385Z      at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
2018-10-16T18:33:32.8961256Z      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2018-10-16T18:33:32.8963698Z   --- End of stack trace from previous location where exception was thrown ---
2018-10-16T18:33:32.8966296Z      at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
2018-10-16T18:33:32.8968371Z      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2018-10-16T18:33:32.8970957Z   Standard Output Messages:
2018-10-16T18:33:32.8973301Z    | [0.001s] TestLifetime Information: Starting test AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterCooldownExpires-DATA at 2018-10-16T18:33:01
2018-10-16T18:33:32.8975806Z    | [0.010s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending SETTINGS frame for stream ID 0 with length 18 and flags NONE
2018-10-16T18:33:32.8977595Z    | [0.010s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending WINDOW_UPDATE frame for stream ID 0 with length 4 and flags 0x0
2018-10-16T18:33:32.8980259Z    | [0.010s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received SETTINGS frame for stream ID 0 with length 0 and flags NONE
2018-10-16T18:33:32.8982576Z    | [0.011s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending SETTINGS frame for stream ID 0 with length 0 and flags ACK
2018-10-16T18:33:32.8985425Z    | [0.012s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received HEADERS frame for stream ID 1 with length 37 and flags END_HEADERS
2018-10-16T18:33:32.8987856Z    | [0.017s] Microsoft.AspNetCore.Server.Kestrel Debug: Trace id ":00000001": HTTP/2 stream error "INTERNAL_ERROR". A Reset is being sent to the stream.
2018-10-16T18:33:32.8991342Z    | Microsoft.AspNetCore.Connections.ConnectionAbortedException: The connection was aborted by the application.
2018-10-16T18:33:32.8994465Z    | [0.019s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending RST_STREAM frame for stream ID 1 with length 4 and flags 0x0
2018-10-16T18:33:32.8998169Z    | [0.028s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9000701Z    | [0.028s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9003177Z    | [0.029s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9005034Z    | [0.029s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9006909Z    | [0.029s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9009256Z    | [0.029s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9011494Z    | [0.029s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9013619Z    | [0.029s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9015458Z    | [0.029s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9017129Z    | [0.029s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9019458Z    | [0.030s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags NONE
2018-10-16T18:33:32.9021485Z    | [0.030s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 100 and flags END_STREAM
2018-10-16T18:33:32.9023995Z    | [0.053s] Microsoft.AspNetCore.Server.Kestrel Information: Connection id "(null)", Request id ":00000001": the application completed without reading the entire request body.
2018-10-16T18:33:32.9025747Z    | [30.040s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending GOAWAY frame for stream ID 0 with length 8 and flags 0x0
2018-10-16T18:33:32.9027912Z    | [30.040s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "(null)" is closed. The last processed stream ID was 1.
2018-10-16T18:33:32.9030244Z    | [30.040s] TestLifetime Information: Finished test AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterCooldownExpires-DATA in 30.0399266s
```