### PR TITLE
Revert "Flush response headers #3031"

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2FrameWriter.cs
@@ -104,6 +104,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
+        public Task FlushAsync(IHttpOutputAborter outputAborter, CancellationToken cancellationToken)
+        {
+            lock (_writeLock)
+            {
+                if (_completed)
+                {
+                    return Task.CompletedTask;
+                }
+
+                return _flusher.FlushAsync(outputAborter, cancellationToken);
+            }
+        }
+
         public Task Write100ContinueAsync(int streamId)
         {
             lock (_writeLock)
@@ -158,11 +171,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     throw new InvalidOperationException(hex.Message, hex); // Report the error to the user if this was the first write.
                 }
             }
-
-            _ = _flusher.FlushAsync();
         }
 
-        public Task WriteResponseTrailersAsync(int streamId, HttpResponseTrailers headers)
+        public Task WriteResponseTrailers(int streamId, HttpResponseTrailers headers)
         {
             lock (_writeLock)
             {


### PR DESCRIPTION
This reverts commit 277a5502fd44d565d8086480b829d1c9995a78ab. Due to a major performance [regression](https://github.com/aspnet/Benchmarks/issues/541). We'll revisit in the future.