### PR TITLE
Wait for reads before advancing clock in Http2TimeoutTests

### DIFF
--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -338,7 +338,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 var stalledReadTask = context.Request.Body.ReadAsync(buffer, 0, buffer.Length);
 
-                // Write to the response so the test knows the app started the s
+                // Write to the response so the test knows the app started the stalled read.
                 await context.Response.Body.WriteAsync(new byte[1], 0, 1);
 
                 await stalledReadTask;

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -100,6 +100,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             new KeyValuePair<string, string>("g", _4kHeaderValue),
         };
 
+        protected static IEnumerable<KeyValuePair<string, string>> ReadRateRequestHeaders(int expectedBytes) => new[]
+        {
+            new KeyValuePair<string, string>(HeaderNames.Method, "POST"),
+            new KeyValuePair<string, string>(HeaderNames.Path, "/" + expectedBytes),
+            new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+        };
+
         protected static readonly byte[] _helloBytes = Encoding.ASCII.GetBytes("hello");
         protected static readonly byte[] _worldBytes = Encoding.ASCII.GetBytes("world");
         protected static readonly byte[] _helloWorldBytes = Encoding.ASCII.GetBytes("hello, world");
@@ -137,6 +145,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected readonly RequestDelegate _waitForAbortApplication;
         protected readonly RequestDelegate _waitForAbortFlushingApplication;
         protected readonly RequestDelegate _waitForAbortWithDataApplication;
+        protected readonly RequestDelegate _readRateApplication;
         protected readonly RequestDelegate _echoMethod;
         protected readonly RequestDelegate _echoHost;
         protected readonly RequestDelegate _echoPath;
@@ -313,6 +322,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10);
 
                 _runningStreams[streamIdFeature.StreamId].TrySetResult(null);
+            };
+
+            _readRateApplication = async context =>
+            {
+                var expectedBytes = int.Parse(context.Request.Path.Value.Substring(1));
+
+                var buffer = new byte[Http2PeerSettings.MinAllowedMaxFrameSize];
+                var received = 0;
+
+                while (received < expectedBytes)
+                {
+                    received += await context.Request.Body.ReadAsync(buffer, 0, buffer.Length);
+                }
+
+                var stalledReadTask = context.Request.Body.ReadAsync(buffer, 0, buffer.Length);
+
+                // Write to the response so the test knows the app started the s
+                await context.Response.Body.WriteAsync(new byte[1], 0, 1);
+
+                await stalledReadTask;
             };
 
             _echoMethod = context =>

--- a/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/test/Kestrel.InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -563,10 +563,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _timeoutControl.Initialize(mockSystemClock.UtcNow);
 
-            await InitializeConnectionAsync(_echoApplication);
+            await InitializeConnectionAsync(_readRateApplication);
 
             // _helloWorldBytes is 12 bytes, and 12 bytes / 240 bytes/sec = .05 secs which is far below the grace period.
-            await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
+            await StartStreamAsync(1, ReadRateRequestHeaders(_helloWorldBytes.Length), endStream: false);
             await SendDataAsync(1, _helloWorldBytes, endStream: false);
 
             await ExpectAsync(Http2FrameType.HEADERS,
@@ -575,7 +575,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withStreamId: 1);
 
             await ExpectAsync(Http2FrameType.DATA,
-                withLength: _helloWorldBytes.Length,
+                withLength: 1,
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 1);
 
@@ -612,10 +612,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _timeoutControl.Initialize(mockSystemClock.UtcNow);
 
-            await InitializeConnectionAsync(_echoApplication);
+            await InitializeConnectionAsync(_readRateApplication);
 
             // _maxData is 16 KiB, and 16 KiB / 240 bytes/sec ~= 68 secs which is far above the grace period.
-            await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
+            await StartStreamAsync(1, ReadRateRequestHeaders(_maxData.Length), endStream: false);
             await SendDataAsync(1, _maxData, endStream: false);
 
             await ExpectAsync(Http2FrameType.HEADERS,
@@ -624,7 +624,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withStreamId: 1);
 
             await ExpectAsync(Http2FrameType.DATA,
-                withLength: _maxData.Length,
+                withLength: 1,
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 1);
 
@@ -665,10 +665,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _timeoutControl.Initialize(mockSystemClock.UtcNow);
 
-            await InitializeConnectionAsync(_echoApplication);
+            await InitializeConnectionAsync(_readRateApplication);
 
             // _maxData is 16 KiB, and 16 KiB / 240 bytes/sec ~= 68 secs which is far above the grace period.
-            await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
+            await StartStreamAsync(1, ReadRateRequestHeaders(_maxData.Length), endStream: false);
             await SendDataAsync(1, _maxData, endStream: false);
 
             await ExpectAsync(Http2FrameType.HEADERS,
@@ -677,11 +677,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withStreamId: 1);
 
             await ExpectAsync(Http2FrameType.DATA,
-                withLength: _maxData.Length,
+                withLength: 1,
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 1);
 
-            await StartStreamAsync(3, _browserRequestHeaders, endStream: false);
+            await StartStreamAsync(3, ReadRateRequestHeaders(_maxData.Length), endStream: false);
             await SendDataAsync(3, _maxData, endStream: false);
 
             await ExpectAsync(Http2FrameType.HEADERS,
@@ -689,7 +689,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
                 withStreamId: 3);
             await ExpectAsync(Http2FrameType.DATA,
-                withLength: _maxData.Length,
+                withLength: 1,
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 3);
 
@@ -734,10 +734,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _timeoutControl.Initialize(mockSystemClock.UtcNow);
 
-            await InitializeConnectionAsync(_echoApplication);
+            await InitializeConnectionAsync(_readRateApplication);
 
             // _maxData is 16 KiB, and 16 KiB / 240 bytes/sec ~= 68 secs which is far above the grace period.
-            await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
+            await StartStreamAsync(1, ReadRateRequestHeaders(_maxData.Length), endStream: false);
             await SendDataAsync(1, _maxData, endStream: true);
 
             await ExpectAsync(Http2FrameType.HEADERS,
@@ -746,7 +746,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withStreamId: 1);
 
             await ExpectAsync(Http2FrameType.DATA,
-                withLength: _maxData.Length,
+                withLength: 1,
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 1);
 
@@ -755,7 +755,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)Http2DataFrameFlags.END_STREAM,
                 withStreamId: 1);
 
-            await StartStreamAsync(3, _browserRequestHeaders, endStream: false);
+            await StartStreamAsync(3, ReadRateRequestHeaders(_maxData.Length), endStream: false);
             await SendDataAsync(3, _maxData, endStream: false);
 
             await ExpectAsync(Http2FrameType.HEADERS,
@@ -763,7 +763,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
                 withStreamId: 3);
             await ExpectAsync(Http2FrameType.DATA,
-                withLength: _maxData.Length,
+                withLength: 1,
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 3);
 
@@ -819,7 +819,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 }
                 else
                 {
-                    await _echoApplication(context);
+                    await _readRateApplication(context);
                 }
             });
 
@@ -830,7 +830,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             }
             await SendDataAsync(1, _maxData, endStream: true);
 
-            await StartStreamAsync(3, _browserRequestHeaders, endStream: false);
+            await StartStreamAsync(3, ReadRateRequestHeaders(_helloWorldBytes.Length), endStream: false);
             await SendDataAsync(3, _helloWorldBytes, endStream: false);
 
             await ExpectAsync(Http2FrameType.HEADERS,
@@ -838,7 +838,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
                 withStreamId: 3);
             await ExpectAsync(Http2FrameType.DATA,
-                withLength: _helloWorldBytes.Length,
+                withLength: 1,
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 3);
 
@@ -859,10 +859,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)Http2DataFrameFlags.END_STREAM,
                 withStreamId: 1);
 
-            await ExpectAsync(Http2FrameType.WINDOW_UPDATE,
+            var updateFrame = await ExpectAsync(Http2FrameType.WINDOW_UPDATE,
                 withLength: 4,
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 0);
+
+            var expectedUpdateSize = ((framesConnectionInWindow / 2) + 1) * _maxData.Length + _helloWorldBytes.Length;
+            Assert.Equal(expectedUpdateSize, updateFrame.WindowUpdateSizeIncrement);
 
             AdvanceClock(limits.MinRequestBodyDataRate.GracePeriod);
 


### PR DESCRIPTION
Prior to this change, HTTP/2 read rate limit tests would fail when the stalled read started after the test started advancing the clock. Example:

```
Failed   DATA_Received_TooSlowlyOnSecondStream_AbortsConnectionAfterNonAdditiveRateTimeout
  Error Message:
   Moq.MockException :
  Expected invocation on the mock once, but was 0 times: h => h.OnTimeout(TimeoutReason.ReadDataRate)

  Configured setups:
  ITimeoutHandler h => h.OnTimeout(It.IsAny<TimeoutReason>())
  No invocations performed.
  Stack Trace:
     at Moq.Mock.VerifyCalls(Mock targetMock, InvocationShape expectation, LambdaExpression expression, Times times, String failMessage)
     at Moq.Mock.Verify[T](Mock`1 mock, Expression`1 expression, Times times, String failMessage)
     at Moq.Mock`1.Verify(Expression`1 expression, Times times)
     at Moq.Mock`1.Verify(Expression`1 expression, Func`1 times)
     at Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2TimeoutTests.<DATA_Received_TooSlowlyOnSecondStream_AbortsConnectionAfterNonAdditiveRateTimeout>d__14.MoveNext() in C:\dev\aspnet\KestrelHttpServer\test\Kestrel.InMemory.FunctionalTests\Http2\Http2TimeoutTests.cs:line 781
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
     at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
     at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
     at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
  Standard Output Messages:
   | [0.001s] TestLifetime Information: Starting test DATA_Received_TooSlowlyOnSecondStream_AbortsConnectionAfterNonAdditiveRateTimeout at 2018-11-09T20:20:47
   | [0.005s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending SETTINGS frame for stream ID 0 with length 18 and flags NONE
   | [0.005s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending WINDOW_UPDATE frame for stream ID 0 with length 4 and flags 0x0
   | [0.005s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received SETTINGS frame for stream ID 0 with length 0 and flags NONE
   | [0.005s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending SETTINGS frame for stream ID 0 with length 0 and flags ACK
   | [0.005s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received HEADERS frame for stream ID 1 with length 318 and flags END_HEADERS
   | [0.005s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 1 with length 16384 and flags END_STREAM
   | [0.005s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "(null)", Request id ":00000001": started reading request body.
   | [0.006s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending HEADERS frame for stream ID 1 with length 37 and flags END_HEADERS
   | [0.006s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending DATA frame for stream ID 1 with length 16384 and flags NONE
   | [0.006s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "(null)", Request id ":00000001": done reading request body.
   | [0.006s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending DATA frame for stream ID 1 with length 0 and flags END_STREAM
   | [0.006s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received HEADERS frame for stream ID 3 with length 318 and flags END_HEADERS
   | [0.007s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" received DATA frame for stream ID 3 with length 16384 and flags NONE
   | [0.007s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "(null)", Request id ":00000003": started reading request body.
   | [0.007s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending HEADERS frame for stream ID 3 with length 37 and flags END_HEADERS
   | [0.007s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending DATA frame for stream ID 3 with length 16384 and flags NONE
   | [0.024s] Microsoft.AspNetCore.Server.Kestrel Trace: Connection id "(null)" sending GOAWAY frame for stream ID 0 with length 8 and flags 0x0
   | [0.024s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "(null)" is closed. The last processed stream ID was 3.
   | [0.025s] Microsoft.AspNetCore.Server.Kestrel Error: Connection id "(null)", Request id ":00000003": An unhandled exception was thrown by the application.
   | System.IO.IOException: The request stream was aborted. ---> Microsoft.AspNetCore.Connections.ConnectionAbortedException: The HTTP/2 connection faulted.
   |    --- End of inner exception stack trace ---
   |    at System.IO.Pipelines.PipeCompletion.ThrowLatchedException()
   |    at System.IO.Pipelines.Pipe.GetReadResult(ReadResult& result)
   |    at System.IO.Pipelines.Pipe.GetReadAsyncResult()
   |    at System.IO.Pipelines.Pipe.DefaultPipeReader.GetResult(Int16 token)
   |    at System.Runtime.CompilerServices.ValueTaskAwaiter`1.GetResult()
   |    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.MessageBody.<ReadAsync>d__27.MoveNext() in C:\dev\aspnet\KestrelHttpServer\src\Kestrel.Core\Internal\Http\MessageBody.cs:line 54
   | --- End of stack trace from previous location where exception was thrown ---
   |    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   |    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   |    at System.Runtime.CompilerServices.ValueTaskAwaiter`1.GetResult()
   |    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpRequestStream.<ReadAsyncInternal>d__21.MoveNext() in C:\dev\aspnet\KestrelHttpServer\src\Kestrel.Core\Internal\Http\HttpRequestStream.cs:line 130
   | --- End of stack trace from previous location where exception was thrown ---
   |    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   |    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   |    at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   |    at Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2TestBase.<>c.<<-ctor>b__49_10>d.MoveNext() in C:\dev\aspnet\KestrelHttpServer\test\Kestrel.InMemory.FunctionalTests\Http2\Http2TestBase.cs:line 218
   | --- End of stack trace from previous location where exception was thrown ---
   |    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   |    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   |    at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   |    at Microsoft.AspNetCore.Testing.DummyApplication.<ProcessRequestAsync>d__7.MoveNext() in C:\dev\aspnet\KestrelHttpServer\test\shared\DummyApplication.cs:line 45
   | --- End of stack trace from previous location where exception was thrown ---
   |    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   |    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   |    at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   |    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.<ProcessRequests>d__185`1.MoveNext() in C:\dev\aspnet\KestrelHttpServer\src\Kestrel.Core\Internal\Http\HttpProtocol.cs:line 545
   | [0.026s] Microsoft.AspNetCore.Server.Kestrel Debug: Connection id "(null)", Request id ":00000003": done reading request body.
   | [0.026s] Microsoft.AspNetCore.Server.Kestrel Information: Connection id "(null)", Request id ":00000003": the application completed without reading the entire request body.
   | [0.026s] TestLifetime Information: Finished test DATA_Received_TooSlowlyOnSecondStream_AbortsConnectionAfterNonAdditiveRateTimeout in 0.025
```