### PR TITLE
Remove invalid Debug.Assert in Http2Connection

### DIFF
--- a/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
+++ b/src/Kestrel.Core/Internal/Http2/Http2Connection.cs
@@ -1062,10 +1062,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                         _streams.TryRemove(streamId, out _);
                     }
                 }
-                else
-                {
-                    Debug.Assert(false, "Missing stream");
-                }
 
                 if (_activeStreamCount == 0)
                 {


### PR DESCRIPTION
The _streams dictionary may not contain the completing stream in
OnStreamCompleted since the IsDraining flag is applied beforehand
which allows it to be removed by the request processing thread.

#3079