### PR TITLE
Log binary data as a parameter

### DIFF
--- a/samples/SampleApp/Startup.cs
+++ b/samples/SampleApp/Startup.cs
@@ -66,6 +66,7 @@ namespace SampleApp
             var hostBuilder = new WebHostBuilder()
                 .ConfigureLogging((_, factory) =>
                 {
+                    factory.SetMinimumLevel(LogLevel.Debug);
                     factory.AddConsole();
                 })
                 .ConfigureAppConfiguration((hostingContext, config) =>

--- a/src/Kestrel.Core/Adapter/Internal/LoggingStream.cs
+++ b/src/Kestrel.Core/Adapter/Internal/LoggingStream.cs
@@ -174,13 +174,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal
                 builder.Append(" ");
             }
             builder.AppendLine();
+            builder.Append("{0}");
+
+            var rawDataBuilder = new StringBuilder();
             // Write the bytes as if they were ASCII
             for (int i = 0; i < buffer.Length; i++)
             {
-                builder.Append((char)buffer[i]);
+                rawDataBuilder.Append((char)buffer[i]);
             }
 
-            _logger.LogDebug(builder.ToString());
+            _logger.LogDebug(builder.ToString(), rawDataBuilder.ToString());
         }
 
         // The below APM methods call the underlying Read/WriteAsync methods which will still be logged.


### PR DESCRIPTION
 #2860 

The LoggingConnectionAdapter first logs the bytes as hex, but then it attempts to case the data to ascii and log it again. This makes for human readable logs if contents is HTTP request/response headers, but can look like garbage for SSL bytes or other data.

We had one test failure where the SSL data generated a sequence of bytes that when downcast to ascii caused an IndexOutOfRangeException in Serilog message processor. It was attempting to find formatting symbols in the message and hit an invalid sequence. I've reviewed the Serilog code and wasn't able to devise a sequence that would reproduce this.

The mitigation for garbage data is to take it out of the message format string and pass it as a parameter. There's visible change on the console.