### PR TITLE
Stop skipping libuv functional tests

### DIFF
--- a/test/Kestrel.Transport.Libuv.FunctionalTests/Kestrel.Transport.Libuv.FunctionalTests.csproj
+++ b/test/Kestrel.Transport.Libuv.FunctionalTests/Kestrel.Transport.Libuv.FunctionalTests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Kestrel.Transport.FunctionalTests\**\*.cs" />
     <Compile Include="..\shared\*.cs" LinkBase="shared" />
     <Compile Include="..\shared\TransportTestHelpers\*.cs" LinkBase="shared\TransportTestHelpers" />
     <Content Include="..\shared\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
I accidentally removed all the test classes shared between Sockets and libuv from the libuv functional test project as part of #3036. Fortunately, we haven't made any transport changes since #3036 was merged.