### PR TITLE
Remove lock contention in IOQueue

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
@@ -8,9 +8,14 @@ using System.Threading;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 {
+#if NETCOREAPP3_0
+    public class IOQueue : PipeScheduler, IThreadPoolWorkItem
+    {
+#else
     public class IOQueue : PipeScheduler
     {
-        private static readonly WaitCallback _doWorkCallback = s => ((IOQueue)s).DoWork();
+        private static readonly WaitCallback _doWorkCallback = s => ((IOQueue)s).Execute();
+#endif
 
         private readonly object _workSync = new object();
         private readonly ConcurrentQueue<Work> _workItems = new ConcurrentQueue<Work>();
@@ -24,19 +29,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 State = state
             };
 
+            // Order is important here with DoWork.
+            // Enqueue prior to checking _doingWork.
             _workItems.Enqueue(work);
 
-            lock (_workSync)
+            if (!Volatile.Read(ref _doingWork))
             {
-                if (!_doingWork)
+                // Not scheduled or working.
+                var submitWork = false;
+                // We re-check under lock here to prevent double schedule or missed schedule.
+                lock (_workSync)
                 {
+                    // Don't schedule if already scheduled or doing work.
+                    if (!_doingWork)
+                    {
+                        submitWork = true;
+                        _doingWork = true;
+                    }
+                }
+
+                // Wasn't scheduled or active, schedule outside lock.
+                if (submitWork)
+                {
+#if NETCOREAPP3_0
+                    System.Threading.ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
+#else
                     System.Threading.ThreadPool.UnsafeQueueUserWorkItem(_doWorkCallback, this);
-                    _doingWork = true;
+#endif
                 }
             }
         }
 
-        private void DoWork()
+#if NETCOREAPP3_0
+        void IThreadPoolWorkItem.Execute()
+#else
+        private void Execute()
+#endif
         {
             while (true)
             {
@@ -45,12 +73,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                     item.Callback(item.State);
                 }
 
+                // Order is important here with Schedule.
+                // Set _doingWork prior to checking .IsEmpty
+                Volatile.Write(ref _doingWork, false);
+
+                // We check under lock here to prevent double schedule or missed schedule.
                 lock (_workSync)
                 {
                     if (_workItems.IsEmpty)
                     {
-                        _doingWork = false;
-                        return;
+                        // Nothing to do, exit.
+                        break;
+                    }
+
+                    if (_doingWork)
+                    {
+                        // Something to do, but DoWork has been rescheduled already, exit.
+                        break;
+                    }
+                    else
+                    {
+                        // Something to do, and not rescheduled yet, reactivate. 
+                        // As we are already running and can do the work.
+                        _doingWork = true;
                     }
                 }
             }

--- a/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
@@ -17,9 +17,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         private static readonly WaitCallback _doWorkCallback = s => ((IOQueue)s).Execute();
 #endif
 
-        private readonly object _workSync = new object();
         private readonly ConcurrentQueue<Work> _workItems = new ConcurrentQueue<Work>();
-        private bool _doingWork;
+        private int _doingWork;
 
         public override void Schedule(Action<object> action, object state)
         {
@@ -29,28 +28,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 State = state
             };
 
-            // Order is important here with DoWork.
+            // Order is important here with Execute.
             // Enqueue prior to checking _doingWork.
             _workItems.Enqueue(work);
 
-            if (!Volatile.Read(ref _doingWork))
+            if (Volatile.Read(ref _doingWork) == 0)
             {
-                // Not scheduled or working.
-                var submitWork = false;
-                // We re-check under lock here to prevent double schedule or missed schedule.
-                lock (_workSync)
-                {
-                    // Don't schedule if already scheduled or doing work.
-                    if (!_doingWork)
-                    {
-                        submitWork = true;
-                        _doingWork = true;
-                    }
-                }
+                // Set as working, and check if it was already working.
+                var submitWork = Interlocked.Exchange(ref _doingWork, 1) == 0;
 
-                // Wasn't scheduled or active, schedule outside lock.
                 if (submitWork)
                 {
+                    // Wasn't scheduled or active, schedule.
 #if NETCOREAPP3_0
                     System.Threading.ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
 #else
@@ -68,36 +57,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         {
             while (true)
             {
-                while (_workItems.TryDequeue(out Work item))
+                var workItems = _workItems;
+                while (workItems.TryDequeue(out Work item))
                 {
                     item.Callback(item.State);
                 }
 
                 // Order is important here with Schedule.
                 // Set _doingWork prior to checking .IsEmpty
-                Volatile.Write(ref _doingWork, false);
+                Volatile.Write(ref _doingWork, 0);
 
-                // We check under lock here to prevent double schedule or missed schedule.
-                lock (_workSync)
+                if (workItems.IsEmpty)
                 {
-                    if (_workItems.IsEmpty)
-                    {
-                        // Nothing to do, exit.
-                        break;
-                    }
-
-                    if (_doingWork)
-                    {
-                        // Something to do, but DoWork has been rescheduled already, exit.
-                        break;
-                    }
-                    else
-                    {
-                        // Something to do, and not rescheduled yet, reactivate. 
-                        // As we are already running and can do the work.
-                        _doingWork = true;
-                    }
+                    // Nothing to do, exit.
+                    break;
                 }
+
+                // Is work, can we set it as active again, prior to it being scheduled?
+                var alreadyScheduled = Interlocked.Exchange(ref _doingWork, 1) == 1;
+
+                if (alreadyScheduled)
+                {
+                    // Something to do, but Execute has been rescheduled already, exit.
+                    break;
+                }
+
+                // Is work, wasn't already scheduled so continue loop
             }
         }
 

--- a/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/IOQueue.cs
@@ -32,6 +32,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             // Enqueue prior to checking _doingWork.
             _workItems.Enqueue(work);
 
+            // Ensure ordering of write -> read is preserved, as order is reversed between Schedule and Execute,
+            // and they are two different memory locations.
+            Thread.MemoryBarrier(); 
+
             if (Volatile.Read(ref _doingWork) == 0)
             {
                 // Set as working, and check if it was already working.
@@ -66,6 +70,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
                 // Order is important here with Schedule.
                 // Set _doingWork prior to checking .IsEmpty
                 Volatile.Write(ref _doingWork, 0);
+
+                // Ensure ordering of write -> read is preserved, as order is reversed between Schedule and Execute,
+                // and they are two different memory locations.
+                Thread.MemoryBarrier();
 
                 if (workItems.IsEmpty)
                 {


### PR DESCRIPTION
Currently a lot of contention on the lock

![image](https://user-images.githubusercontent.com/1142958/48316131-4c8f7700-e5d7-11e8-8d6f-7118399f6a79.png)

Go through the lock if its not already doing work; otherwise skip the lock.

Submit work to threadpool outside the lock

After contention is much reduced

![image](https://user-images.githubusercontent.com/1142958/48323012-04497680-e622-11e8-8310-0479454a9fdc.png)


Also removes QUWIC allocations from the IOQueue on .NET Core 3.0

![image](https://user-images.githubusercontent.com/1142958/48327874-08cd5980-e639-11e8-8e9d-d38a1b4106f8.png)

Resolves: https://github.com/aspnet/KestrelHttpServer/issues/3042