### PR TITLE
Fix Selenium tests WIP

### DIFF
--- a/test/Kestrel.Interop.FunctionalTests/ChromeTests.cs
+++ b/test/Kestrel.Interop.FunctionalTests/ChromeTests.cs
@@ -110,7 +110,13 @@ namespace Interop.FunctionalTests
             var chromeOptions = new ChromeOptions();
             chromeOptions.AddArguments(ChromeArgs);
 
-            using (var driver = new ChromeDriver(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), chromeOptions))
+            var chromeDriverLocation = Environment.GetEnvironmentVariable("ChromeWebDriver");
+            if (string.IsNullOrEmpty(chromeDriverLocation))
+            {
+                chromeDriverLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            }
+
+            using (var driver = new ChromeDriver(chromeDriverLocation, chromeOptions))
             {
                 driver.Navigate().GoToUrl(testUrl);
 


### PR DESCRIPTION
Trying to address https://github.com/aspnet/AspNetCore-Internal/issues/1363.

These tests pass locally and passes on the VSTS linux agents. I'm suspecting that there's something wrong with the setup of the VSTS Windows agents. I see that the version Chrome and Selenium Chrome driver is different from my local machine so I'm going to see if using the installed chrome driver fixes the issue.