### PR TITLE
[2.2] Use non-pinnable buffer for zero byte read

### DIFF
--- a/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
+++ b/src/Kestrel.Transport.Sockets/Internal/SocketReceiver.cs
@@ -15,7 +15,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
         public SocketAwaitableEventArgs WaitForDataAsync()
         {
+#if NETCOREAPP2_1
+            _awaitableEventArgs.SetBuffer(Memory<byte>.Empty);
+#else
             _awaitableEventArgs.SetBuffer(Array.Empty<byte>(), 0, 0);
+#endif
 
             if (!_socket.ReceiveAsync(_awaitableEventArgs))
             {


### PR DESCRIPTION
Time is being spent Pinning 

![image](https://user-images.githubusercontent.com/1142958/48315798-b5282500-e5d2-11e8-8ffc-d43a54dccae5.png)

and Unpinning

![image](https://user-images.githubusercontent.com/1142958/48322423-648ae900-e61f-11e8-9d2d-8ceff0b9ed97.png)

Kestrel uses prepinned buffers so shouldn't have these costs. It comes from pinning `Array.Empty<byte>()` in the zero-byte reads.

After using `Memory<byte>.Empty` these costs go away:

![image](https://user-images.githubusercontent.com/1142958/48322467-9bf99580-e61f-11e8-8792-34ff383688b0.png)


@sebastienros could you benchmark this; see if it makes a difference?