### PR TITLE
Add more chrome test logging and fix an issue with tests running as root on VSTS

### DIFF
--- a/test/Kestrel.Transport.FunctionalTests/ChromeTests.cs
+++ b/test/Kestrel.Transport.FunctionalTests/ChromeTests.cs
@@ -49,6 +49,7 @@ namespace Interop.FunctionalTests
             ShutdownLogPath = Path.Combine(ResolvedLogOutputDirectory, $"{ResolvedTestMethodName}.sd.json");
 
             ChromeArgs = $"--headless " +
+                $"--no-sandbox " +
                 $"--disable-gpu " +
                 $"--allow-insecure-localhost " +
                 $"--enable-logging " +
@@ -109,6 +110,9 @@ namespace Interop.FunctionalTests
 
             var headlessChromeProcess = Process.Start(chromeStartInfo);
             var chromeOutput = await headlessChromeProcess.StandardOutput.ReadToEndAsync();
+            var chromeError = await headlessChromeProcess.StandardError.ReadToEndAsync();
+            Logger.LogInformation($"Standard output: {chromeOutput}");
+            Logger.LogInformation($"Standard error: {chromeError}");
 
             headlessChromeProcess.WaitForExit();
 


### PR DESCRIPTION
Tests on VSTS run in root and on ubuntu that requires a --no-sandbox flag to be passed in. This addresses https://github.com/aspnet/AspNetCore/issues/3727.