### PR TITLE
Send RST for canceled HTTP/2 writes

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2OutputProducer.cs
@@ -74,10 +74,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        // Review: This is called when a CancellationToken fires mid-write. In HTTP/1.x, this aborts the entire connection.
-        // Should we do that here?
+        // This is called when a CancellationToken fires mid-write. In HTTP/1.x, this aborts the entire connection.
+        // For HTTP/2 we abort the stream.
         void IHttpOutputAborter.Abort(ConnectionAbortedException abortReason)
         {
+            _stream.ResetAndAbort(abortReason, Http2ErrorCode.INTERNAL_ERROR);
             Dispose();
         }
 

--- a/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Stream.cs
@@ -427,7 +427,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             ResetAndAbort(abortReason, Http2ErrorCode.INTERNAL_ERROR);
         }
 
-        private void ResetAndAbort(ConnectionAbortedException abortReason, Http2ErrorCode error)
+        internal void ResetAndAbort(ConnectionAbortedException abortReason, Http2ErrorCode error)
         {
             // Future incoming frames will drain for a default grace period to avoid destabilizing the connection.
             var states = ApplyCompletionFlag(StreamCompletionFlags.Aborted);

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -1998,5 +1998,90 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForConnectionErrorAsync<HPackEncodingException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1, Http2ErrorCode.INTERNAL_ERROR,
                 CoreStrings.HPackErrorNotEnoughBuffer);
         }
+
+        [Fact]
+        public async Task WriteAsync_PreCancelledCancellationToken_DoesNotAbort()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                // The cancellation is checked at the start of WriteAsync and no application state is changed.
+                await Assert.ThrowsAsync<OperationCanceledException>(() => context.Response.WriteAsync("hello,", new CancellationToken(true)));
+                Assert.False(context.Response.HasStarted);
+            });
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 55,
+                withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+                withStreamId: 1);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 0,
+                withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+                withStreamId: 1);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
+        }
+
+        [Fact]
+        public async Task WriteAsync_CancellationTokenTriggeredDueToFlowControl_SendRST()
+        {
+            var cts = new CancellationTokenSource();
+            var writeStarted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            await InitializeConnectionAsync(async context =>
+            {
+                await context.Response.Body.FlushAsync(); // https://github.com/aspnet/KestrelHttpServer/issues/3031
+                var writeTask = context.Response.WriteAsync("hello,", cts.Token);
+                writeStarted.SetResult(0);
+                await Assert.ThrowsAsync<OperationCanceledException>(() => writeTask);
+            });
+
+            _clientSettings.InitialWindowSize = 0;
+            await SendSettingsAsync();
+            await ExpectAsync(Http2FrameType.SETTINGS,
+                withLength: 0,
+                withFlags: (byte)Http2SettingsFrameFlags.ACK,
+                withStreamId: 0);
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 37,
+                withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+                withStreamId: 1);
+
+            await writeStarted.Task;
+
+            cts.Cancel();
+
+            await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, null);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+        }
     }
 }


### PR DESCRIPTION
 #3007 There are two scenarios:
1) The cancellation token is tripped before the write actually starts. WriteAsync will throw but no state changes take place. The app can handle the exception or let Kestrel handle it like any other app exception.
2) The cancellation token is tripped after the write starts. In this case the response is aborted and a RST is sent. Without the RST no response would be sent the client would not know anything was wrong until they eventually timed out.

Logs:
```
| [0.650s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending HEADERS frame for stream ID 1 with length 37 and flags END_HEADERS
| [0.684s] Microsoft.AspNetCore.Server.Kestrel Debug: Trace id ":00000001": HTTP/2 stream error "INTERNAL_ERROR". A Reset is being sent to the stream.
| Microsoft.AspNetCore.Connections.ConnectionAbortedException: The connection or stream was aborted because a write operation was aborted with a CancellationToken. ---> System.OperationCanceledException: The operation was canceled.
|    at System.Threading.CancellationToken.ThrowOperationCanceledException()
|    at System.IO.Pipelines.PipeAwaitable.ObserveCancelation()
|    at System.IO.Pipelines.Pipe.GetFlushResult(FlushResult& result)
|    at System.IO.Pipelines.Pipe.GetFlushAsyncResult()
|    at System.IO.Pipelines.Pipe.DefaultPipeWriter.GetResult(Int16 token)
|    at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
| --- End of stack trace from previous location where exception was thrown ---
|    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TimingPipeFlusher.TimeFlushAsync(MinDataRate minRate, Int64 count, IHttpOutputAborter outputAborter, CancellationToken cancellationToken) in d:\github\AspNet\KestrelHttpServer\src\Kestrel.Core\Internal\Infrastructure\TimingPipeFlusher.cs:line 82
|    --- End of inner exception stack trace ---
| [0.730s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending RST_STREAM frame for stream ID 1 with length 4 and flags 0x0
```